### PR TITLE
Set environment variables for Pub

### DIFF
--- a/src/analysis/analyzer.ts
+++ b/src/analysis/analyzer.ts
@@ -69,7 +69,7 @@ export class Analyzer extends AnalyzerGen {
 		// Register for version.
 		this.registerForServerConnected((e) => { this.version = e.version; this.capabilities.version = this.version; });
 
-		this.createProcess(undefined, dartVMPath, args, undefined);
+		this.createProcess(undefined, dartVMPath, args);
 
 		this.serverSetSubscriptions({
 			subscriptions: ["STATUS"],

--- a/src/debug/flutter_run.ts
+++ b/src/debug/flutter_run.ts
@@ -1,13 +1,12 @@
 import { Disposable } from "vscode";
 import * as f from "../flutter/flutter_types";
 import { StdIOService, UnknownNotification, UnknownResponse } from "../services/stdio_service";
-import { flutterEnv } from "./utils";
 
 export class FlutterRun extends StdIOService<UnknownNotification> {
 	constructor(flutterBinPath: string, projectFolder: string, args: string[], logFile: string) {
 		super(() => logFile, true, true);
 
-		this.createProcess(projectFolder, flutterBinPath, ["run", "--machine"].concat(args), flutterEnv);
+		this.createProcess(projectFolder, flutterBinPath, ["run", "--machine"].concat(args));
 	}
 
 	protected shouldHandleMessage(message: string): boolean {

--- a/src/debug/flutter_test.ts
+++ b/src/debug/flutter_test.ts
@@ -1,12 +1,11 @@
 import { Disposable } from "vscode";
 import { StdIOService } from "../services/stdio_service";
-import { flutterEnv } from "./utils";
 
 export class FlutterTest extends StdIOService<Notification> {
 	constructor(flutterBinPath: string, projectFolder: string, args: string[], logFile: string) {
 		super(() => logFile, true, true);
 
-		this.createProcess(projectFolder, flutterBinPath, ["test", "--machine"].concat(args), flutterEnv);
+		this.createProcess(projectFolder, flutterBinPath, ["test", "--machine"].concat(args));
 	}
 
 	protected shouldHandleMessage(message: string): boolean {

--- a/src/debug/utils.ts
+++ b/src/debug/utils.ts
@@ -8,6 +8,9 @@ export const isWin = /^win/.test(process.platform);
 const toolEnv = Object.create(process.env);
 toolEnv.FLUTTER_HOST = "VSCode";
 toolEnv.PUB_ENVIRONMENT = (toolEnv.PUB_ENVIRONMENT ? `${toolEnv.PUB_ENVIRONMENT}:` : "") + "vscode.dart-code";
+if (process.env.DART_CODE_IS_TEST_RUN) {
+	toolEnv.PUB_ENVIRONMENT += ".test.bot";
+}
 
 export function safeSpawn(workingDirectory: string, binPath: string, args: string[]): child_process.ChildProcess {
 	// Spawning processes on Windows with funny symbols in the path requires quoting. However if you quote an

--- a/src/debug/utils.ts
+++ b/src/debug/utils.ts
@@ -5,16 +5,17 @@ import { DebugProtocol } from "vscode-debugprotocol";
 
 export const isWin = /^win/.test(process.platform);
 
-export const flutterEnv = Object.create(process.env);
-flutterEnv.FLUTTER_HOST = "VSCode";
+const toolEnv = Object.create(process.env);
+toolEnv.FLUTTER_HOST = "VSCode";
+toolEnv.PUB_ENVIRONMENT = (toolEnv.PUB_ENVIRONMENT ? `${toolEnv.PUB_ENVIRONMENT}:` : "") + "vscode.dart-code";
 
-export function safeSpawn(workingDirectory: string, binPath: string, args: string[], env?: any): child_process.ChildProcess {
+export function safeSpawn(workingDirectory: string, binPath: string, args: string[]): child_process.ChildProcess {
 	// Spawning processes on Windows with funny symbols in the path requires quoting. However if you quote an
 	// executable with a space in its path and an argument also has a space, you have to then quote all of the
 	// arguments too!
 	// Tragic.
 	// https://github.com/nodejs/node/issues/7367
-	return child_process.spawn(`"${binPath}"`, args.map((a) => `"${a}"`), { cwd: workingDirectory, env, shell: true });
+	return child_process.spawn(`"${binPath}"`, args.map((a) => `"${a}"`), { cwd: workingDirectory, env: toolEnv, shell: true });
 }
 
 export function uriToFilePath(uri: string, returnWindowsPath: boolean = isWin): string {

--- a/src/flutter/flutter_daemon.ts
+++ b/src/flutter/flutter_daemon.ts
@@ -1,6 +1,5 @@
 import * as vs from "vscode";
 import { config } from "../config";
-import { flutterEnv } from "../debug/utils";
 import { StdIOService, UnknownNotification, UnknownResponse } from "../services/stdio_service";
 import { reloadExtension } from "../utils";
 import { FlutterDeviceManager } from "./device_manager";
@@ -12,7 +11,7 @@ export class FlutterDaemon extends StdIOService<UnknownNotification> {
 	constructor(flutterBinPath: string, projectFolder: string) {
 		super(() => config.flutterDaemonLogFile, true);
 
-		this.createProcess(projectFolder, flutterBinPath, ["daemon"], flutterEnv);
+		this.createProcess(projectFolder, flutterBinPath, ["daemon"]);
 
 		this.deviceManager = new FlutterDeviceManager(this);
 

--- a/src/services/stdio_service.ts
+++ b/src/services/stdio_service.ts
@@ -24,14 +24,12 @@ export abstract class StdIOService<T> implements Disposable {
 		this.treatHandlingErrorsAsUnhandledMessages = treatHandlingErrorsAsUnhandledMessages;
 	}
 
-	protected createProcess(workingDirectory: string, binPath: string, args: string[], env: any) {
+	protected createProcess(workingDirectory: string, binPath: string, args: string[]) {
 		this.logTraffic(`Spawning ${binPath} with args ${JSON.stringify(args)}`);
 		if (workingDirectory)
 			this.logTraffic(`..  in ${workingDirectory}`);
-		if (env)
-			this.logTraffic(`..  in ${JSON.stringify(env)}`);
 
-		this.process = safeSpawn(workingDirectory, binPath, args, env);
+		this.process = safeSpawn(workingDirectory, binPath, args);
 
 		this.process.stdout.on("data", (data: Buffer) => {
 			const message = data.toString();


### PR DESCRIPTION
This implements #877 as requested by @kevmoo.

We already have an env var we pass for flutter (which sets `FLUTTER_HOST`). Rather than adding more and having to make sure they were used int he correct places, I've made a single env variable which sets both `FLUTTER_HOST` and `PUB_ENVIRONMENT` and then is used inside `safeSpawn` (which is the function we always use for spawning processes to handle Windows path escaping issues).

In theory, this should solve all the requirements (including that when Pub is invoked by Flutter, assuming it passed the env through).

Does this sound reasonable? Are there any problems with sending both of these all the time?

@kevmoo I assumed the note about test runs was for Dart Code's tests (and not end users tests) but if this is incorrect, let me know. @devoncarew Also let me know if you want me to change the FLUTTER_HOST for test runs (we do run `flutter config --no-analytics` in the Travis/AppVeyor scripts but that doesn't cover people (like me) running the tests locally during dev).