### PR TITLE
Altered string_interp regex

### DIFF
--- a/syntaxes/dart.json
+++ b/syntaxes/dart.json
@@ -295,12 +295,9 @@
 					"captures": {
 						"2": {
 							"name": "variable.parameter.dart"
-						},
-						"3": {
-							"name": "variable.parameter.dart"
 						}
 					},
-					"match": "\\$((\\w+)|\\{([^{}\"']+)\\})"
+					"match": "\\$((\\w+)|\\{([^{}]+)\\})"
 				},
 				{
 					"match": "\\\\.",

--- a/syntaxes/dart.json
+++ b/syntaxes/dart.json
@@ -295,6 +295,9 @@
 					"captures": {
 						"2": {
 							"name": "variable.parameter.dart"
+						},
+						"3": {
+							"name": "variable.parameter.dart"
 						}
 					},
 					"match": "\\$((\\w+)|\\{([^{}]+)\\})"


### PR DESCRIPTION
Simplified it to allow quote characters, and not require a Dart variable name.
Potential fix for #305