### PR TITLE
Remove text reference to FLUTTER_HOME

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ export function activate(context: vs.ExtensionContext) {
 	if (sdks.dart == null) {
 		if (util.isFlutterProject) {
 			vs.window.showErrorMessage("Could not find a Flutter SDK to use. " +
-				"Please add it to your PATH or set FLUTTER_HOME and reload.",
+				"Please add it to your PATH or set FLUTTER_ROOT and reload.",
 				"Go to Flutter Downloads"
 			).then(selectedItem => {
 				if (selectedItem)


### PR DESCRIPTION
As of v1.4.0, the FLUTTER_HOME variable is no longer used, in favor of FLUTTER_ROOT. This message told the user to set their FLUTTER_HOME instead of FLUTTER_ROOT.