### PR TITLE
Added more trigger characters to auto completion

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,10 +163,11 @@ export function activate(context: vs.ExtensionContext) {
 		activeFileFilters.push(HTML_MODE);
 	}
 
+	const triggerCharacters = ".: =(${'\"abcdefghijklmnopqrstuvwxyz".split("");
 	activeFileFilters.forEach((filter) => {
 		context.subscriptions.push(vs.languages.registerHoverProvider(filter, hoverProvider));
 		context.subscriptions.push(vs.languages.registerDocumentFormattingEditProvider(filter, formattingEditProvider));
-		context.subscriptions.push(vs.languages.registerCompletionItemProvider(filter, completionItemProvider, ".", ":", " ", "=", "(", "$", "{"));
+		context.subscriptions.push(vs.languages.registerCompletionItemProvider(filter, completionItemProvider, ...triggerCharacters));
 		context.subscriptions.push(vs.languages.registerDefinitionProvider(filter, definitionProvider));
 		context.subscriptions.push(vs.languages.registerDocumentSymbolProvider(filter, documentSymbolProvider));
 		context.subscriptions.push(vs.languages.registerReferenceProvider(filter, referenceProvider));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,7 +163,7 @@ export function activate(context: vs.ExtensionContext) {
 		activeFileFilters.push(HTML_MODE);
 	}
 
-	const triggerCharacters = ".: =(${'\"abcdefghijklmnopqrstuvwxyz".split("");
+	const triggerCharacters = ".: =(${'\"".split("");
 	activeFileFilters.forEach((filter) => {
 		context.subscriptions.push(vs.languages.registerHoverProvider(filter, hoverProvider));
 		context.subscriptions.push(vs.languages.registerDocumentFormattingEditProvider(filter, formattingEditProvider));

--- a/src/providers/dart_completion_item_provider.ts
+++ b/src/providers/dart_completion_item_provider.ts
@@ -40,6 +40,10 @@ export class DartCompletionItemProvider implements CompletionItemProvider {
 			switch (context.triggerCharacter) {
 				case "{":
 					return line.endsWith("${");
+				case "'":
+					return line.endsWith("import '") || line.endsWith("export '");
+				case "\"":
+					return line.endsWith("import \"") || line.endsWith("export \"");
 			}
 		}
 


### PR DESCRIPTION
Fixes #512 .

I tried to tweak the logic as you described but realized that thanks to completion of `import` statements (which inserts `import '|';` I rarely actually type `import '` or `import "`. So it wasn't doing anything useful for me.

I did try different combinations and settled on the one in this PR. I spent about an hour in the editor working on some Dart code with this setting and (to my personal taste) found it to be exactly what I wanted.

One edge case I found was not related to this change:

In annotations, if I type e.g. `@TestOn(` auto complete is triggered (by `(` character) even though there is nothing to complete in this case. This one is tricky since in some cases an annotation can have named arguments in which case it actually could be useful.
