### PR TITLE
Switch DAs to be hosted in-process (same as we used to debug)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,32 +16,6 @@
 			"preLaunchTask": "npm: watch"
 		},
 		{
-			"name": "Dart Debug Server",
-			"type": "node",
-			"request": "launch",
-			"cwd": "${workspaceRoot}",
-			"program": "${workspaceRoot}/src/debug/dart_debug_entry.ts",
-			"args": [
-				"--server=4711"
-			],
-			"outFiles": [
-				"${workspaceRoot}/out/src/**/*.js"
-			]
-		},
-		{
-			"name": "Flutter Debug Server",
-			"type": "node",
-			"request": "launch",
-			"cwd": "${workspaceRoot}",
-			"program": "${workspaceRoot}/src/debug/flutter_debug_entry.ts",
-			"args": [
-				"--server=4711"
-			],
-			"outFiles": [
-				"${workspaceRoot}/out/src/**/*.js"
-			]
-		},
-		{
 			"name": "Launch Tests (Multi-root)",
 			"type": "extensionHost",
 			"request": "launch",
@@ -112,22 +86,6 @@
 				"${workspaceRoot}/out/test/**/*.js"
 			],
 			"preLaunchTask": "npm: watch"
-		}
-	],
-	"compounds": [
-		{
-			"name": "Extension + Dart Debug Server",
-			"configurations": [
-				"Extension",
-				"Dart Debug Server"
-			]
-		},
-		{
-			"name": "Extension + Flutter Debug Server",
-			"configurations": [
-				"Extension",
-				"Flutter Debug Server"
-			]
 		}
 	]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Running Dart Code from source is relatively straight forward. You should:
 
 This will compile Dart Code and launch the Code `"Extension Development Host"`. You may see a warning in the top of the screen telling you the extension has been overwritten - this is normal; it's Code informing you that the normal installed version of the extension has been replaced by the version you just compiled. This only affects that particular session of the extension development host.
 
-You'll now have two versions of Code open - the standard instance that has the Dart Code source code open and the extension development host which is running the extension. In the standard instance you should be able to add breakpoints in the Dart Code source code and hit them by using Dart Code in the extension development host, with the exception of the debug adapters (see below). If you make code changes you'll want to click the `Restart` button in the standard instance (or press `Ctrl+Shift+F5`) in order to reload changes.
+You'll now have two versions of Code open - the standard instance that has the Dart Code source code open and the extension development host which is running the extension. In the standard instance you should be able to add breakpoints in the Dart Code source code and hit them by using Dart Code in the extension development host. If you make code changes you'll want to click the `Restart` button in the standard instance (or press `Ctrl+Shift+F5`) in order to reload changes.
 
 ## Automated Tests
 
@@ -53,16 +53,7 @@ All tests will be run on all platforms by Travis and AppVeyor when you submit a 
 
 ## Debugging the Debug Adapters
 
