### PR TITLE
Added ability for findDartSdk to use the Flutter cached version.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,7 @@ export function activate(context: vs.ExtensionContext) {
 		versionStatusItem.show();
 		context.subscriptions.push(versionStatusItem);
 
-		if (config.checkForSdkUpdates && !util.isFlutterProject) {
+		if (config.checkForSdkUpdates && !util.isFlutterProject()) {
 			util.getLatestSdkVersion().then(version => {
 				if (util.isOutOfDate(sdkVersion, version))
 					vs.window.showWarningMessage(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,7 +63,7 @@ export function activate(context: vs.ExtensionContext) {
 		versionStatusItem.show();
 		context.subscriptions.push(versionStatusItem);
 
-		if (config.checkForSdkUpdates) {
+		if (config.checkForSdkUpdates && !util.isFlutterProject) {
 			util.getLatestSdkVersion().then(version => {
 				if (util.isOutOfDate(sdkVersion, version))
 					vs.window.showWarningMessage(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,7 @@ export function findDartSdk(): string {
 	let paths = (<string>process.env.PATH).split(path.delimiter);
 
 	// Putting Flutter before userDefined, so that UD takes priority
-	if (isFlutterProject)
+	if (isFlutterProject())
 		paths.unshift(path.join(findFlutterSdk(), "bin/cache/dart-sdk/bin"));
 
 	// We don't expect the user to add .\bin in config, but it would be in the PATHs

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,9 +18,11 @@ export const extensionVersion = getExtensionVersion();
 export const isDevelopment = checkIsDevelopment();
 
 export function isFlutterProject(): boolean {
-	if (workspace.rootPath)
-		if (fs.existsSync(path.join(workspace.rootPath, "pubspec.yaml")))
-			return fs.readFileSync((path.join(workspace.rootPath, "pubspec.yaml"))).includes("sdk: flutter");
+	if (workspace.rootPath)  // If VS Code has a project open
+		if (fs.existsSync(path.join(workspace.rootPath, "pubspec.yaml"))){
+			let regex = new RegExp('sdk:\\sflutter', 'i');
+			return regex.test(fs.readFileSync((path.join(workspace.rootPath, "pubspec.yaml"))).toString());
+		}
 	return false;
 }
 


### PR DESCRIPTION
Fixes #286
Also fixed a minor annoyance of Dart-Code offering to update the Dart SDK when Flutter rolls their own.