### PR TITLE
Handle initial thread states other than PauseStart

### DIFF
--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -178,9 +178,8 @@ export class DartDebugSession extends DebugSession {
 							isolate.runnable ? "IsolateRunnable" : "IsolateStart",
 						);
 
-						if (isolate.pauseEvent.kind === "PauseStart") {
-							const thread = this.threadManager.getThreadInfoFromRef(isolateRef);
-							thread.receivedPauseStart();
+						if (isolate.pauseEvent.kind.startsWith("Pause")) {
+							this.handlePauseEvent(isolate.pauseEvent);
 						}
 
 						// Helpers to categories libraries as SDK/ExternalLibrary/not.
@@ -689,6 +688,14 @@ export class DartDebugSession extends DebugSession {
 	public async handleDebugEvent(event: VMEvent) {
 		const kind = event.kind;
 
+		if (kind.startsWith("Pause")) {
+			this.handlePauseEvent(event);
+		}
+	}
+
+	private async handlePauseEvent(event: VMEvent) {
+		const kind = event.kind;
+
 		// For PausePostRequest we need to re-send all breakpoints; this happens after a flutter restart
 		if (kind === "PausePostRequest") {
 			await this.threadManager.resetBreakpoints();
@@ -703,7 +710,7 @@ export class DartDebugSession extends DebugSession {
 			// "PauseStart" should auto-resume after breakpoints are set.
 			const thread = this.threadManager.getThreadInfoFromRef(event.isolate);
 			thread.receivedPauseStart();
-		} else if (kind.startsWith("Pause")) {
+		} else {
 			const thread = this.threadManager.getThreadInfoFromRef(event.isolate);
 
 			// PauseStart, PauseExit, PauseBreakpoint, PauseInterrupted, PauseException


### PR DESCRIPTION
Passes initial thread pause states through the same handling as when
they are received as Debug events. This is should have no effect on
'launch' mode, where these states would not be encountered, but
will improve future 'attach' handling.