### PR TITLE
tweaks to the exception report

### DIFF
--- a/src/analyzer_status_reporter.ts
+++ b/src/analyzer_status_reporter.ts
@@ -97,7 +97,7 @@ Exception from analysis server (running from VSCode / Dart Code)
 - ${env.appName} ${codeVersion}
 - Dart Code ${dartCodeVersion}
 
-### Exception ${error.isFatal ? ' (Fatal)' : ''}
+### Exception${error.isFatal ? ' (fatal)' : ''}
 
 ${error.message}
 

--- a/src/analyzer_status_reporter.ts
+++ b/src/analyzer_status_reporter.ts
@@ -79,14 +79,13 @@ export class AnalyzerStatusReporter extends Disposable {
 	}
 
 	private reportError(error: ServerErrorNotification) {
-		// TODO: How to get the VSCode version?
 		let sdkVersion = getDartSdkVersion(dartSdkRoot);
 		let dartCodeVersion = extensions.getExtension('DanTup.dart-code').packageJSON.version;
 
 		let data = `
 Please report the following to https://github.com/dart-lang/sdk/issues/new :
 
-Exception from analysis server (running from [Dart Code](https://marketplace.visualstudio.com/items?itemName=DanTup.dart-code))
+Exception from analysis server (running from VSCode / Dart Code)
 
 ### What I was doing
 
@@ -103,7 +102,7 @@ Exception from analysis server (running from [Dart Code](https://marketplace.vis
 ${error.message}
 
 \`\`\`text
-${error.stackTrace}
+${error.stackTrace.trim()}
 \`\`\`
 `;
 


### PR DESCRIPTION
Some tweaks to the exception report:

- trim extra whitespace
- make the subject line for the report a bit more terse
- remove an obsolete TODO:

Also, I noticed that the reported value for the dart sdk version was `null`, but did not see an obvious reason for it. The status line contribution for the sdk version was correct (non-null).

@DanTup 