-In order to debug the debug adapters you need to run them in a `"server mode"`. This mode starts the debug adapters at extension activation time and keeps them open for the whole session. You'll also need to ensure that when you start the debug session from within Dart Code you have configured it to connect to this debug session.
-
-1. In the main Code instance, switch to the `Debug` pane
-2. In the configuration dropdown, choose the configuration named `Extension + Dart Server` or `Extension + Flutter Server`
-3. Press `F5` to launch the extension development host running the extension and also the debug server
-4. In the extension development host, open the `launch.json` file for the Dart project you're going to debug
-5. Add `"debugServer": 4711` to the debug configuration to instruct Dart Code to use the debug server (note: don't forget to remove this later, otherwise you'll get errors when trying to debug if there's no debug server running)
-6. Press `F5` in the extension development host to begin debugging
-
-In this mode, you should be able to hit breakpoints in the debug adapters too. The debug toolbar in the main instance will allow you to switch between the extension/debug server processes and you should see the status of both in the debugging panes.
+Debug adapters now run in-process and debugging them should be the same as any other extension code.
 
 ## Code Etiquette and Style
 

--- a/package.json
+++ b/package.json
@@ -565,7 +565,8 @@
 			{
 				"type": "dart",
 				"label": "Dart & Flutter",
-				"adapterExecutableCommand": "dart.getDebuggerExecutable",
+				"program": "./out/src/debug/dart_debug_entry.js",
+				"runtime": "node",
 				"languages": [
 					"dart"
 				],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -277,6 +277,7 @@ export function activate(context: vs.ExtensionContext) {
 	context.subscriptions.push(vs.debug.registerDebugConfigurationProvider("dart", debugProvider));
 	context.subscriptions.push(vs.debug.registerDebugConfigurationProvider("flutter", dummyDebugProvider));
 	context.subscriptions.push(vs.debug.registerDebugConfigurationProvider("dart-cli", dummyDebugProvider));
+	context.subscriptions.push(debugProvider);
 
 	// Setup that requires server version/capabilities.
 	const connectedSetup = analyzer.registerForServerConnected((sc) => {

--- a/src/providers/debug_config_provider.ts
+++ b/src/providers/debug_config_provider.ts
@@ -1,16 +1,22 @@
 import * as path from "path";
+import * as net from "net";
 import { Analytics } from "../analytics";
 import { config } from "../config";
+import { DartDebugSession } from "../debug/dart_debug_impl";
 import { DebugConfigurationProvider, WorkspaceFolder, CancellationToken, DebugConfiguration, ProviderResult, commands, window } from "vscode";
+import { DebugSession } from "vscode-debugadapter";
+import { FlutterDebugSession } from "../debug/flutter_debug_impl";
+import { FlutterDeviceManager } from "../flutter/device_manager";
 import { FlutterLaunchRequestArguments, isWin } from "../debug/utils";
 import { ProjectType, Sdks, isFlutterProject } from "../utils";
-import { FlutterDeviceManager } from "../flutter/device_manager";
 import { SdkCommands } from "../commands/sdk";
+import { spawn } from "child_process";
 
 export class DebugConfigProvider implements DebugConfigurationProvider {
 	private sdks: Sdks;
 	private analytics: Analytics;
 	private deviceManager: FlutterDeviceManager;
+	private debugServers: { [index: string]: net.Server } = {};
 
 	constructor(sdks: Sdks, analytics: Analytics, deviceManager: FlutterDeviceManager) {
 		this.sdks = sdks;
@@ -40,9 +46,33 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			// to open.
 			debugConfig.type = null;
 			window.showInformationMessage("Set the 'program' value in your launch config (eg ${workspaceRoot}/bin/main.dart) then launch again");
+			return debugConfig;
 		}
 
+		// Start port listener on launch of first debug session.
+		const debugServer = isFlutter
+			? this.getServer("flutter", () => new FlutterDebugSession())
+			: this.getServer("dart", () => new DartDebugSession());
+
+		// Make VS Code connect to debug server instead of launching debug adapter.
+		// TODO: Why do we need this cast? The node-mock-debug does not?
+		(debugConfig as any).debugServer = debugServer.address().port;
 		return debugConfig;
+	}
+
+	private getServer(type: string, create: () => DebugSession): net.Server {
+		// Start port listener on launch of first debug session.
+		if (!this.debugServers[type]) {
+
+			// Start listening on a random port.
+			this.debugServers[type] = net.createServer((socket) => {
+				const session = create();
+				session.setRunAsServer(true);
+				session.start(socket as NodeJS.ReadableStream, socket);
+			}).listen(0);
+		}
+
+		return this.debugServers[type];
 	}
 
 	private setupDebugConfig(folder: WorkspaceFolder | undefined, debugConfig: FlutterLaunchRequestArguments, isFlutter: boolean, deviceId: string) {
@@ -74,6 +104,15 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			debugConfig.flutterPath = debugConfig.flutterPath || (this.sdks.flutter ? path.join(this.sdks.flutter, "bin", flutterExec) : null);
 			debugConfig.flutterRunLogFile = debugConfig.flutterRunLogFile || conf.flutterRunLogFile;
 			debugConfig.deviceId = debugConfig.deviceId || deviceId;
+		}
+	}
+
+	public dispose() {
+		if (this.debugServers) {
+			for (const type of Object.keys(this.debugServers)) {
+				this.debugServers[type].close();
+				this.debugServers[type] = null;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This means the debugging is much simpler (it just works like the rest of the extension) and we can dynamically pick which DA to start in resolveDebugConfiguration. This may unblock us for folders-in-subfolders and `flutter test`.

Raising as a PR just for testing CodeClimate's integration.