### PR TITLE
some tweaks to code completion

### DIFF
--- a/src/providers/dart_completion_item_provider.ts
+++ b/src/providers/dart_completion_item_provider.ts
@@ -1,9 +1,12 @@
 "use strict";
 
-import { TextDocument, Position, CancellationToken, CompletionItemProvider, CompletionList, CompletionItem, CompletionItemKind, TextEdit, Range } from "vscode";
+import {
+	TextDocument, Position, CancellationToken, CompletionItemProvider, CompletionList,
+	CompletionItem, CompletionItemKind, TextEdit, Range
+} from "vscode";
 import { Analyzer } from "../analysis/analyzer";
-import * as as from "../analysis/analysis_server_types";
 import { logError } from "../utils";
+import * as as from "../analysis/analysis_server_types";
 
 export class DartCompletionItemProvider implements CompletionItemProvider {
 	private analyzer: Analyzer;
@@ -11,7 +14,9 @@ export class DartCompletionItemProvider implements CompletionItemProvider {
 		this.analyzer = analyzer;
 	}
 
-	provideCompletionItems(document: TextDocument, position: Position, token: CancellationToken): Thenable<CompletionList> {
+	provideCompletionItems(
+		document: TextDocument, position: Position, token: CancellationToken
+	): Thenable<CompletionList> {
 		return new Promise<CompletionList>((resolve, reject) => {
 			this.analyzer.completionGetSuggestions({
 				file: document.fileName,
@@ -23,24 +28,30 @@ export class DartCompletionItemProvider implements CompletionItemProvider {
 						return;
 
 					disposable.dispose();
-					resolve(new CompletionList(notification.results.map(r => this.convertResult(document, notification, r))));
+					resolve(new CompletionList(notification.results.map(r => {
+						return this.convertResult(document, notification, r);
+					})));
 				})
 			}, e => { logError(e); reject(); });
 		});
 	}
 
-	private convertResult(document: TextDocument, notification: as.CompletionResultsNotification, suggestion: as.CompletionSuggestion): CompletionItem {
+	private convertResult(
+		document: TextDocument, notification: as.CompletionResultsNotification, suggestion: as.CompletionSuggestion
+	): CompletionItem {
 		let start = document.positionAt(suggestion.selectionOffset);
-
-		let detail: string = null;
+		let label = suggestion.completion;
+		let detail: string = "";
 
 		if (suggestion.element) {
 			let element = suggestion.element;
-			detail = element.kind;
+			detail = element.kind.toLowerCase();
 
-			// If element has parameters (METHOD/CONSTRUCTOR/FUNCTION), 
-			// show its parameters and return type.
+			// If element has parameters (METHOD/CONSTRUCTOR/FUNCTION), show its
+			// parameters and return type.
 			if (element.parameters) {
+				label += element.parameters.length == 2 ? "()" : "(…)";
+
 				let sig = `${element.name}${element.parameters}`;
 
 				if (element.kind == "CONSTRUCTOR") {
@@ -49,21 +60,27 @@ export class DartCompletionItemProvider implements CompletionItemProvider {
 						: `${suggestion.declaringType}${sig}`;
 				}
 
-				if (element.returnType)
-					sig += " → " + element.returnType
-
 				detail += " " + sig;
 			}
+
+			if (element.returnType)
+				detail += " → " + element.returnType
 		}
 
+		detail = detail.length == 0 ? detail = null : detail.trim();
+
+		let kind = suggestion.element
+			? this.getElementKind(suggestion.element.kind)
+			: this.getSuggestionKind(suggestion.kind);
+
 		return {
-			label: suggestion.completion,
-			kind: this.getKind(suggestion.kind),
+			label: label,
+			kind: kind,
 			detail: detail,
 			documentation: suggestion.docSummary,
 			sortText: null,
 			filterText: null,
-			insertText: null,
+			insertText: suggestion.completion,
 			textEdit: new TextEdit(
 				new Range(
 					document.positionAt(notification.replacementOffset),
@@ -74,8 +91,7 @@ export class DartCompletionItemProvider implements CompletionItemProvider {
 		};
 	}
 
-	private getKind(kind: as.CompletionSuggestionKind): CompletionItemKind {
-		// TODO: Review these...
+	private getSuggestionKind(kind: as.CompletionSuggestionKind): CompletionItemKind {
 		switch (kind) {
 			case "ARGUMENT_LIST":
 				return CompletionItemKind.Variable;
@@ -92,6 +108,57 @@ export class DartCompletionItemProvider implements CompletionItemProvider {
 			case "OPTIONAL_ARGUMENT":
 				return CompletionItemKind.Variable;
 			case "PARAMETER":
+				return CompletionItemKind.Value;
+		}
+	}
+
+	private getElementKind(kind: as.ElementKind): CompletionItemKind {
+		switch (kind) {
+			case "CLASS":
+				return CompletionItemKind.Class;
+			case "CLASS_TYPE_ALIAS":
+				return CompletionItemKind.Class;
+			case "COMPILATION_UNIT":
+				return CompletionItemKind.Module;
+			case "CONSTRUCTOR":
+				return CompletionItemKind.Constructor;
+			case "ENUM":
+				return CompletionItemKind.Enum;
+			case "ENUM_CONSTANT":
+				return CompletionItemKind.Enum;
+			case "FIELD":
+				return CompletionItemKind.Field;
+			case "FILE":
+				return CompletionItemKind.File;
+			case "FUNCTION":
+				return CompletionItemKind.Function;
+			case "FUNCTION_TYPE_ALIAS":
+				return CompletionItemKind.Function;
+			case "GETTER":
+				return CompletionItemKind.Property;
+			case "LABEL":
+				return CompletionItemKind.Module;
+			case "LIBRARY":
+				return CompletionItemKind.Module;
+			case "LOCAL_VARIABLE":
+				return CompletionItemKind.Variable;
+			case "METHOD":
+				return CompletionItemKind.Method;
+			case "PARAMETER":
+				return CompletionItemKind.Variable;
+			case "PREFIX":
+				return CompletionItemKind.Variable;
+			case "SETTER":
+				return CompletionItemKind.Property;
+			case "TOP_LEVEL_VARIABLE":
+				return CompletionItemKind.Variable;
+			case "TYPE_PARAMETER":
+				return CompletionItemKind.Variable;
+			case "UNIT_TEST_GROUP":
+				return CompletionItemKind.Module;
+			case "UNIT_TEST_TEST":
+				return CompletionItemKind.Method;
+			case "UNKNOWN":
 				return CompletionItemKind.Value;
 		}
 	}


### PR DESCRIPTION
A follow-up to https://github.com/Dart-Code/Dart-Code/pull/111:

- show return types for getters
- change how we calc the completion type icons to use the element kind if available
- show the element type in lower case (instead of the default uppercase)

<img width="465" alt="screen shot 2016-08-19 at 1 48 59 pm" src="https://cloud.githubusercontent.com/assets/1269969/17824690/6843d748-6618-11e6-8ef8-b659c5c5c431.png">
