### PR TITLE
Dont report errors in stable sdk

### DIFF
--- a/src/analysis/analyzer_status_reporter.ts
+++ b/src/analysis/analyzer_status_reporter.ts
@@ -100,8 +100,6 @@ export class AnalyzerStatusReporter {
 	}
 
 	private shouldReportErrors(): boolean {
-		// TODO: Confirm if we should be using Flutter SDK version in flutter
-		// (if we don't, won't all servers always be dev?)
 		if (this.sdks.projectType === ProjectType.Flutter && this.sdks.flutter)
 			return !isStableSdk(getSdkVersion(this.sdks.flutter));
 		else

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -305,6 +305,12 @@ function checkIsDevExtension() {
 	return extensionVersion.endsWith("-dev") || env.machineId === "someValue.machineId";
 }
 
+export function isStableSdk(sdkVersion: string): boolean {
+	// We'll consider empty versions as dev; stable versions will likely always
+	// be shipped with valid version files.
+	return !!(sdkVersion && sdkVersion.indexOf("-") === -1);
+}
+
 export function logError(error: { message: string }): void {
 	if (isDevExtension)
 		window.showErrorMessage("DEBUG: " + error.message);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -308,7 +308,7 @@ function checkIsDevExtension() {
 export function isStableSdk(sdkVersion: string): boolean {
 	// We'll consider empty versions as dev; stable versions will likely always
 	// be shipped with valid version files.
-	return !!(sdkVersion && sdkVersion.indexOf("-") === -1);
+	return !!(sdkVersion && !semver.prerelease(sdkVersion));
 }
 
 export function logError(error: { message: string }): void {

--- a/test/dart_only/util.test.ts
+++ b/test/dart_only/util.test.ts
@@ -31,13 +31,15 @@ describe("util.isStableSdk", () => {
 		assert.equal(util.isStableSdk(undefined), false);
 	});
 	it("should consider anything without a hyphen as stable", () => {
-		assert.equal(util.isStableSdk("1"), true);
-		assert.equal(util.isStableSdk("1.2"), true);
+		assert.equal(util.isStableSdk("1.0.0"), true);
+		assert.equal(util.isStableSdk("1.2.0"), true);
 		assert.equal(util.isStableSdk("1.2.3"), true);
 	});
 	it("should consider anything with a hyphen as unstable", () => {
-		assert.equal(util.isStableSdk("1-dev"), false);
-		assert.equal(util.isStableSdk("1.2-beta"), false);
+		assert.equal(util.isStableSdk("1.0.0-dev"), false);
+		assert.equal(util.isStableSdk("1.2.0-beta"), false);
 		assert.equal(util.isStableSdk("1.2.3-alpha.3"), false);
+		assert.equal(util.isStableSdk("0.2.2-pre.55"), false);
+		assert.equal(util.isStableSdk("2.0.0-dev.37.0.flutter-7328726088"), false);
 	});
 });

--- a/test/dart_only/util.test.ts
+++ b/test/dart_only/util.test.ts
@@ -24,3 +24,20 @@ describe("util.versionIsAtLeast", () => {
 		assert.equal(util.versionIsAtLeast("1.19.1-dev.0.0", "1.19.0"), true);
 	});
 });
+
+describe("util.isStableSdk", () => {
+	it("should consider missing versions as unstable", () => {
+		assert.equal(util.isStableSdk(null), false);
+		assert.equal(util.isStableSdk(undefined), false);
+	});
+	it("should consider anything without a hyphen as stable", () => {
+		assert.equal(util.isStableSdk("1"), true);
+		assert.equal(util.isStableSdk("1.2"), true);
+		assert.equal(util.isStableSdk("1.2.3"), true);
+	});
+	it("should consider anything with a hyphen as unstable", () => {
+		assert.equal(util.isStableSdk("1-dev"), false);
+		assert.equal(util.isStableSdk("1.2-beta"), false);
+		assert.equal(util.isStableSdk("1.2.3-alpha.3"), false);
+	});
+});


### PR DESCRIPTION
@devoncarew Please review and let me know what you think... some questions:

1. Is it correct to use the Flutter SDK version when making this decision for a flutter project? It seems strange since the errors are only reported for the analyzer, but if not, all analyzers inside Flutter will be considered dev, since they always have "pre-release" versions (containing hyphens).
2. Is the problem of stable reports being out of date just a consequence of there being no stable releases for so long? Will this change when Dart 2 ships?
3. When Dart 2 ships, won't we see a huge drop in people on dev SDKs and want to revert this?