### PR TITLE
Update package-lock to match a fresh install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
 			"dev": true
 		},
 		"@types/ws": {
-			"version": "https://registry.npmjs.org/@types/ws/-/ws-0.0.38.tgz",
+			"version": "0.0.38",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-0.0.38.tgz",
 			"integrity": "sha1-QhBv/0tCLKlWc04p8Nc6bYkxlNM=",
 			"dev": true,
 			"requires": {


### PR DESCRIPTION
This PR commits the updated package-lock.json generated by running `npm install` on a fresh checkout of the master branch [which results in a modification of the `"@types/ws"` entry].