### PR TITLE
Add memory usage to status bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -626,6 +626,10 @@
 							"previewDart2": {
 								"description": "Whether to enable previewing Dart 2.0 functionality such as optional new/const.\n\ntrue: send --preview-dart-2\n\nfalse: send --no-preview-dart-2\n\nnull: do not send a flag"
 							},
+							"showMemoryUsage": {
+								"type": "boolean",
+								"description": "Whether to show memory usage for your Flutter app in the status bar during debug sessions (if not set, will automatically show for profile builds).\n\nNote: memory usage shown in debug builds may not be indicative of usage in release builds. Use profile builds for more accurate figures when testing memory usage."
+							},
 							"flutterMode": {
 								"description": "The mode for launching the Flutter application:\n\ndebug: Turns on all assertions, includes all debug information, enables all debugger aids and optimizes for fast dev cycles\n\nrelease: Turns off all assertions, strips as much debug information as possible, turns of debugger aids and optimises for fast startup, fast execution and small package sizes.\n\nprofile: Same as release mode exept profiling aids and tracing are enabled.",
 								"enum": [

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -75,7 +75,7 @@ export class DebugCommands {
 				const memory = e.body.memory;
 				const message = `${Math.ceil(memory.current / 1024 / 1024)}MB of ${Math.ceil(memory.total / 1024 / 1024)}MB`;
 				this.debugMetrics.text = message;
-				this.debugMetrics.tooltip = "This is the amount of memory being consumed by your application out of what has been allocated.";
+				this.debugMetrics.tooltip = "This is the amount of memory being consumed by your applications heaps (out of what has been allocated).\n\nNote: memory usage shown in debug builds may not be indicative of usage in release builds. Use profile builds for more accurate figures when testing memory usage.";
 				this.debugMetrics.show();
 			}
 		}));

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -839,8 +839,10 @@ export class DartDebugSession extends DebugSession {
 		let total = 0;
 
 		for (const isolate of isolates) {
-			current += isolate._heaps.new.used + isolate._heaps.new.external;
-			total += isolate._heaps.new.capacity + isolate._heaps.new.external;
+			for (const heap of [isolate._heaps.old, isolate._heaps.new]) {
+				current += heap.used + heap.external;
+				total += heap.capacity + heap.external;
+			}
 		}
 
 		this.sendEvent(new Event("dart.debugMetrics", { memory: { current, total } }));

--- a/src/debug/dart_debug_protocol.ts
+++ b/src/debug/dart_debug_protocol.ts
@@ -54,6 +54,7 @@ export interface VMIsolate extends VMResponse {
 	runnable: boolean;
 	pauseEvent: VMEvent;
 	libraries: VMLibraryRef[];
+	_heaps?: { new: VMHeapSpace, old: VMHeapSpace };
 }
 
 export interface VMObjectRef extends VMResponse {
@@ -63,6 +64,13 @@ export interface VMObjectRef extends VMResponse {
 export interface VMStack extends VMResponse {
 	frames: VMFrame[];
 	asyncCausalFrames?: VMFrame[];
+}
+
+export interface VMHeapSpace extends VMResponse {
+	name: string;
+	used: number;
+	capacity: number;
+	external: number;
 }
 
 export interface VMFrame extends VMResponse {

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -19,7 +19,6 @@ export class FlutterDebugSession extends DartDebugSession {
 		super();
 
 		this.sendStdOutToConsole = false;
-		this.pollforMemoryMs = 1000;
 	}
 
 	protected initializeRequest(
@@ -62,6 +61,10 @@ export class FlutterDebugSession extends DartDebugSession {
 
 		if (args.args) {
 			appArgs = appArgs.concat(args.args);
+		}
+
+		if (args.flutterMode === "profile") {
+			this.pollforMemoryMs = 1000;
 		}
 
 		this.flutter = new FlutterRun(this.args.flutterPath, args.cwd, appArgs, this.args.flutterRunLogFile);

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -19,6 +19,7 @@ export class FlutterDebugSession extends DartDebugSession {
 		super();
 
 		this.sendStdOutToConsole = false;
+		this.pollforMemoryMs = 1000;
 	}
 
 	protected initializeRequest(

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -63,7 +63,7 @@ export class FlutterDebugSession extends DartDebugSession {
 			appArgs = appArgs.concat(args.args);
 		}
 
-		if (args.flutterMode === "profile") {
+		if (args.showMemoryUsage) {
 			this.pollforMemoryMs = 1000;
 		}
 

--- a/src/debug/utils.ts
+++ b/src/debug/utils.ts
@@ -202,6 +202,7 @@ export interface DartLaunchRequestArguments extends DebugProtocol.LaunchRequestA
 	vmArgs: string[];
 	observatoryLogFile: string;
 	previewDart2: boolean;
+	showMemoryUsage: boolean;
 }
 
 export interface FlutterLaunchRequestArguments extends DartLaunchRequestArguments {

--- a/src/flutter/device_manager.ts
+++ b/src/flutter/device_manager.ts
@@ -9,7 +9,7 @@ export class FlutterDeviceManager implements vs.Disposable {
 	public currentDevice: f.Device = null;
 
 	constructor(daemon: FlutterDaemon) {
-		this.statusBarItem = vs.window.createStatusBarItem(vs.StatusBarAlignment.Right, 0);
+		this.statusBarItem = vs.window.createStatusBarItem(vs.StatusBarAlignment.Right, 1);
 		this.statusBarItem.tooltip = "Flutter";
 		this.statusBarItem.show();
 		this.updateStatusBar();

--- a/src/providers/debug_config_provider.ts
+++ b/src/providers/debug_config_provider.ts
@@ -154,6 +154,10 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			debugConfig.flutterRunLogFile = debugConfig.flutterRunLogFile || conf.flutterRunLogFile;
 			debugConfig.flutterTestLogFile = debugConfig.flutterTestLogFile || conf.flutterTestLogFile;
 			debugConfig.deviceId = debugConfig.deviceId || deviceId;
+			debugConfig.showMemoryUsage =
+				debugConfig.showMemoryUsage !== undefined && debugConfig.showMemoryUsage !== null
+					? debugConfig.showMemoryUsage
+					: debugConfig.flutterMode === "profile";
 		}
 	}
 

--- a/src/sdk/status_bar_version_tracker.ts
+++ b/src/sdk/status_bar_version_tracker.ts
@@ -23,7 +23,7 @@ export class StatusBarVersionTracker implements vs.Disposable {
 	}
 
 	private addStatusBarItem(text: string, tooltip: string, command: string) {
-		const statusBarItem = vs.window.createStatusBarItem(vs.StatusBarAlignment.Right, 1);
+		const statusBarItem = vs.window.createStatusBarItem(vs.StatusBarAlignment.Right, 2);
 		statusBarItem.text = text;
 		statusBarItem.tooltip = tooltip;
 		statusBarItem.command = command;


### PR DESCRIPTION
See #739.

@devoncarew Please take a look. I'm a little skeptical about the numbers - this reads like "6MB of 9MB" when I run the stocks example app (iOS simulator)... Does this seem in the right ballpark? I'm surprised anything would consume that little memory these days when my editor consumes GBs!

- [x] Add option to disable (maybe separate for debug/profile, maybe with diff defaults?)
- [x] Add in old heap values