### PR TITLE
Support angular template analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v2.4.0
+
+### Preview Features in this version
+
+- [`dart.previewAnalyzeAngularTemplates`](https://github.com/Dart-Code/Dart-Code/pull/393) - Surfaces analysis results on AngularDart templates. Requires the [angular_analyzer_plugin](https://github.com/dart-lang/angular_analyzer_plugin).
+
 # v2.3.3
 
 - The dependency tree will now update after packages are changed/updated

--- a/package.json
+++ b/package.json
@@ -391,11 +391,6 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Whether to automatically send a 'hot reload' request during a Flutter debug session when saving files."
-				},
-				"dart.analyzeAngularTemplates": {
-					"type": "boolean",
-					"default": false,
-					"description": "Whether to analyze HTML files as AngularDart templates"
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -391,6 +391,11 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Whether to automatically send a 'hot reload' request during a Flutter debug session when saving files."
+				},
+				"dart.analyzeAngularTemplates": {
+					"type": "boolean",
+					"default": false,
+					"description": "Whether to analyze HTML files as AngularDart templates"
 				}
 			}
 		},

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,7 +24,6 @@ class Config {
 	}
 
 	get allowAnalytics() { return this.getConfig<boolean>("allowAnalytics"); }
-	get analyzeAngularTemplates() { return this.getConfig<boolean>("analyzeAngularTemplates"); }
 	get analyzerDiagnosticsPort() { return this.getConfig<number>("analyzerDiagnosticsPort"); }
 	get analyzerObservatoryPort() { return this.getConfig<number>("analyzerObservatoryPort"); }
 	get analyzerLogFile() { return resolveHomePath(this.getConfig<string>("analyzerLogFile")); }
