### PR TITLE
Skip tests requiring newer version of VS Code

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/Dart-Code/Dart-Code.git"
 	},
 	"categories": [
-		"Languages",
+		"Programming Languages",
 		"Snippets",
 		"Linters",
 		"Formatters",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ import { referencesFlutterSdk } from "./sdk/utils";
 import { forceWindowsDriveLetterToUppercase } from "./debug/utils";
 
 export const extensionVersion = getExtensionVersion();
+export const vsCodeVersionConstraint = getVsCodeVersionConstraint();
 export const isDevExtension = checkIsDevExtension();
 export const FLUTTER_CREATE_PROJECT_TRIGGER_FILE = "dart_code_flutter_create.dart";
 
@@ -139,6 +140,11 @@ export function isInsideFolderNamed(file: string, folderName: string): boolean {
 function getExtensionVersion(): string {
 	const packageJson = require("../../package.json");
 	return packageJson.version;
+}
+
+function getVsCodeVersionConstraint(): string {
+	const packageJson = require("../../package.json");
+	return packageJson.engines.vscode;
 }
 
 export function versionIsAtLeast(inputVersion: string, requiredVersion: string): boolean {

--- a/test/dart_only/debug/dart_cli.test.ts
+++ b/test/dart_only/debug/dart_cli.test.ts
@@ -45,7 +45,7 @@ describe("dart cli debugger", () => {
 		]);
 	});
 
-	it("receives successfully runs a Dart script with a relative path", async () => {
+	it("successfully runs a Dart script with a relative path", async () => {
 		const config = await startDebugger(helloWorldMainFile);
 		config.program = path.relative(fsPath(helloWorldFolder), fsPath(helloWorldMainFile));
 		await Promise.all([


### PR DESCRIPTION
Since we're often developing in branches that require newer versions of Code (Insiders), this will skip the tests quietly if they can't run in that version of code. This'll stop us getting red crosses on all open PRs targetting the next version.