### PR TITLE
Stash dart SDK path in a temp file so debugger can read.

### DIFF
--- a/src/debug/debug_impl.ts
+++ b/src/debug/debug_impl.ts
@@ -8,6 +8,7 @@ import {
 	Thread, StackFrame, Scope, Source, Handles, Breakpoint, ThreadEvent, Variable
 } from "vscode-debugadapter";
 import { DebugProtocol } from "vscode-debugprotocol";
+import { readSdkPath } from "./sdk_path"
 
 export interface DartLaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
 	cwd: string;
@@ -20,6 +21,8 @@ export class DartDebugSession extends DebugSession {
 	private cwd: string;
 	private childProcess: child_process.ChildProcess;
 	private processExited: boolean = false;
+	private sdkPath = readSdkPath();
+	private dartPath = this.sdkPath != null ? path.join(this.sdkPath, "bin", "dart") : "dart"; 
 
 	public constructor() {
 		super();
@@ -58,8 +61,7 @@ export class DartDebugSession extends DebugSession {
 		if (args.args)
 			appArgs = appArgs.concat(args.args);
 
-		// TODO: dart sdk path - send a request to the client for it
-		let process = child_process.spawn("dart", appArgs, {
+		let process = child_process.spawn(this.dartPath, appArgs, {
 			cwd: args.cwd
 		});
 

--- a/src/debug/sdk_path.ts
+++ b/src/debug/sdk_path.ts
@@ -1,0 +1,30 @@
+"use strict"
+
+// This file exists to write the SDK path from config in the extension and read it from the
+// debug adapter. Everything imported here must be available in both places (eg. no vscode).
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs";
+
+const sdkPathStoreName = "dart-code.sdk";
+const sdkPathStore = path.join(os.tmpdir(), sdkPathStoreName);
+
+export function readSdkPath(): string {
+	// If this file doesn't exist, return null. We'll have to hope it's
+	// in PATH.
+	try {
+		return fs.readFileSync(sdkPathStore, "utf8").trim();
+	}
+	catch (e) {
+		return null;
+	}
+}
+
+export function writeSdkPath(sdkPath: string) {
+	try {
+		fs.writeFileSync(sdkPathStore, sdkPath, "utf8");
+	}
+	catch (e) {
+		console.warn(e);
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import { FileChangeHandler } from "./file_change_handler";
 import { OpenFileTracker } from "./open_file_tracker";
 import { PubManager } from "./commands/pub";
 import { ServerStatusNotification } from "./analysis/analysis_server_types";
+import * as debug from "./debug/sdk_path"
 
 const DART_MODE: vs.DocumentFilter = { language: "dart", scheme: "file" };
 const stateLastKnownSdkPathName = "dart.lastKnownSdkPath";
@@ -41,6 +42,7 @@ export function activate(context: vs.ExtensionContext) {
 		return; // Don't set anything else up; we can't work like this!
 	}
 	context.globalState.update(stateLastKnownSdkPathName, dartSdkRoot);
+	debug.writeSdkPath(dartSdkRoot); // Write the SDK path for the debugger to find.
 
 	// Show the SDK version in the status bar.
 	let sdkVersion = util.getDartSdkVersion(dartSdkRoot);


### PR DESCRIPTION
@devoncarew How does this look? We stash the SDK during activation and then read it back in the debug adapter. I created a file to hold the read/write functions (although only one is needed on each side it made sense to keep the path in one place) and added a comment about it being used in both places (it's important not to pull in `vscode` etc. or the debugger fails to launch with no useful error!).

If you think is good, we can merge as the solution to #83  in lieu of something better.