### PR TITLE
Activate Dart-Code on encountering html files

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 	"icon": "media/icon.png",
 	"activationEvents": [
 		"onLanguage:dart",
+		"onLanguage:html",
 		"onView:dartPackages",
 		"workspaceContains:**/pubspec.yaml"
 	],


### PR DESCRIPTION
Activates the Dart-Code extension when html files are encountered. Optimally, this would only be enabled if the `dart.previewAnalyzeAngularTemplates` option is set, but I don't think there is infrastructure for that. This solves issues with auto complete and warnings not showing up in Angular templates unless a dart file is opened first.