### PR TITLE
show async stack frames when debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 analyzer.log
 .vscode/.browse.VC.db*
 .vscode-test/
+.DS_Store

--- a/src/debug/dart_debug_protocol.ts
+++ b/src/debug/dart_debug_protocol.ts
@@ -65,14 +65,22 @@ export interface VMObjectRef extends VMResponse {
 
 export interface VMStack extends VMResponse {
 	frames: VMFrame[];
+	asyncCausalFrames?: VMFrame[];
 }
 
 export interface VMFrame extends VMResponse {
 	index: number;
-	function: VMFuncRef;
-	// CodeRef code;
-	location: VMSourceLocation;
-	vars: VMBoundVariable[];
+	kind: string;
+	code?: VMCodeRef;
+	function?: VMFuncRef;
+	location?: VMSourceLocation;
+	vars?: VMBoundVariable[];
+}
+
+export interface VMCodeRef extends VMObjectRef {
+  name: string;
+  // CodeKind: Dart, Native, Stub, Tag, Collected
+  kind: string;
 }
 
 export interface VMSourceLocation extends VMResponse {


### PR DESCRIPTION
- show async stack frames when debugging - prefer to use the `asyncCausalFrames` field when that's available, and represent async gap marker frames as blank frames names `<asynchronous gap>`
- fix https://github.com/Dart-Code/Dart-Code/issues/259
- improve the text of stack frames (use the value from the code ref instead of the function name)

<img width="399" alt="screen shot 2017-07-02 at 11 17 59 pm" src="https://user-images.githubusercontent.com/1269969/27780293-f15f39b0-5f7c-11e7-87ee-dfd5bbbece9e.png">

@DanTup 