### PR TITLE
remove code to work around a pre 1.6 issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"publisher": "DanTup",
 	"preview": true,
 	"engines": {
-		"vscode": "^1.4.0"
+		"vscode": "^1.6.0"
 	},
 	"license": "SEE LICENSE IN LICENSE",
 	"bugs": {

--- a/src/providers/dart_hover_provider.ts
+++ b/src/providers/dart_hover_provider.ts
@@ -73,19 +73,6 @@ export class DartHoverProvider implements HoverProvider {
 		if (index != -1)
 			doc = doc.substring(0, index);
 
-		// Truncate long dartdoc.
-		let lines = doc.split("\n");
-		if (lines.length > 20 && !vsCodeVersion.hasScrollableHovers) {
-			for (let index = 20 - 6; index < lines.length; index++) {
-				if (lines[index].trim().length == 0) {
-					lines = lines.slice(0, index);
-					lines.push("\n…");
-					break;
-				}
-			}
-			doc = lines.join("\n");
-		}
-
 		// Remove colons from old-style references like [:foo:].
 		doc = doc.replace(/\[:\S+:\]/g, (match) => `[${match.substring(2, match.length - 2)}]`);
 


### PR DESCRIPTION
- remove some pre vscode 1.6 code - hovers in 1.6 better support longer hover docs

@DanTup 
