### PR TITLE
Add keybinding ctrl+f5 to flutter.fullRestart command

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,6 +204,11 @@
 				"key": "f4",
 				"mac": "f4",
 				"when": "editorLangId == dart"
+			},
+			{
+				"command": "flutter.fullRestart",
+				"when": "dart-code:flutterProjectLoaded && inDebugMode",
+				"key": "ctrl+f5"
 			}
 		],
 		"menus": {


### PR DESCRIPTION
ctrl+f5 is used on mac too (not cmd+f5)

<img width="974" alt="screen shot 2018-03-10 at 3 22 43 pm" src="https://user-images.githubusercontent.com/4861023/37247851-2b44ae20-2477-11e8-9003-05cf9e38f3da.png">

---

If merged this will close #678.