@@ -52,6 +51,7 @@ class Config {
 	get sdkContainer() { return resolveHomePath(this.getConfig<string>("sdkContainer")); }
 
 	// Preview features.
+	get previewAnalyzeAngularTemplates() { return this.getConfig<boolean>("previewAnalyzeAngularTemplates"); }
 	get previewFlutterCloseTagDecorations() { return this.getConfig<boolean>("previewFlutterCloseTagDecorations"); }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,7 @@ class Config {
 	}
 
 	get allowAnalytics() { return this.getConfig<boolean>("allowAnalytics"); }
+	get analyzeAngularTemplates() { return this.getConfig<boolean>("analyzeAngularTemplates"); }
 	get analyzerDiagnosticsPort() { return this.getConfig<number>("analyzerDiagnosticsPort"); }
 	get analyzerObservatoryPort() { return this.getConfig<number>("analyzerObservatoryPort"); }
 	get analyzerLogFile() { return resolveHomePath(this.getConfig<string>("analyzerLogFile")); }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ import { FlutterWidgetConstructorDecoratorProvider } from "./providers/flutter_w
 import { DartPackageFileContentProvider } from "./providers/dart_package_file_content_provider";
 
 const DART_MODE: vs.DocumentFilter = { language: "dart", scheme: "file" };
+const HTML_MODE: vs.DocumentFilter = { language: "html", scheme: "file" };
 const DART_DOWNLOAD_URL = "https://www.dartlang.org/install";
 const FLUTTER_DOWNLOAD_URL = "https://flutter.io/setup/";
 
@@ -137,17 +138,44 @@ export function activate(context: vs.ExtensionContext) {
 	// TODO: Check if EventEmitter<T> would be more appropriate than our own.
 
 	// Set up providers.
-	context.subscriptions.push(vs.languages.registerHoverProvider(DART_MODE, new DartHoverProvider(analyzer)));
-	context.subscriptions.push(vs.languages.registerDocumentFormattingEditProvider(DART_MODE, new DartFormattingEditProvider(analyzer)));
-	context.subscriptions.push(vs.languages.registerOnTypeFormattingEditProvider(DART_MODE, new DartTypeFormattingEditProvider(analyzer), "}", ";"));
-	context.subscriptions.push(vs.languages.registerCompletionItemProvider(DART_MODE, new DartCompletionItemProvider(analyzer), ".", ":", " ", "=", "("));
-	context.subscriptions.push(vs.languages.registerDefinitionProvider(DART_MODE, new DartDefinitionProvider(analyzer)));
-	context.subscriptions.push(vs.languages.registerDocumentSymbolProvider(DART_MODE, new DartDocumentSymbolProvider(analyzer)));
-	context.subscriptions.push(vs.languages.registerReferenceProvider(DART_MODE, new DartReferenceProvider(analyzer)));
+	let hoverProvider = new DartHoverProvider(analyzer);
+	let formattingEditProvider = new DartFormattingEditProvider(analyzer);
+	let typeFormattingEditProvider = new DartTypeFormattingEditProvider(analyzer);
+	let completionItemProvider = new DartCompletionItemProvider(analyzer);
+	let definitionProvider = new DartDefinitionProvider(analyzer);
+	let documentSymbolProvider = new DartDocumentSymbolProvider(analyzer);
+	let referenceProvider = new DartReferenceProvider(analyzer);
+	let documentHighlightProvider = new DartDocumentHighlightProvider(analyzer);
+	let codeActionProvider = new DartCodeActionProvider(analyzer);
+	let renameProvider = new DartRenameProvider(analyzer);
+
+	context.subscriptions.push(vs.languages.registerHoverProvider(DART_MODE, hoverProvider));
+	context.subscriptions.push(vs.languages.registerDocumentFormattingEditProvider(DART_MODE, formattingEditProvider));
+	context.subscriptions.push(vs.languages.registerOnTypeFormattingEditProvider(DART_MODE, typeFormattingEditProvider, "}", ";"));
+	context.subscriptions.push(vs.languages.registerCompletionItemProvider(DART_MODE, completionItemProvider, ".", ":", " ", "=", "("));
+	context.subscriptions.push(vs.languages.registerDefinitionProvider(DART_MODE, definitionProvider));
+	context.subscriptions.push(vs.languages.registerDocumentSymbolProvider(DART_MODE, documentSymbolProvider));
+	context.subscriptions.push(vs.languages.registerReferenceProvider(DART_MODE, referenceProvider));
+	context.subscriptions.push(vs.languages.registerDocumentHighlightProvider(DART_MODE, documentHighlightProvider));
+	context.subscriptions.push(vs.languages.registerCodeActionsProvider(DART_MODE, codeActionProvider));
+	context.subscriptions.push(vs.languages.registerRenameProvider(DART_MODE, renameProvider));
+
+	// Analyze Angular2 templates, requires the angular_analyzer_plugin.
+	if (config.analyzeAngularTemplates) {
+		context.subscriptions.push(vs.languages.registerHoverProvider(HTML_MODE, hoverProvider));
+		context.subscriptions.push(vs.languages.registerDocumentFormattingEditProvider(HTML_MODE, formattingEditProvider));
+		// Don't register a formatting provider for now, the analyzer doesn't
+		// support it, and it might not make sense in an HTML context anyway.
+		context.subscriptions.push(vs.languages.registerCompletionItemProvider(HTML_MODE, completionItemProvider, ".", ":", " ", "=", "("));
+		context.subscriptions.push(vs.languages.registerDefinitionProvider(HTML_MODE, definitionProvider));
+		context.subscriptions.push(vs.languages.registerDocumentSymbolProvider(HTML_MODE, documentSymbolProvider));
+		context.subscriptions.push(vs.languages.registerReferenceProvider(HTML_MODE, referenceProvider));
+		context.subscriptions.push(vs.languages.registerDocumentHighlightProvider(HTML_MODE, documentHighlightProvider));
+		context.subscriptions.push(vs.languages.registerCodeActionsProvider(HTML_MODE, codeActionProvider));
+		context.subscriptions.push(vs.languages.registerRenameProvider(HTML_MODE, renameProvider));
+	}
+
 	context.subscriptions.push(vs.languages.registerWorkspaceSymbolProvider(new DartWorkspaceSymbolProvider(analyzer)));
-	context.subscriptions.push(vs.languages.registerDocumentHighlightProvider(DART_MODE, new DartDocumentHighlightProvider(analyzer)));
-	context.subscriptions.push(vs.languages.registerCodeActionsProvider(DART_MODE, new DartCodeActionProvider(analyzer)));
-	context.subscriptions.push(vs.languages.registerRenameProvider(DART_MODE, new DartRenameProvider(analyzer)));
 	context.subscriptions.push(vs.languages.setLanguageConfiguration(DART_MODE.language, new DartLanguageConfiguration()));
 	context.subscriptions.push(vs.workspace.registerTextDocumentContentProvider("dart-package", new DartPackageFileContentProvider()));
 	context.subscriptions.push(new AnalyzerStatusReporter(analyzer));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -149,31 +149,27 @@ export function activate(context: vs.ExtensionContext) {
 	let codeActionProvider = new DartCodeActionProvider(analyzer);
 	let renameProvider = new DartRenameProvider(analyzer);
 
-	context.subscriptions.push(vs.languages.registerHoverProvider(DART_MODE, hoverProvider));
-	context.subscriptions.push(vs.languages.registerDocumentFormattingEditProvider(DART_MODE, formattingEditProvider));
-	context.subscriptions.push(vs.languages.registerOnTypeFormattingEditProvider(DART_MODE, typeFormattingEditProvider, "}", ";"));
-	context.subscriptions.push(vs.languages.registerCompletionItemProvider(DART_MODE, completionItemProvider, ".", ":", " ", "=", "("));
-	context.subscriptions.push(vs.languages.registerDefinitionProvider(DART_MODE, definitionProvider));
-	context.subscriptions.push(vs.languages.registerDocumentSymbolProvider(DART_MODE, documentSymbolProvider));
-	context.subscriptions.push(vs.languages.registerReferenceProvider(DART_MODE, referenceProvider));
-	context.subscriptions.push(vs.languages.registerDocumentHighlightProvider(DART_MODE, documentHighlightProvider));
-	context.subscriptions.push(vs.languages.registerCodeActionsProvider(DART_MODE, codeActionProvider));
-	context.subscriptions.push(vs.languages.registerRenameProvider(DART_MODE, renameProvider));
-
-	// Analyze Angular2 templates, requires the angular_analyzer_plugin.
-	if (config.analyzeAngularTemplates) {
-		context.subscriptions.push(vs.languages.registerHoverProvider(HTML_MODE, hoverProvider));
-		context.subscriptions.push(vs.languages.registerDocumentFormattingEditProvider(HTML_MODE, formattingEditProvider));
-		// Don't register a formatting provider for now, the analyzer doesn't
-		// support it, and it might not make sense in an HTML context anyway.
-		context.subscriptions.push(vs.languages.registerCompletionItemProvider(HTML_MODE, completionItemProvider, ".", ":", " ", "=", "("));
-		context.subscriptions.push(vs.languages.registerDefinitionProvider(HTML_MODE, definitionProvider));
-		context.subscriptions.push(vs.languages.registerDocumentSymbolProvider(HTML_MODE, documentSymbolProvider));
-		context.subscriptions.push(vs.languages.registerReferenceProvider(HTML_MODE, referenceProvider));
-		context.subscriptions.push(vs.languages.registerDocumentHighlightProvider(HTML_MODE, documentHighlightProvider));
-		context.subscriptions.push(vs.languages.registerCodeActionsProvider(HTML_MODE, codeActionProvider));
-		context.subscriptions.push(vs.languages.registerRenameProvider(HTML_MODE, renameProvider));
+	var activeFileFilters = [DART_MODE];
+	if (config.previewAnalyzeAngularTemplates) {
+		// Analyze Angular2 templates, requires the angular_analyzer_plugin.
+		activeFileFilters.push(HTML_MODE);
 	}
+
+	activeFileFilters.forEach((filter) => {
+		context.subscriptions.push(vs.languages.registerHoverProvider(filter, hoverProvider));
+		context.subscriptions.push(vs.languages.registerDocumentFormattingEditProvider(filter, formattingEditProvider));
+		context.subscriptions.push(vs.languages.registerCompletionItemProvider(filter, completionItemProvider, ".", ":", " ", "=", "("));
+		context.subscriptions.push(vs.languages.registerDefinitionProvider(filter, definitionProvider));
+		context.subscriptions.push(vs.languages.registerDocumentSymbolProvider(filter, documentSymbolProvider));
+		context.subscriptions.push(vs.languages.registerReferenceProvider(filter, referenceProvider));
+		context.subscriptions.push(vs.languages.registerDocumentHighlightProvider(filter, documentHighlightProvider));
+		context.subscriptions.push(vs.languages.registerCodeActionsProvider(filter, codeActionProvider));
+		context.subscriptions.push(vs.languages.registerRenameProvider(filter, renameProvider));
+	});
+
+	// Even with the angular_analyzer_plugin, the analysis server only supports
+	// formatting for dart files.
+	context.subscriptions.push(vs.languages.registerOnTypeFormattingEditProvider(DART_MODE, typeFormattingEditProvider, "}", ";"));
 
 	context.subscriptions.push(vs.languages.registerWorkspaceSymbolProvider(new DartWorkspaceSymbolProvider(analyzer)));
 	context.subscriptions.push(vs.languages.setLanguageConfiguration(DART_MODE.language, new DartLanguageConfiguration()));
@@ -407,7 +403,8 @@ function getAnalyzerSettings() {
 		+ config.analyzerInstrumentationLogFile
 		+ config.analyzerAdditionalArgs
 		+ config.flutterDaemonLogFile
-		+ config.previewFlutterCloseTagDecorations;
+		+ config.previewFlutterCloseTagDecorations
+		+ config.previewAnalyzeAngularTemplates;
 }
 
 export function deactivate() {


### PR DESCRIPTION
If you have the angular_analyzer_plugin [1] active, the dart analysis server supports analysis and code completion for AngularDart templates. This PR surfaces this information by registering the same dart providers for html files. This functionality is gated behind a new "analyzeAngularTemplates" option (default: false).

[1] https://github.com/dart-lang/angular_analyzer_plugin