### PR TITLE
add selectDeviceOnConnect setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -590,6 +590,12 @@
 					"items": {
 						"type": "string"
 					}
+				},
+				"dart.selectDeviceOnConnect": {
+					"type": "boolean",
+					"default": true,
+					"description": "Select newly connected devices as current device.",
+					"scope": "window"
 				}
 			}
 		},

--- a/src/config.ts
+++ b/src/config.ts
@@ -44,6 +44,7 @@ class Config {
 	get sdkPath() { return resolveHomePath(this.getConfig<string>("sdkPath")); }
 	public setSdkPath(value: string): Thenable<void> { return this.setConfig("sdkPath", value, ConfigurationTarget.Workspace); }
 	get sdkPaths() { return (this.getConfig<string[]>("sdkPaths") || []).map(resolveHomePath); }
+	get selectDeviceOnConnect() {return this.getConfig<boolean>("selectDeviceOnConnect"); }
 
 	public setGlobalDartSdkPath(value: string): Thenable<void> { return this.setConfig("sdkPath", value, ConfigurationTarget.Global); }
 	public setGlobalFlutterSdkPath(value: string): Thenable<void> { return this.setConfig("flutterSdkPath", value, ConfigurationTarget.Global); }

--- a/src/flutter/device_manager.ts
+++ b/src/flutter/device_manager.ts
@@ -1,6 +1,7 @@
 import * as vs from "vscode";
 import { FlutterDaemon } from "./flutter_daemon";
 import * as f from "./flutter_types";
+import { config } from "../config";
 
 export class FlutterDeviceManager implements vs.Disposable {
 	private subscriptions: vs.Disposable[] = [];
@@ -27,7 +28,9 @@ export class FlutterDeviceManager implements vs.Disposable {
 
 	public deviceAdded(dev: f.Device) {
 		this.devices.push(dev);
-		this.currentDevice = dev;
+		if (this.currentDevice == null || config.selectDeviceOnConnect) {
+			this.currentDevice = dev;
+		}
 		this.updateStatusBar();
 	}
 


### PR DESCRIPTION
Every few minutes flutter would find my iPhone or iPad on wifi and select it as the current device which would drive me crazy when all I wanted to do was to develop on the simulator.

So I added an option that won't switch the device one `dart.selectDeviceOnConnect` is set to `false`.