### PR TITLE
Update the Dart SDK path finding logic for fuchsia

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -193,26 +193,15 @@ function findFuchsiaDartSdk(fuchsiaRoot: string): string {
 	if (!fuchsiaRoot)
 		return null;
 
-	// Default build directories to include, in the order of precedence.
-	let buildDirs = ["out/release-x86-64", "out/debug-x86-64"];
-	
-	// Check if .config file exists, and read the build directory from it.
-	const configPath = path.join(fuchsiaRoot, ".config");
-	if (fs.existsSync(configPath)) {
-		const regex = new RegExp('^FUCHSIA_BUILD_DIR="(.+)"$', 'm');
-		const matches = regex.exec(fs.readFileSync(configPath).toString());
-		if (matches != null && matches.length >= 2) {
-			// The build directory appears in the config file should take precedence over the default ones.
-			buildDirs.unshift(matches[1]);
-		}
-	}
+	let platformName = "linux";
+	if (isWin)
+		platformName = "win";
+	else if (process.platform == "darwin")
+		platformName = "mac";
 
-	// For each build dir, see if <build_dir>/dart_host/dart-sdk exists with the dart executable under bin/.
-	for (let i = 0; i < buildDirs.length; i++) {
-		const fuchsiaDartSdkPath = path.join(fuchsiaRoot, buildDirs[i], "dart_host/dart-sdk");
-		if (hasDartExecutable(path.join(fuchsiaDartSdkPath, "bin")))
-			return fuchsiaDartSdkPath;
-	}		
+	const fuchsiaDartSdkPath = path.join(fuchsiaRoot, "third_party/dart/tools/sdks", platformName, "dart-sdk");
+	if (hasDartExecutable(path.join(fuchsiaDartSdkPath, "bin")))
+		return fuchsiaDartSdkPath;
 
 	return null;
 }


### PR DESCRIPTION
This changes the logic for finding the correct Dart SDK location for
Fuchsia.

Also, now the user-defined "dart.sdkPath" setting takes precedence, in
case the auto-detected Dart SDK is not the desired one to use.