### PR TITLE
implement a document highlighting provider

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { DartDefinitionProvider } from "./providers/dart_definition_provider";
 import { DartReferenceProvider } from "./providers/dart_reference_provider";
 import { DartDiagnosticProvider } from "./providers/dart_diagnostic_provider";
 import { DartFormattingEditProvider } from "./providers/dart_formatting_edit_provider";
+import { DartDocumentHighlightProvider } from "./providers/dart_highlighting_provider";
 import { DartHoverProvider } from "./providers/dart_hover_provider";
 import { DartIndentFixer } from "./dart_indent_fixer";
 import { DartDocumentSymbolProvider } from "./providers/dart_document_symbol_provider";
@@ -63,6 +64,7 @@ export function activate(context: vs.ExtensionContext) {
 	context.subscriptions.push(vs.languages.registerDocumentSymbolProvider(DART_MODE, new DartDocumentSymbolProvider(analyzer)));
 	context.subscriptions.push(vs.languages.registerReferenceProvider(DART_MODE, new DartReferenceProvider(analyzer)));
 	context.subscriptions.push(vs.languages.registerWorkspaceSymbolProvider(new DartWorkspaceSymbolProvider(analyzer)));
+	context.subscriptions.push(vs.languages.registerDocumentHighlightProvider(DART_MODE, new DartDocumentHighlightProvider(analyzer)));
 	context.subscriptions.push(new AnalyzerStatusReporter(analyzer));
 
 	// Set up diagnostics.

--- a/src/providers/dart_definition_provider.ts
+++ b/src/providers/dart_definition_provider.ts
@@ -1,6 +1,9 @@
 "use strict";
 
-import { DefinitionProvider, Definition, TextDocument, Location, Uri, Position, CancellationToken, CompletionItemProvider, CompletionList, CompletionItem, CompletionItemKind, TextEdit, Range } from "vscode";
+import {
+	DefinitionProvider, Definition, TextDocument, Location, Uri, Position, CancellationToken,
+	CompletionItemProvider, CompletionList, CompletionItem, CompletionItemKind, TextEdit, Range
+} from "vscode";
 import { Analyzer } from "../analysis/analyzer";
 import * as as from "../analysis/analysis_server_types";
 import * as util from "../utils";

--- a/src/providers/dart_document_symbol_provider.ts
+++ b/src/providers/dart_document_symbol_provider.ts
@@ -1,6 +1,9 @@
 "use strict";
 
-import { TextDocument, DocumentSymbolProvider, SymbolInformation, CancellationToken, SymbolKind, Location, Uri, Range, Position } from "vscode";
+import {
+	TextDocument, DocumentSymbolProvider, SymbolInformation, CancellationToken, SymbolKind,
+	Location, Uri, Range, Position
+} from "vscode";
 import { Analyzer, getSymbolKindForElementKind } from "../analysis/analyzer";
 import { toRange } from "../utils";
 import * as as from "../analysis/analysis_server_types";
@@ -14,19 +17,14 @@ export class DartDocumentSymbolProvider implements DocumentSymbolProvider {
 
 	provideDocumentSymbols(document: TextDocument, token: CancellationToken): Thenable<SymbolInformation[]> {
 		let file = document.fileName;
-
-		this.analyzer.analysisSetSubscriptions({
-			subscriptions: { "OUTLINE": [file] }
-		});
+		this.analyzer.analysisSetSubscriptions({ subscriptions: { "OUTLINE": [file] } });
 
 		return new Promise<SymbolInformation[]>((resolve, reject) => {
 			let disposable = this.analyzer.registerForAnalysisOutline(n => {
 				if (n.file != file)
 					return;
 
-				this.analyzer.analysisSetSubscriptions({
-					subscriptions: { "OUTLINE": [] }
-				});
+				this.analyzer.analysisSetSubscriptions({ subscriptions: { "OUTLINE": [] } });
 				disposable.dispose();
 
 				let symbols: SymbolInformation[] = [];
@@ -60,7 +58,7 @@ export class DartDocumentSymbolProvider implements DocumentSymbolProvider {
 				this.transcribeOutline(document, symbols, element, child);
 		}
 	}
-	
+
 	private getRange(document: TextDocument, outline: as.Outline): Range {
 		// The outline's location includes whitespace before the block but the elements
 		// location only includes the small range declaring the element. To give the best

--- a/src/providers/dart_highlighting_provider.ts
+++ b/src/providers/dart_highlighting_provider.ts
@@ -1,0 +1,70 @@
+
+"use strict";
+
+import {
+	DocumentHighlightProvider, DocumentHighlight, TextDocument, Position, CancellationToken, Range
+} from "vscode";
+import { Analyzer } from "../analysis/analyzer";
+import * as as from "../analysis/analysis_server_types";
+
+export class DartDocumentHighlightProvider implements DocumentHighlightProvider {
+	private analyzer: Analyzer;
+	constructor(analyzer: Analyzer) {
+		this.analyzer = analyzer;
+	}
+
+	provideDocumentHighlights(
+		document: TextDocument, position: Position, token: CancellationToken
+	): Thenable<DocumentHighlight[]> {
+		let file = document.fileName;
+		let offset = document.offsetAt(position);
+
+		this.analyzer.analysisSetSubscriptions({ subscriptions: { "OCCURRENCES": [file] } });
+
+		return new Promise<DocumentHighlight[]>((resolve, reject) => {
+			let disposable = this.analyzer.registerForAnalysisOccurrences(n => {
+				if (n.file != file)
+					return;
+
+				this.analyzer.analysisSetSubscriptions({ subscriptions: { "OCCURRENCES": [] } });
+				disposable.dispose();
+
+				let highlights: DocumentHighlight[] = [];
+				for (let occurrence of n.occurrences) {
+					this.buildOccurrences(highlights, document, offset, occurrence);
+					if (highlights.length > 0) {
+						resolve(highlights);
+						return;
+					}
+				}
+				resolve(highlights);
+			});
+		});
+	}
+
+	private buildOccurrences(
+		highlights: DocumentHighlight[], document: TextDocument, position: number, occurrences: as.Occurrences
+	) {
+		let element = occurrences.element;
+		let offsets: number[] = occurrences.offsets;
+		let length: number = occurrences.length;
+
+		for (let i = 0; i < offsets.length; i++) {
+			let offset = offsets[i];
+
+			if ((offset <= position) && (position < (offset + length))) {
+				for (let i = 0; i < offsets.length; i++) {
+					let offset = offsets[i];
+					let range = new Range(
+						document.positionAt(offset),
+						document.positionAt(offset + length)
+					);
+					highlights.push(new DocumentHighlight(range));
+				}
+
+				return;
+			}
+		}
+	}
+
+}

--- a/src/providers/dart_highlighting_provider.ts
+++ b/src/providers/dart_highlighting_provider.ts
@@ -1,4 +1,3 @@
-
 "use strict";
 
 import {

--- a/src/providers/dart_reference_provider.ts
+++ b/src/providers/dart_reference_provider.ts
@@ -1,6 +1,9 @@
 "use strict";
 
-import { ReferenceProvider, ReferenceContext, TextDocument, Location, Uri, Position, CancellationToken, CompletionItemProvider, CompletionList, CompletionItem, CompletionItemKind, TextEdit, Range } from "vscode";
+import {
+	ReferenceProvider, ReferenceContext, TextDocument, Location, Uri, Position, CancellationToken,
+	CompletionItemProvider, CompletionList, CompletionItem, CompletionItemKind, TextEdit, Range
+} from "vscode";
 import { Analyzer } from "../analysis/analyzer";
 import * as as from "../analysis/analysis_server_types";
 import * as util from "../utils";
@@ -24,7 +27,7 @@ export class DartReferenceProvider implements ReferenceProvider {
 						return;
 
 					disposable.dispose();
-					resolve(notification.results.map(r => this.convertResult(r)));					
+					resolve(notification.results.map(r => this.convertResult(r)));
 				});
 			});
 		});


### PR DESCRIPTION
- implement a document highlighting provider
- fix #64 
- wrap some long lines

This uses the same technique as the document symbol provider - it turns on an analysis server notification briefly, waits for some results, turns off the notification, and converts the results to the expected vscode format.

<img width="476" alt="screen shot 2016-08-11 at 4 51 16 pm" src="https://cloud.githubusercontent.com/assets/1269969/17608797/e32d0852-5fe3-11e6-8160-31be83f4c491.png">
