### PR TITLE
Add support for attaching to process

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,11 @@
 				}
 			},
 			{
+				"command": "dart.attach",
+				"title": "Attach to Dart Process",
+				"category": "Debug"
+			},
+			{
 				"command": "dart.goToSuper",
 				"title": "Go to Super Method",
 				"category": "Dart"
@@ -250,6 +255,10 @@
 				{
 					"command": "dart.goToSuper",
 					"when": "dart-code:dartProjectLoaded && editorLangId == dart"
+				},
+				{
+					"command": "dart.attach",
+					"when": "dart-code:dartProjectLoaded && !inDebugMode"
 				},
 				{
 					"command": "dart.sortMembers",

--- a/package.json
+++ b/package.json
@@ -688,14 +688,14 @@
 							},
 							"observatoryUri": {
 								"type": "string",
-								"description": "URI of the Observaty instance to attach to."
+								"description": "URI (or port) of the Observatory instance to attach to."
 							}
 						}
 					}
 				},
 				"configurationSnippets": [
 					{
-						"label": "Dart",
+						"label": "Dart: Launch",
 						"description": "Launch and debug Dart applications",
 						"body": {
 							"name": "Dart",
@@ -705,7 +705,7 @@
 						}
 					},
 					{
-						"label": "Flutter",
+						"label": "Flutter: Launch",
 						"description": "Launch and debug Flutter applications",
 						"body": {
 							"name": "Flutter",
@@ -715,13 +715,12 @@
 						}
 					},
 					{
-						"label": "Dart - Attach",
+						"label": "Dart: Attach",
 						"description": "Debug an already-running Dart application",
 						"body": {
-							"name": "Dart - Attach",
+							"name": "Dart: Attach to Process",
 							"type": "dart",
-							"request": "attach",
-							"packages": "^\"\\${workspaceFolder}/.packages\""
+							"request": "attach"
 						}
 					}
 				]

--- a/package.json
+++ b/package.json
@@ -721,14 +721,10 @@
 							"name": "Dart - Attach",
 							"type": "dart",
 							"request": "attach",
-							"packages": "^\"\\${workspaceFolder}/.packages\"",
-							"observatoryUri": "^\"http://127.0.0.1:\\${command:PromptForObservatoryAddress}/\""
+							"packages": "^\"\\${workspaceFolder}/.packages\""
 						}
 					}
-				],
-				"variables": {
-					"PromptForObservatoryAddress": "dart.getObservatoryAddress"
-				}
+				]
 			}
 		]
 	},

--- a/package.json
+++ b/package.json
@@ -675,6 +675,22 @@
 								}
 							}
 						}
+					},
+					"attach": {
+						"properties": {
+							"cwd": {
+								"type": "string",
+								"description": "Workspace root."
+							},
+							"packages": {
+								"type": "string",
+								"description": "Path to the packages file, if it's not at the workspace root."
+							},
+							"observatoryUri": {
+								"type": "string",
+								"description": "URI of the Observaty instance to attach to."
+							}
+						}
 					}
 				},
 				"configurationSnippets": [
@@ -697,8 +713,22 @@
 							"request": "launch",
 							"program": "^\"lib/main.dart\""
 						}
+					},
+					{
+						"label": "Dart - Attach",
+						"description": "Debug an already-running Dart application",
+						"body": {
+							"name": "Dart - Attach",
+							"type": "dart",
+							"request": "attach",
+							"packages": "^\"\\${workspaceFolder}/.packages\"",
+							"observatoryUri": "^\"http://127.0.0.1:\\${command:PromptForObservatoryAddress}/\""
+						}
 					}
-				]
+				],
+				"variables": {
+					"PromptForObservatoryAddress": "dart.getObservatoryAddress"
+				}
 			}
 		]
 	},

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -113,11 +113,6 @@ export class DebugCommands {
 				analytics.logDebuggerOpenObservatory();
 			}
 		}));
-		context.subscriptions.push(vs.commands.registerCommand("dart.getObservatoryAddress", () => {
-			return vs.window.showInputBox({
-				prompt: "Observatory address (URL or port, depending on your launch.json).",
-			});
-		}));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.openTimeline", () => {
 			if (this.observatoryUri) {
 				openInBrowser(this.observatoryUri + "/#/timeline-dashboard");

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -158,6 +158,17 @@ export class DebugCommands {
 		// We can't just use a service command here, as we need to call it twice (once to get, once to change) and
 		// currently it seems like the DA can't return responses to us here, so we'll have to do them both inside the DA.
 		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePlatform", () => this.sendCustomFlutterDebugCommand("togglePlatform")));
+
+		// Attach commands.
+		context.subscriptions.push(vs.commands.registerCommand("dart.attach", () => {
+			if (this.currentDebugSession)
+				return;
+			vs.debug.startDebugging(undefined, {
+				name: "Dart: Attach to Process",
+				request: "attach",
+				type: "dart",
+			});
+		}));
 	}
 
 	private serviceSettings: { [id: string]: () => void } = {};

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -113,6 +113,11 @@ export class DebugCommands {
 				analytics.logDebuggerOpenObservatory();
 			}
 		}));
+		context.subscriptions.push(vs.commands.registerCommand("dart.getObservatoryAddress", () => {
+			return vs.window.showInputBox({
+				prompt: "Observatory address (URL or port, depending on your launch.json).",
+			});
+		}));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.openTimeline", () => {
 			if (this.observatoryUri) {
 				openInBrowser(this.observatoryUri + "/#/timeline-dashboard");

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -106,10 +106,7 @@ export class DartDebugSession extends DebugSession {
 
 	protected async attachRequest(response: DebugProtocol.AttachResponse, args: DartAttachRequestArguments): Promise<void> {
 		if (!args || !args.observatoryUri) {
-			response.success = false;
-			response.message = "Unable to attach; no Observatory address provided.";
-			this.sendResponse(response);
-			return;
+			return this.errorResponse(response, "Unable to attach; no Observatory address provided.");
 		}
 		if (!args.packages) {
 			return this.errorResponse(response, "Unable to attach; no packages file provided.");

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -111,6 +111,9 @@ export class DartDebugSession extends DebugSession {
 			this.sendResponse(response);
 			return;
 		}
+		if (!args.packages) {
+			return this.errorResponse(response, "Unable to attach; no packages file provided.");
+		}
 
 		this.cwd = args.cwd;
 		this.debugSdkLibraries = args.debugSdkLibraries;

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -117,6 +117,10 @@ export class DartDebugSession extends DebugSession {
 		this.debugExternalLibraries = args.debugExternalLibraries;
 		this.observatoryLogFile = args.observatoryLogFile;
 
+		// Support relative paths
+		if (!path.isAbsolute(args.packages))
+			args.packages = path.join(args.cwd, args.packages);
+
 		try {
 			this.packageMap = new PackageMap(PackageMap.findPackagesFile(args.packages));
 		} catch (e) {

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -5,7 +5,7 @@ import { DebugSession, Event, InitializedEvent, OutputEvent, Scope, Source, Stac
 import { DebugProtocol } from "vscode-debugprotocol";
 import { DebuggerResult, ObservatoryConnection, VM, VMBreakpoint, VMErrorRef, VMEvent, VMFrame, VMInstance, VMInstanceRef, VMIsolate, VMIsolateRef, VMLibraryRef, VMMapEntry, VMObj, VMResponse, VMScript, VMScriptRef, VMSentinel, VMSourceLocation, VMStack } from "./dart_debug_protocol";
 import { PackageMap } from "./package_map";
-import { DartLaunchRequestArguments, PromiseCompleter, formatPathForVm, safeSpawn, uriToFilePath } from "./utils";
+import { DartAttachRequestArguments, DartLaunchRequestArguments, PromiseCompleter, formatPathForVm, safeSpawn, uriToFilePath } from "./utils";
 
 // TODO: supportsSetVariable
 // TODO: class variables?
@@ -15,13 +15,15 @@ import { DartLaunchRequestArguments, PromiseCompleter, formatPathForVm, safeSpaw
 // completionsRequest(response: DebugProtocol.CompletionsResponse, args: DebugProtocol.CompletionsArguments): void;
 
 export class DartDebugSession extends DebugSession {
-	protected args: DartLaunchRequestArguments;
 	// TODO: Tidy all this up
-	protected sourceFile: string;
 	protected childProcess: child_process.ChildProcess;
 	private processExited: boolean = false;
 	public observatory: ObservatoryConnection;
+	protected cwd: string;
+	private observatoryLogFile: string;
 	private observatoryLogStream: fs.WriteStream;
+	private debugSdkLibraries: boolean;
+	private debugExternalLibraries: boolean;
 	private threadManager: ThreadManager;
 	private packageMap: PackageMap;
 	protected sendStdOutToConsole: boolean = true;
@@ -56,12 +58,14 @@ export class DartDebugSession extends DebugSession {
 			return;
 		}
 
-		this.args = args;
 		// Force relative paths to absolute.
 		if (!path.isAbsolute(args.program))
 			args.program = path.join(args.cwd, args.program);
-		this.sourceFile = path.relative(args.cwd, args.program);
+		this.cwd = args.cwd;
 		this.packageMap = new PackageMap(PackageMap.findPackagesFile(args.program));
+		this.debugSdkLibraries = args.debugSdkLibraries;
+		this.debugExternalLibraries = args.debugExternalLibraries;
+		this.observatoryLogFile = args.observatoryLogFile;
 
 		this.sendResponse(response);
 
@@ -106,6 +110,27 @@ export class DartDebugSession extends DebugSession {
 			this.sendEvent(new InitializedEvent());
 	}
 
+	protected attachRequest(response: DebugProtocol.AttachResponse, args: DartAttachRequestArguments): void {
+		this.cwd = args.cwd;
+		this.packageMap = new PackageMap(PackageMap.findPackagesFile(args.packages));
+		this.debugSdkLibraries = args.debugSdkLibraries;
+		this.debugExternalLibraries = args.debugExternalLibraries;
+		this.observatoryLogFile = args.observatoryLogFile;
+
+		this.sendResponse(response);
+		let uri = args.observatoryUri;
+		if (!uri.endsWith("/"))
+			uri = uri + "/";
+		this.initObservatory(`${uri}ws`);
+	}
+
+	protected sourceFileForArgs(args: DartLaunchRequestArguments) {
+		if (args.program == null) {
+			return null;
+		}
+		return path.relative(args.cwd, args.program);
+	}
+
 	protected spawnProcess(args: DartLaunchRequestArguments) {
 		const debug = !args.noDebug;
 		let appArgs = [];
@@ -125,12 +150,12 @@ export class DartDebugSession extends DebugSession {
 		if (args.vmAdditionalArgs) {
 			appArgs = appArgs.concat(args.vmAdditionalArgs);
 		}
-		appArgs.push(this.sourceFile);
+		appArgs.push(this.sourceFileForArgs(args));
 		if (args.args) {
 			appArgs = appArgs.concat(args.args);
 		}
 
-		const process = safeSpawn(args.cwd, this.args.dartPath, appArgs);
+		const process = safeSpawn(args.cwd, args.dartPath, appArgs);
 
 		return process;
 	}
@@ -147,9 +172,9 @@ export class DartDebugSession extends DebugSession {
 		this.observatory.onLogging((message) => {
 			const max: number = 2000;
 
-			if (this.args.observatoryLogFile) {
+			if (this.observatoryLogFile) {
 				if (!this.observatoryLogStream)
-					this.observatoryLogStream = fs.createWriteStream(this.args.observatoryLogFile);
+					this.observatoryLogStream = fs.createWriteStream(this.observatoryLogFile);
 				this.observatoryLogStream.write(`[${(new Date()).toLocaleTimeString()}]: `);
 				if (message.length > max)
 					this.observatoryLogStream.write(message.substring(0, max) + "…\r\n");
@@ -189,8 +214,8 @@ export class DartDebugSession extends DebugSession {
 								// Note: Condition is negated.
 								const shouldDebug = !(
 									// Inside here is shouldNotDebug!
-									(isSdkLibrary(library) && !this.args.debugSdkLibraries)
-									|| (isExternalLibrary(library) && !this.args.debugExternalLibraries)
+									(isSdkLibrary(library) && !this.debugSdkLibraries)
+									|| (isExternalLibrary(library) && !this.debugExternalLibraries)
 								);
 								this.observatory.setLibraryDebuggable(isolateRef.id, library.id, shouldDebug);
 							}),
@@ -229,6 +254,7 @@ export class DartDebugSession extends DebugSession {
 	): void {
 		if (this.childProcess != null)
 			this.childProcess.kill();
+		// TODO: Restart any paused threads for the attach case.
 		super.disconnectRequest(response, args);
 	}
 
@@ -845,7 +871,7 @@ export class DartDebugSession extends DebugSession {
 	private convertVMUriToUserName(uri: string): string {
 		if (uri.startsWith("file:")) {
 			uri = uriToFilePath(uri);
-			uri = path.relative(this.args.cwd, uri);
+			uri = path.relative(this.cwd, uri);
 		}
 
 		return uri;

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -113,10 +113,15 @@ export class DartDebugSession extends DebugSession {
 		}
 
 		this.cwd = args.cwd;
-		this.packageMap = new PackageMap(PackageMap.findPackagesFile(args.packages));
 		this.debugSdkLibraries = args.debugSdkLibraries;
 		this.debugExternalLibraries = args.debugExternalLibraries;
 		this.observatoryLogFile = args.observatoryLogFile;
+
+		try {
+			this.packageMap = new PackageMap(PackageMap.findPackagesFile(args.packages));
+		} catch (e) {
+			this.errorResponse(response, `Unable to connect to load packages file: ${e}`);
+		}
 
 		try {
 			await this.initObservatory(this.websocketUriForObservatoryUri(args.observatoryUri));

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -105,12 +105,21 @@ export class DartDebugSession extends DebugSession {
 	}
 
 	protected attachRequest(response: DebugProtocol.AttachResponse, args: DartAttachRequestArguments): void {
+		if (!args || !args.observatoryUri) {
+			response.success = false;
+			response.message = "Unable to attach; no Observatory address provided.";
+			this.sendResponse(response);
+			return;
+		}
+
 		this.cwd = args.cwd;
 		this.packageMap = new PackageMap(PackageMap.findPackagesFile(args.packages));
 		this.debugSdkLibraries = args.debugSdkLibraries;
 		this.debugExternalLibraries = args.debugExternalLibraries;
 		this.observatoryLogFile = args.observatoryLogFile;
 
+		// TODO: Hold off on sending the response until initObservatory has succeeded or failed
+		// so that attach failures (e.g., invalid URLs, wrong port) are reported.
 		this.sendResponse(response);
 		this.initObservatory(this.websocketUriForObservatoryUri(args.observatoryUri));
 	}

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -262,8 +262,24 @@ export class DartDebugSession extends DebugSession {
 		if (this.childProcess != null) {
 			this.childProcess.kill();
 		} else {
-			// TODO: Restart any paused threads, and remove breakpoints.
-			this.observatory.close();
+			// Remove all breakpoints from the VM.
+			const removeBreakpointPromises = [];
+			for (const thread of this.threadManager.threads) {
+				removeBreakpointPromises.push(thread.removeAllBreakpoints());
+			}
+			Promise.all(removeBreakpointPromises).then((_) => {
+				// Restart any paused threads.
+				const resumePromises = [];
+				for (const thread of this.threadManager.threads) {
+					if (thread.paused) {
+						resumePromises.push(this.observatory.resume(thread.ref.id));
+					}
+				}
+				Promise.all(resumePromises).then((_) => {
+					// Finally, shut down the connection to the observatory.
+					this.observatory.close();
+				}).catch((error) => this.observatory.close());
+			}).catch((error) => this.observatory.close());
 		}
 		super.disconnectRequest(response, args);
 	}
@@ -1183,6 +1199,22 @@ class ThreadInfo {
 		this.manager = manager;
 		this.ref = ref;
 		this.number = num;
+	}
+
+	public removeAllBreakpoints(): Promise<DebuggerResult[]> {
+		const removeBreakpointPromises = [];
+		for (const uri of Object.keys(this.vmBps)) {
+			const breakpoints = this.vmBps[uri];
+			if (breakpoints) {
+				for (const bp of breakpoints) {
+					removeBreakpointPromises.push(this.manager.debugSession.observatory.removeBreakpoint(this.ref.id, bp.id));
+				}
+			}
+		}
+
+		this.vmBps = {};
+
+		return Promise.all(removeBreakpointPromises);
 	}
 
 	public setBreakpoints(uri: string, breakpoints: DebugProtocol.SourceBreakpoint[]): Promise<boolean[]> {

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -275,7 +275,7 @@ export class DartDebugSession extends DebugSession {
 	): void {
 		if (this.childProcess != null) {
 			this.childProcess.kill();
-		} else {
+		} else if (this.observatory) {
 			// Remove all breakpoints from the VM.
 			const removeBreakpointPromises = [];
 			for (const thread of this.threadManager.threads) {

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -847,10 +847,10 @@ export class DartDebugSession extends DebugSession {
 
 					// Output any logpoint messages.
 					for (const logPoint of logPoints) {
-						// TODO: Escape triple quotes?
 						const logMessage = logPoint.logMessage
 							.replace(/(^|[^\\\$]){/g, "$1\${") // Prefix any {tokens} with $ if they don't have
 							.replace(/\\({)/g, "$1"); // Remove slashes
+						// TODO: Escape triple quotes?
 						const printCommand = `print("""${logMessage}""")`;
 						await this.evaluateAndSendErrors(thread, printCommand);
 					}

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -165,13 +165,15 @@ export class DartDebugSession extends DebugSession {
 	}
 
 	private websocketUriForObservatoryUri(uri: string) {
-		let wsUri = uri.trim();
-		if (!wsUri.endsWith("/ws")) {
-			if (!wsUri.endsWith("/"))
-				wsUri = wsUri + "/";
-			wsUri = wsUri + "ws";
-		}
-		return wsUri;
+		const wsUri = uri.trim();
+		if (wsUri.endsWith("/ws"))
+			return wsUri;
+		else if (wsUri.endsWith("/ws/"))
+			return wsUri.substr(0, wsUri.length - 1);
+		else if (wsUri.endsWith("/"))
+			return `${wsUri}ws`;
+		else
+			return `${wsUri}/ws`;
 	}
 
 	protected initObservatory(uri: string): Promise<void> {

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -33,11 +33,8 @@ export class FlutterDebugSession extends DartDebugSession {
 		const debug = !args.noDebug;
 		let appArgs = [];
 
-		const sourceFile = this.sourceFileForArgs(args);
-		if (sourceFile) {
-			appArgs.push("-t");
-			appArgs.push(sourceFile);
-		}
+		appArgs.push("-t");
+		appArgs.push(this.sourceFileForArgs(args));
 
 		if (args.deviceId) {
 			appArgs.push("-d");

--- a/src/debug/flutter_test_debug_impl.ts
+++ b/src/debug/flutter_test_debug_impl.ts
@@ -34,8 +34,7 @@ export class FlutterTestDebugSession extends DartDebugSession {
 			appArgs.push("--start-paused");
 		}
 
-		const sourceFile = this.sourceFileForArgs(args);
-		appArgs.push(sourceFile);
+		appArgs.push(this.sourceFileForArgs(args));
 
 		if (args.args) {
 			appArgs = appArgs.concat(args.args);

--- a/src/debug/flutter_test_debug_impl.ts
+++ b/src/debug/flutter_test_debug_impl.ts
@@ -34,15 +34,16 @@ export class FlutterTestDebugSession extends DartDebugSession {
 			appArgs.push("--start-paused");
 		}
 
-		if (this.sourceFile) {
-			appArgs.push(this.sourceFile);
+		const sourceFile = this.sourceFileForArgs(args);
+		if (sourceFile) {
+			appArgs.push(sourceFile);
 		}
 
 		if (args.args) {
 			appArgs = appArgs.concat(args.args);
 		}
 
-		this.flutter = new FlutterTest(this.args.flutterPath, args.cwd, appArgs, this.args.flutterTestLogFile);
+		this.flutter = new FlutterTest(args.flutterPath, args.cwd, appArgs, args.flutterTestLogFile);
 		// this.flutter.registerForUnhandledMessages((msg) => this.log(msg));
 
 		// Set up subscriptions.

--- a/src/debug/flutter_test_debug_impl.ts
+++ b/src/debug/flutter_test_debug_impl.ts
@@ -35,9 +35,7 @@ export class FlutterTestDebugSession extends DartDebugSession {
 		}
 
 		const sourceFile = this.sourceFileForArgs(args);
-		if (sourceFile) {
-			appArgs.push(sourceFile);
-		}
+		appArgs.push(sourceFile);
 
 		if (args.args) {
 			appArgs = appArgs.concat(args.args);

--- a/src/debug/utils.ts
+++ b/src/debug/utils.ts
@@ -125,3 +125,14 @@ export interface FlutterLaunchRequestArguments extends DartLaunchRequestArgument
 	flutterTestLogFile: string;
 	deviceId: string;
 }
+
+export interface DartAttachRequestArguments extends DebugProtocol.AttachRequestArguments {
+	type: string;
+	request: string;
+	cwd: string;
+	debugSdkLibraries: boolean;
+	debugExternalLibraries: boolean;
+	packages: string;
+	observatoryUri: string;
+	observatoryLogFile: string;
+}

--- a/src/providers/debug_config_provider.ts
+++ b/src/providers/debug_config_provider.ts
@@ -140,6 +140,8 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 				if (!input)
 					return;
 
+				input = input.trim();
+
 				if (Number.isInteger(parseFloat(input)))
 					return;
 

--- a/src/providers/debug_config_provider.ts
+++ b/src/providers/debug_config_provider.ts
@@ -98,6 +98,8 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			if (/^\s*[0-9]+\s*$/.exec(debugConfig.observatoryUri)) {
 				debugConfig.observatoryUri = "http://127.0.0.1:" + debugConfig.observatoryUri.trim();
 			}
+
+			debugConfig.packages = debugConfig.packages || path.join(fsPath(folder.uri), ".packages");
 		}
 
 		// Disable Flutter mode for attach.

--- a/src/providers/debug_config_provider.ts
+++ b/src/providers/debug_config_provider.ts
@@ -40,6 +40,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		function resolveVariables(input: string): string {
 			if (!input) return input;
 			if (input === "${file}") return openFile;
+			if (!folder) return input;
 			return input.replace(/\${workspaceFolder}/, fsPath(folder.uri));
 		}
 

--- a/src/providers/debug_config_provider.ts
+++ b/src/providers/debug_config_provider.ts
@@ -134,8 +134,21 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 	private async getObservatoryUri(observatoryUri: string): Promise<string> {
 		observatoryUri = observatoryUri || await vs.window.showInputBox({
 			ignoreFocusOut: true, // Don't close the window if the user tabs away to get the uri
-			placeHolder: "Observatory URI or port",
-			prompt: "Enter an Observatory URI",
+			placeHolder: "Paste an Observatory URI or port",
+			prompt: "Enter Observatory URI",
+			validateInput: (input) => {
+				if (!input)
+					return;
+
+				if (Number.isInteger(parseFloat(input)))
+					return;
+
+				// Uri.parse doesn't seem to work as expected, so do our own basic validation
+				// https://github.com/Microsoft/vscode/issues/49818
+
+				if (!input.startsWith("http://") && !input.startsWith("https://"))
+					return "Please enter a valid Observatory URI or port number";
+			},
 		});
 		observatoryUri = observatoryUri && observatoryUri.trim();
 

--- a/src/providers/debug_config_provider.ts
+++ b/src/providers/debug_config_provider.ts
@@ -132,7 +132,11 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 	}
 
 	private async getObservatoryUri(observatoryUri: string): Promise<string> {
-		observatoryUri = observatoryUri || await vs.window.showInputBox({ prompt: "Enter Observatory address. This can be a full URL, or just a port for localhost." });
+		observatoryUri = observatoryUri || await vs.window.showInputBox({
+			ignoreFocusOut: true, // Don't close the window if the user tabs away to get the uri
+			placeHolder: "Observatory URI or port",
+			prompt: "Enter an Observatory URI",
+		});
 		observatoryUri = observatoryUri && observatoryUri.trim();
 
 		// If the input is just a number, treat is as a localhost port.

--- a/src/providers/debug_config_provider.ts
+++ b/src/providers/debug_config_provider.ts
@@ -67,7 +67,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			debugConfig.packages = debugConfig.packages || path.join(fsPath(folder.uri), ".packages");
 
 			// For attaching, the Observatory address must be specified. If it's not provided already, prompt for it.
-			debugConfig.observatoryUri = debugConfig.observatoryUri || await this.getObservatoryUri();
+			debugConfig.observatoryUri = await this.getObservatoryUri(debugConfig.observatoryUri);
 
 			if (!debugConfig.observatoryUri) {
 				// Set type=null which causes launch.json to open.
@@ -125,15 +125,16 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		}
 	}
 
-	private async getObservatoryUri(): Promise<string> {
-		let userInput = await vs.window.showInputBox({ prompt: "Enter Observatory address. This can be a full URL, or just a port for localhost." });
+	private async getObservatoryUri(observatoryUri: string): Promise<string> {
+		observatoryUri = observatoryUri || await vs.window.showInputBox({ prompt: "Enter Observatory address. This can be a full URL, or just a port for localhost." });
+		observatoryUri = observatoryUri && observatoryUri.trim();
 
 		// If the input is just a number, treat is as a localhost port.
-		if (userInput && /^\s*[0-9]+\s*$/.exec(userInput)) {
-			userInput = `http://127.0.0.1:${userInput}`;
+		if (observatoryUri && /^[0-9]+$/.exec(observatoryUri)) {
+			observatoryUri = `http://127.0.0.1:${observatoryUri}`;
 		}
 
-		return userInput;
+		return observatoryUri;
 	}
 
 	private getDebugServer(debugType: DebuggerType, port?: number) {

--- a/src/providers/debug_config_provider.ts
+++ b/src/providers/debug_config_provider.ts
@@ -79,7 +79,9 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		// If we don't have a cwd then find the best one from the project root.
 		debugConfig.cwd = debugConfig.cwd || fsPath(folder.uri);
 
-		const isFlutter = isFlutterProjectFolder(debugConfig.cwd as string);
+		// Disable Flutter mode for attach.
+		// TODO: Update FlutterDebugSession to understand attach mode, and remove this limitation.
+		const isFlutter = isFlutterProjectFolder(debugConfig.cwd as string) && debugConfig.request === "launch";
 		const isTest = isTestFile(resolveVariables(debugConfig.program as string));
 		const debugType = isFlutter
 			? (isTest ? DebuggerType.FlutterTest : DebuggerType.Flutter)

--- a/test/dart_only/debug/dart_cli.test.ts
+++ b/test/dart_only/debug/dart_cli.test.ts
@@ -54,9 +54,9 @@ describe("dart cli debugger", () => {
 			// TODO: Figure out if this is a bug - because we never connect to Observatory, we never
 			// resolve this properly.
 			// dc.configurationSequence(),
-			ensureOutputContains(dc, "stderr", "Unrecognized flags: fake-flag").then((_) => console.log("Got output")),
-			dc.waitForEvent("terminated").then((_) => console.log("Got terminate")),
-			dc.launch(config).then((_) => console.log("launched")),
+			ensureOutputContains(dc, "stderr", "Unrecognized flags: fake-flag"),
+			dc.waitForEvent("terminated"),
+			dc.launch(config),
 		]);
 	});
 

--- a/test/dart_only/debug/dart_cli.test.ts
+++ b/test/dart_only/debug/dart_cli.test.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import * as vs from "vscode";
 import { DebugClient } from "vscode-debugadapter-testsupport";
 import { fsPath } from "../../../src/utils";
-import { ensureMapEntry, ensureOutputContains, ensureVariable, evaluate, getTopFrameVariables, getVariables, spawnProcessPaused } from "../../debug_helpers";
+import { attach, ensureMapEntry, ensureOutputContains, ensureVariable, evaluate, getTopFrameVariables, getVariables, spawnProcessPaused } from "../../debug_helpers";
 import { activate, closeAllOpenFiles, defer, ext, getAttachConfiguration, getLaunchConfiguration, helloWorldBrokenFile, helloWorldFolder, helloWorldGoodbyeFile, helloWorldMainFile, openFile, platformEol, positionOf, sb } from "../../helpers";
 
 describe("dart cli debugger", () => {
@@ -307,7 +307,7 @@ describe("dart cli debugger", () => {
 			await Promise.all([
 				dc.configurationSequence(),
 				dc.waitForEvent("terminated"),
-				dc.attachRequest(config as any),
+				attach(dc, config),
 			]);
 		});
 
@@ -320,7 +320,7 @@ describe("dart cli debugger", () => {
 			await Promise.all([
 				dc.configurationSequence(),
 				dc.waitForEvent("terminated"),
-				dc.launch(config),
+				attach(dc, config),
 			]);
 		});
 
@@ -335,13 +335,14 @@ describe("dart cli debugger", () => {
 			await Promise.all([
 				dc.configurationSequence(),
 				dc.waitForEvent("terminated"),
-				dc.launch(config),
+				attach(dc, config),
 			]);
 
 			assert.ok(showInputBox.calledOnce);
 		});
 
-		it("to a paused Dart script and can set breakpoints", async () => {
+		// NEED TO MAKE ATTACH VERSION
+		it.skip("to a paused Dart script and can set breakpoints", async () => {
 			const process = spawnProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
 			const observatoryUri = await process.observatoryUri;
 
@@ -354,7 +355,8 @@ describe("dart cli debugger", () => {
 			]);
 		});
 
-		it("and removes breakpoints and unpauses on detach", async () => {
+		// NEED TO MAKE ATTACH VERSION
+		it.skip("and removes breakpoints and unpauses on detach", async () => {
 			const process = spawnProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
 			const observatoryUri = await process.observatoryUri;
 

--- a/test/dart_only/debug/dart_cli.test.ts
+++ b/test/dart_only/debug/dart_cli.test.ts
@@ -353,7 +353,22 @@ describe("dart cli debugger", () => {
 				}),
 			]);
 		});
-		it("and removes breakpoints and unpauses on detach");
+
+		it("and removes breakpoints and unpauses on detach", async () => {
+			const process = spawnProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
+			const observatoryUri = await process.observatoryUri;
+
+			const config = await attachDebugger(observatoryUri);
+			await Promise.all([
+				dc.hitBreakpoint(config, {
+					line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
+					path: fsPath(helloWorldMainFile),
+				}).then((_) => dc.disconnectRequest()),
+			]);
+
+			await process.exitCode;
+		});
+
 		it("and reports failure to connect to the Observatory");
 	});
 });

--- a/test/dart_only/debug/dart_cli.test.ts
+++ b/test/dart_only/debug/dart_cli.test.ts
@@ -361,5 +361,6 @@ describe("dart cli debugger", () => {
 			]);
 		});
 		it("and removes breakpoints and unpauses on detach");
+		it("and reports failure to connect to the Observatory");
 	});
 });

--- a/test/dart_only/debug/dart_cli.test.ts
+++ b/test/dart_only/debug/dart_cli.test.ts
@@ -4,7 +4,7 @@ import * as vs from "vscode";
 import { DebugClient } from "vscode-debugadapter-testsupport";
 import { fsPath } from "../../../src/utils";
 import { ensureMapEntry, ensureOutputContains, ensureVariable, evaluate, getObservatoryUriForProcess, getTopFrameVariables, getVariables, spawnProcessPaused } from "../../debug_helpers";
-import { activate, closeAllOpenFiles, defer, ext, helloWorldBrokenFile, helloWorldFolder, helloWorldGoodbyeFile, helloWorldMainFile, openFile, platformEol, positionOf, sb } from "../../helpers";
+import { activate, closeAllOpenFiles, defer, ext, getAttachConfiguration, getLaunchConfiguration, helloWorldBrokenFile, helloWorldFolder, helloWorldGoodbyeFile, helloWorldMainFile, openFile, platformEol, positionOf, sb } from "../../helpers";
 
 describe("dart cli debugger", () => {
 	beforeEach(() => activate(helloWorldMainFile));
@@ -16,41 +16,14 @@ describe("dart cli debugger", () => {
 		defer(() => dc.stop());
 	});
 
-	// TODO: Combine this with the duplicates in other debugger tests (flutter run/flutter test) and
-	// move to helpers.ts
-	async function getLaunchConfig(script: vs.Uri): Promise<vs.DebugConfiguration> {
-		return await ext.exports.debugProvider.resolveDebugConfiguration(
-			vs.workspace.workspaceFolders[0],
-			{
-				name: "Dart & Flutter",
-				program: script && fsPath(script),
-				request: "launch",
-				type: "dart",
-			},
-		);
-	}
-
-	// TODO: move to helpers.ts
-	async function getAttachConfig(observatoryUri: string): Promise<vs.DebugConfiguration> {
-		return await ext.exports.debugProvider.resolveDebugConfiguration(
-			vs.workspace.workspaceFolders[0],
-			{
-				name: "Dart & Flutter",
-				observatoryUri,
-				request: "attach",
-				type: "dart",
-			},
-		);
-	}
-
 	async function startDebugger(script: vs.Uri): Promise<vs.DebugConfiguration> {
-		const config = await getLaunchConfig(script);
+		const config = await getLaunchConfiguration(script);
 		await dc.start(config.debugServer);
 		return config;
 	}
 
 	async function attachDebugger(observatoryUri: string): Promise<vs.DebugConfiguration> {
-		const config = await getAttachConfig(observatoryUri);
+		const config = await getAttachConfiguration(observatoryUri);
 		await dc.start(config.debugServer);
 		return config;
 	}
@@ -327,7 +300,7 @@ describe("dart cli debugger", () => {
 
 	describe("attaches", () => {
 		it("to a paused Dart script and can unpause to run it to completion", async () => {
-			const process = spawnProcessPaused(await getLaunchConfig(helloWorldMainFile));
+			const process = spawnProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
 			defer(() => process && !process.killed && process.kill());
 
 			const observatoryUri = await getObservatoryUriForProcess(process);
@@ -341,7 +314,7 @@ describe("dart cli debugger", () => {
 		});
 
 		it("when provided only a port in launch.config", async () => {
-			const process = spawnProcessPaused(await getLaunchConfig(helloWorldMainFile));
+			const process = spawnProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
 			defer(() => process && !process.killed && process.kill());
 
 			const observatoryUri = await getObservatoryUriForProcess(process);
@@ -356,7 +329,7 @@ describe("dart cli debugger", () => {
 		});
 
 		it("to the observatory uri provided by the user when not specified in launch.json", async () => {
-			const process = spawnProcessPaused(await getLaunchConfig(helloWorldMainFile));
+			const process = spawnProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
 			defer(() => process && !process.killed && process.kill());
 
 			const observatoryUri = await getObservatoryUriForProcess(process);
@@ -374,7 +347,7 @@ describe("dart cli debugger", () => {
 		});
 
 		it("to a paused Dart script and can set breakpoints", async () => {
-			const process = spawnProcessPaused(await getLaunchConfig(helloWorldMainFile));
+			const process = spawnProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
 			defer(() => process && !process.killed && process.kill());
 
 			const observatoryUri = await getObservatoryUriForProcess(process);

--- a/test/dart_only/debug/dart_cli.test.ts
+++ b/test/dart_only/debug/dart_cli.test.ts
@@ -1,17 +1,17 @@
 import * as assert from "assert";
 import * as path from "path";
 import * as vs from "vscode";
-import { DebugClient } from "vscode-debugadapter-testsupport";
 import { fsPath } from "../../../src/utils";
+import { DartDebugClient } from "../../debug_client";
 import { attach, ensureMapEntry, ensureOutputContains, ensureVariable, evaluate, getTopFrameVariables, getVariables, spawnProcessPaused } from "../../debug_helpers";
 import { activate, closeAllOpenFiles, defer, ext, getAttachConfiguration, getLaunchConfiguration, helloWorldBrokenFile, helloWorldFolder, helloWorldGoodbyeFile, helloWorldMainFile, openFile, platformEol, positionOf, sb } from "../../helpers";
 
 describe("dart cli debugger", () => {
 	beforeEach(() => activate(helloWorldMainFile));
 
-	let dc: DebugClient;
+	let dc: DartDebugClient;
 	beforeEach(() => {
-		dc = new DebugClient(process.execPath, path.join(ext.extensionPath, "out/src/debug/dart_debug_entry.js"), "dart");
+		dc = new DartDebugClient(process.execPath, path.join(ext.extensionPath, "out/src/debug/dart_debug_entry.js"), "dart");
 		dc.defaultTimeout = 30000;
 		defer(() => dc.stop());
 	});

--- a/test/dart_only/debug/dart_cli.test.ts
+++ b/test/dart_only/debug/dart_cli.test.ts
@@ -316,7 +316,8 @@ describe("dart cli debugger", () => {
 			const observatoryUri = await process.observatoryUri;
 			const observatoryPort = /:([0-9]+)\/?$/.exec(observatoryUri)[1];
 
-			const config = await attachDebugger(observatoryUri);
+			// Include whitespace as a test for trimming.
+			const config = await attachDebugger(` ${observatoryPort} `);
 			await Promise.all([
 				dc.configurationSequence(),
 				dc.waitForEvent("terminated"),

--- a/test/dart_only/debug/dart_cli.test.ts
+++ b/test/dart_only/debug/dart_cli.test.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import * as vs from "vscode";
 import { fsPath } from "../../../src/utils";
 import { DartDebugClient } from "../../debug_client";
-import { attach, ensureMapEntry, ensureOutputContains, ensureVariable, evaluate, getTopFrameVariables, getVariables, spawnProcessPaused } from "../../debug_helpers";
+import { ensureMapEntry, ensureOutputContains, ensureVariable, evaluate, getTopFrameVariables, getVariables, spawnProcessPaused } from "../../debug_helpers";
 import { activate, closeAllOpenFiles, defer, ext, getAttachConfiguration, getLaunchConfiguration, helloWorldBrokenFile, helloWorldFolder, helloWorldGoodbyeFile, helloWorldMainFile, openFile, platformEol, positionOf, sb } from "../../helpers";
 
 describe("dart cli debugger", () => {
@@ -307,7 +307,7 @@ describe("dart cli debugger", () => {
 			await Promise.all([
 				dc.configurationSequence(),
 				dc.waitForEvent("terminated"),
-				attach(dc, config),
+				dc.launch(config),
 			]);
 		});
 
@@ -320,7 +320,7 @@ describe("dart cli debugger", () => {
 			await Promise.all([
 				dc.configurationSequence(),
 				dc.waitForEvent("terminated"),
-				attach(dc, config),
+				dc.launch(config),
 			]);
 		});
 
@@ -335,14 +335,13 @@ describe("dart cli debugger", () => {
 			await Promise.all([
 				dc.configurationSequence(),
 				dc.waitForEvent("terminated"),
-				attach(dc, config),
+				dc.launch(config),
 			]);
 
 			assert.ok(showInputBox.calledOnce);
 		});
 
-		// NEED TO MAKE ATTACH VERSION
-		it.skip("to a paused Dart script and can set breakpoints", async () => {
+		it("to a paused Dart script and can set breakpoints", async () => {
 			const process = spawnProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
 			const observatoryUri = await process.observatoryUri;
 
@@ -355,8 +354,7 @@ describe("dart cli debugger", () => {
 			]);
 		});
 
-		// NEED TO MAKE ATTACH VERSION
-		it.skip("and removes breakpoints and unpauses on detach", async () => {
+		it("and removes breakpoints and unpauses on detach", async () => {
 			const process = spawnProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
 			const observatoryUri = await process.observatoryUri;
 

--- a/test/dart_only/debug/dart_cli.test.ts
+++ b/test/dart_only/debug/dart_cli.test.ts
@@ -364,9 +364,14 @@ describe("dart cli debugger", () => {
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
 					path: fsPath(helloWorldMainFile),
-				}).then((_) => dc.disconnectRequest()),
+				}).then(async (_) => {
+					console.log("Disconnecting...");
+					await dc.disconnectRequest();
+					console.log("Disconnected!");
+				}),
 			]);
 
+			console.log("Waiting for process to terminate...");
 			await process.exitCode;
 		});
 

--- a/test/debug_client.ts
+++ b/test/debug_client.ts
@@ -2,9 +2,18 @@ import { DebugProtocol } from "vscode-debugprotocol";
 import { DebugClient } from "./debug_client_ms";
 
 export class DartDebugClient extends DebugClient {
-	public launch(launchArgs: any): Promise<DebugProtocol.LaunchResponse> {
-		if (launchArgs.request === "attach")
-			throw new Error("Cannot call launch with an attach config");
-		return super.launch(launchArgs);
+	public async launch(launchArgs: any): Promise<DebugProtocol.LaunchResponse> {
+		// We override the base method to swap for attachRequest when required, so that
+		// all the existing methods that provide useful functionality but assume launching
+		// (for ex. hitBreakpoint) can be used in attach tests.
+		const response = await this.initializeRequest();
+		if (response.body && response.body.supportsConfigurationDoneRequest) {
+			this._supportsConfigurationDoneRequest = true;
+		}
+		if (launchArgs.request === "attach") {
+			return this.attachRequest(launchArgs);
+		} else {
+			return this.launchRequest(launchArgs);
+		}
 	}
 }

--- a/test/debug_client.ts
+++ b/test/debug_client.ts
@@ -1,4 +1,10 @@
+import { DebugProtocol } from "vscode-debugprotocol";
 import { DebugClient } from "./debug_client_ms";
 
 export class DartDebugClient extends DebugClient {
+	public launch(launchArgs: any): Promise<DebugProtocol.LaunchResponse> {
+		if (launchArgs.request === "attach")
+			throw new Error("Cannot call launch with an attach config");
+		return super.launch(launchArgs);
+	}
 }

--- a/test/debug_client.ts
+++ b/test/debug_client.ts
@@ -1,8 +1,9 @@
+import * as assert from "assert";
 import { DebugProtocol } from "vscode-debugprotocol";
 import { DebugClient } from "./debug_client_ms";
 
 export class DartDebugClient extends DebugClient {
-	public async launch(launchArgs: any): Promise<DebugProtocol.LaunchResponse> {
+	public async launch(launchArgs: any): Promise<void> {
 		// We override the base method to swap for attachRequest when required, so that
 		// all the existing methods that provide useful functionality but assume launching
 		// (for ex. hitBreakpoint) can be used in attach tests.
@@ -11,9 +12,19 @@ export class DartDebugClient extends DebugClient {
 			this._supportsConfigurationDoneRequest = true;
 		}
 		if (launchArgs.request === "attach") {
-			return this.attachRequest(launchArgs);
+			// Attach will be paused by default and issue a step when we connect; but our tests
+			// generally assume we will automatically resume.
+			await this.attachRequest(launchArgs);
+			await this.waitForEvent("stopped");
+			await this.resume();
 		} else {
-			return this.launchRequest(launchArgs);
+			await this.launchRequest(launchArgs);
 		}
+	}
+
+	public async resume(): Promise<DebugProtocol.ContinueResponse> {
+		const threads = await this.threadsRequest();
+		assert.equal(threads.body.threads.length, 1);
+		return this.continueRequest({ threadId: threads.body.threads[0].id });
 	}
 }

--- a/test/debug_client.ts
+++ b/test/debug_client.ts
@@ -1,0 +1,4 @@
+import { DebugClient } from "./debug_client_ms";
+
+export class DartDebugClient extends DebugClient {
+}

--- a/test/debug_client_ms.ts
+++ b/test/debug_client_ms.ts
@@ -320,14 +320,14 @@ export class DebugClient extends ProtocolClient {
 	/**
 	 * Returns a promise that will resolve if a 'initialize' and a 'launch' request were successful.
 	 */
-	public launch(launchArgs: any): Promise<DebugProtocol.LaunchResponse> {
+	public launch(launchArgs: any): Promise<void> {
 
 		return this.initializeRequest().then(response => {
 			if (response.body && response.body.supportsConfigurationDoneRequest) {
 				this._supportsConfigurationDoneRequest = true;
 			}
 			return this.launchRequest(launchArgs);
-		});
+		}).then((_) => { });
 	}
 
 	private configurationDone(): Promise<DebugProtocol.Response> {

--- a/test/debug_client_ms.ts
+++ b/test/debug_client_ms.ts
@@ -45,7 +45,7 @@ export class DebugClient extends ProtocolClient {
 	private _debugType: string;
 	private _socket: net.Socket;
 
-	private _supportsConfigurationDoneRequest: boolean;
+	protected _supportsConfigurationDoneRequest: boolean;
 
 	public defaultTimeout = 5000;
 

--- a/test/debug_client_ms.ts
+++ b/test/debug_client_ms.ts
@@ -1,0 +1,469 @@
+// This is a copy of MS's DebugClient with minimal changes made to aid extending. debug_client.ts includes
+// a subclass to provide most additional functionality to keep it easy to update this as MS update theirs.
+//
+// Original source:
+// https://raw.githubusercontent.com/Microsoft/vscode-debugadapter-node/master/testSupport/src/debugClient.ts
+
+/* tslint:disable */
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import fs = require('fs');
+import constants = require('constants');
+import cp = require('child_process');
+import assert = require('assert');
+import net = require('net');
+import { ProtocolClient } from 'vscode-debugadapter-testsupport/lib/protocolClient';
+import { DebugProtocol } from 'vscode-debugprotocol';
+
+export interface ILocation {
+	path: string;
+	line: number;
+	column?: number;
+	verified?: boolean;
+}
+
+export interface IPartialLocation {
+	path?: string;
+	line?: number;
+	column?: number;
+	verified?: boolean;
+}
+
+export class DebugClient extends ProtocolClient {
+
+	private static CASE_INSENSITIVE_FILESYSTEM: boolean;
+
+	private _runtime: string;
+	private _executable: string;
+	private _adapterProcess: cp.ChildProcess;
+	private _spawnOptions: cp.SpawnOptions;
+	private _enableStderr: boolean;
+	private _debugType: string;
+	private _socket: net.Socket;
+
+	private _supportsConfigurationDoneRequest: boolean;
+
+	public defaultTimeout = 5000;
+
+	/**
+	 * Creates a DebugClient object that provides a promise-based API to write
+	 * debug adapter tests.
+	 * A simple mocha example for setting and hitting a breakpoint in line 15 of a program 'test.js' looks like this:
+	 *
+	 * var dc;
+	 * setup( () => {
+	 *     dc = new DebugClient('node', './out/node/nodeDebug.js', 'node');
+	 *     return dc.start();
+	 * });
+	 * teardown( () => dc.stop() );
+	 *
+	 * test('should stop on a breakpoint', () => {
+	 *     return dc.hitBreakpoint({ program: 'test.js' }, 'test.js', 15);
+	 * });
+	 */
+	constructor(runtime: string, executable: string, debugType: string, spwanOptions?: cp.SpawnOptions) {
+		super();
+		this._runtime = runtime;
+		this._executable = executable;
+		this._spawnOptions = spwanOptions;
+		this._enableStderr = false;
+		this._debugType = debugType;
+		this._supportsConfigurationDoneRequest = false;
+
+		if (DebugClient.CASE_INSENSITIVE_FILESYSTEM === undefined) {
+			try {
+				fs.accessSync(process.execPath.toLowerCase(), constants.F_OK);
+				fs.accessSync(process.execPath.toUpperCase(), constants.F_OK);
+				DebugClient.CASE_INSENSITIVE_FILESYSTEM = true;
+			} catch (err) {
+				DebugClient.CASE_INSENSITIVE_FILESYSTEM = false;
+			}
+		}
+	}
+
+	// ---- life cycle --------------------------------------------------------------------------------------------------------
+
+	/**
+	 * Starts a new debug adapter and sets up communication via stdin/stdout.
+	 * If a port number is specified the adapter is not launched but a connection to
+	 * a debug adapter running in server mode is established. This is useful for debugging
+	 * the adapter while running tests. For this reason all timeouts are disabled in server mode.
+	 */
+	public start(port?: number): Promise<void> {
+
+		return new Promise<void>((resolve, reject) => {
+			if (typeof port === 'number') {
+				this._socket = net.createConnection(port, '127.0.0.1', () => {
+					this.connect(this._socket, this._socket);
+					resolve();
+				});
+			} else {
+				this._adapterProcess = cp.spawn(this._runtime, [this._executable], this._spawnOptions);
+				const sanitize = (s: string) => s.toString().replace(/\r?\n$/mg, '');
+				this._adapterProcess.stderr.on('data', (data: string) => {
+					if (this._enableStderr) {
+						console.log(sanitize(data));
+					}
+				});
+
+				this._adapterProcess.on('error', (err) => {
+					console.log(err);
+					reject(err);
+				});
+				this._adapterProcess.on('exit', (code: number, signal: string) => {
+					if (code) {
+						// done(new Error('debug adapter exit code: ' + code));
+					}
+				});
+
+				this.connect(this._adapterProcess.stdout, this._adapterProcess.stdin);
+				resolve();
+			}
+		});
+	}
+
+	/**
+	 * Shutdown the debuggee and the debug adapter (or disconnect if in server mode).
+	 */
+	public stop(): Promise<void> {
+
+		return this.disconnectRequest().then(() => {
+			this.stopAdapter();
+		}).catch(() => {
+			this.stopAdapter();
+		});
+	}
+
+	private stopAdapter() {
+		if (this._adapterProcess) {
+			this._adapterProcess.kill();
+			this._adapterProcess = null;
+		}
+		if (this._socket) {
+			this._socket.end();
+			this._socket = null;
+		}
+	}
+
+	// ---- protocol requests -------------------------------------------------------------------------------------------------
+
+	public initializeRequest(args?: DebugProtocol.InitializeRequestArguments): Promise<DebugProtocol.InitializeResponse> {
+		if (!args) {
+			args = {
+				adapterID: this._debugType,
+				linesStartAt1: true,
+				columnsStartAt1: true,
+				pathFormat: 'path'
+			};
+		}
+		return this.send('initialize', args);
+	}
+
+	public configurationDoneRequest(args?: DebugProtocol.ConfigurationDoneArguments): Promise<DebugProtocol.ConfigurationDoneResponse> {
+		return this.send('configurationDone', args);
+	}
+
+	public launchRequest(args: DebugProtocol.LaunchRequestArguments): Promise<DebugProtocol.LaunchResponse> {
+		return this.send('launch', args);
+	}
+
+	public attachRequest(args: DebugProtocol.AttachRequestArguments): Promise<DebugProtocol.AttachResponse> {
+		return this.send('attach', args);
+	}
+
+	public restartRequest(args: DebugProtocol.RestartArguments): Promise<DebugProtocol.RestartResponse> {
+		return this.send('restart', args);
+	}
+
+	public disconnectRequest(args?: DebugProtocol.DisconnectArguments): Promise<DebugProtocol.DisconnectResponse> {
+		return this.send('disconnect', args);
+	}
+
+	public setBreakpointsRequest(args: DebugProtocol.SetBreakpointsArguments): Promise<DebugProtocol.SetBreakpointsResponse> {
+		return this.send('setBreakpoints', args);
+	}
+
+	public setFunctionBreakpointsRequest(args: DebugProtocol.SetFunctionBreakpointsArguments): Promise<DebugProtocol.SetFunctionBreakpointsResponse> {
+		return this.send('setFunctionBreakpoints', args);
+	}
+
+	public setExceptionBreakpointsRequest(args: DebugProtocol.SetExceptionBreakpointsArguments): Promise<DebugProtocol.SetExceptionBreakpointsResponse> {
+		return this.send('setExceptionBreakpoints', args);
+	}
+
+	public continueRequest(args: DebugProtocol.ContinueArguments): Promise<DebugProtocol.ContinueResponse> {
+		return this.send('continue', args);
+	}
+
+	public nextRequest(args: DebugProtocol.NextArguments): Promise<DebugProtocol.NextResponse> {
+		return this.send('next', args);
+	}
+
+	public stepInRequest(args: DebugProtocol.StepInArguments): Promise<DebugProtocol.StepInResponse> {
+		return this.send('stepIn', args);
+	}
+
+	public stepOutRequest(args: DebugProtocol.StepOutArguments): Promise<DebugProtocol.StepOutResponse> {
+		return this.send('stepOut', args);
+	}
+
+	public stepBackRequest(args: DebugProtocol.StepBackArguments): Promise<DebugProtocol.StepBackResponse> {
+		return this.send('stepBack', args);
+	}
+
+	public reverseContinueRequest(args: DebugProtocol.ReverseContinueArguments): Promise<DebugProtocol.ReverseContinueResponse> {
+		return this.send('reverseContinue', args);
+	}
+
+	public restartFrameRequest(args: DebugProtocol.RestartFrameArguments): Promise<DebugProtocol.RestartFrameResponse> {
+		return this.send('restartFrame', args);
+	}
+
+	public gotoRequest(args: DebugProtocol.GotoArguments): Promise<DebugProtocol.GotoResponse> {
+		return this.send('goto', args);
+	}
+
+	public pauseRequest(args: DebugProtocol.PauseArguments): Promise<DebugProtocol.PauseResponse> {
+		return this.send('pause', args);
+	}
+
+	public stackTraceRequest(args: DebugProtocol.StackTraceArguments): Promise<DebugProtocol.StackTraceResponse> {
+		return this.send('stackTrace', args);
+	}
+
+	public scopesRequest(args: DebugProtocol.ScopesArguments): Promise<DebugProtocol.ScopesResponse> {
+		return this.send('scopes', args);
+	}
+
+	public variablesRequest(args: DebugProtocol.VariablesArguments): Promise<DebugProtocol.VariablesResponse> {
+		return this.send('variables', args);
+	}
+
+	public setVariableRequest(args: DebugProtocol.SetVariableArguments): Promise<DebugProtocol.SetVariableResponse> {
+		return this.send('setVariable', args);
+	}
+
+	public sourceRequest(args: DebugProtocol.SourceArguments): Promise<DebugProtocol.SourceResponse> {
+		return this.send('source', args);
+	}
+
+	public threadsRequest(): Promise<DebugProtocol.ThreadsResponse> {
+		return this.send('threads');
+	}
+
+	public modulesRequest(args: DebugProtocol.ModulesArguments): Promise<DebugProtocol.ModulesResponse> {
+		return this.send('modules');
+	}
+
+	public evaluateRequest(args: DebugProtocol.EvaluateArguments): Promise<DebugProtocol.EvaluateResponse> {
+		return this.send('evaluate', args);
+	}
+
+	public stepInTargetsRequest(args: DebugProtocol.StepInTargetsArguments): Promise<DebugProtocol.StepInTargetsResponse> {
+		return this.send('stepInTargets', args);
+	}
+
+	public gotoTargetsRequest(args: DebugProtocol.GotoTargetsArguments): Promise<DebugProtocol.GotoTargetsResponse> {
+		return this.send('gotoTargets', args);
+	}
+
+	public completionsRequest(args: DebugProtocol.CompletionsArguments): Promise<DebugProtocol.CompletionsResponse> {
+		return this.send('completions', args);
+	}
+
+	public exceptionInfoRequest(args: DebugProtocol.ExceptionInfoArguments): Promise<DebugProtocol.ExceptionInfoResponse> {
+		return this.send('exceptionInfo', args);
+	}
+
+	public customRequest(command: string, args?: any): Promise<DebugProtocol.Response> {
+		return this.send(command, args);
+	}
+
+	// ---- convenience methods -----------------------------------------------------------------------------------------------
+
+	/*
+	 * Returns a promise that will resolve if an event with a specific type was received within some specified time.
+	 * The promise will be rejected if a timeout occurs.
+	 */
+	public waitForEvent(eventType: string, timeout?: number): Promise<DebugProtocol.Event> {
+
+		timeout = timeout || this.defaultTimeout;
+
+		return new Promise((resolve, reject) => {
+			this.once(eventType, event => {
+				resolve(event);
+			});
+			if (!this._socket) {	// no timeouts if debugging the tests
+				setTimeout(() => {
+					reject(new Error(`no event '${eventType}' received after ${timeout} ms`));
+				}, timeout);
+			}
+		});
+	}
+
+	/*
+	 * Returns a promise that will resolve if an 'initialized' event was received within some specified time
+	 * and a subsequent 'configurationDone' request was successfully executed.
+	 * The promise will be rejected if a timeout occurs or if the 'configurationDone' request fails.
+	 */
+	public configurationSequence(): Promise<any> {
+
+		return this.waitForEvent('initialized').then(event => {
+			return this.configurationDone();
+		});
+	}
+
+	/**
+	 * Returns a promise that will resolve if a 'initialize' and a 'launch' request were successful.
+	 */
+	public launch(launchArgs: any): Promise<DebugProtocol.LaunchResponse> {
+
+		return this.initializeRequest().then(response => {
+			if (response.body && response.body.supportsConfigurationDoneRequest) {
+				this._supportsConfigurationDoneRequest = true;
+			}
+			return this.launchRequest(launchArgs);
+		});
+	}
+
+	private configurationDone(): Promise<DebugProtocol.Response> {
+		if (this._supportsConfigurationDoneRequest) {
+			return this.configurationDoneRequest();
+		} else {
+			// if debug adapter doesn't support the configurationDoneRequest we have to send the setExceptionBreakpointsRequest.
+			return this.setExceptionBreakpointsRequest({ filters: ['all'] });
+		}
+	}
+
+	/*
+	 * Returns a promise that will resolve if a 'stopped' event was received within some specified time
+	 * and the event's reason and line number was asserted.
+	 * The promise will be rejected if a timeout occurs, the assertions fail, or if the 'stackTrace' request fails.
+	 */
+	public assertStoppedLocation(reason: string, expected: { path?: string | RegExp, line?: number, column?: number }): Promise<DebugProtocol.StackTraceResponse> {
+
+		return this.waitForEvent('stopped').then(event => {
+			assert.equal(event.body.reason, reason);
+			return this.stackTraceRequest({
+				threadId: event.body.threadId
+			});
+		}).then(response => {
+			const frame = response.body.stackFrames[0];
+			if (typeof expected.path === 'string' || expected.path instanceof RegExp) {
+				this.assertPath(frame.source.path, expected.path, 'stopped location: path mismatch');
+			}
+			if (typeof expected.line === 'number') {
+				assert.equal(frame.line, expected.line, 'stopped location: line mismatch');
+			}
+			if (typeof expected.column === 'number') {
+				assert.equal(frame.column, expected.column, 'stopped location: column mismatch');
+			}
+			return response;
+		});
+	}
+
+	private assertPartialLocationsEqual(locA: IPartialLocation, locB: IPartialLocation): void {
+		if (locA.path) {
+			this.assertPath(locA.path, locB.path, 'breakpoint verification mismatch: path');
+		}
+		if (typeof locA.line === 'number') {
+			assert.equal(locA.line, locB.line, 'breakpoint verification mismatch: line');
+		}
+		if (typeof locB.column === 'number' && typeof locA.column === 'number') {
+			assert.equal(locA.column, locB.column, 'breakpoint verification mismatch: column');
+		}
+	}
+
+	/*
+	 * Returns a promise that will resolve if enough output events with the given category have been received
+	 * and the concatenated data match the expected data.
+	 * The promise will be rejected as soon as the received data cannot match the expected data or if a timeout occurs.
+	 */
+	public assertOutput(category: string, expected: string, timeout?: number): Promise<DebugProtocol.Event> {
+
+		timeout = timeout || this.defaultTimeout;
+
+		return new Promise((resolve, reject) => {
+			let output = '';
+			this.on('output', event => {
+				const e = <DebugProtocol.OutputEvent>event;
+				if (e.body.category === category) {
+					output += e.body.output;
+					if (output.indexOf(expected) === 0) {
+						resolve(event);
+					} else if (expected.indexOf(output) !== 0) {
+						const sanitize = (s: string) => s.toString().replace(/\r/mg, '\\r').replace(/\n/mg, '\\n');
+						reject(new Error(`received data '${sanitize(output)}' is not a prefix of the expected data '${sanitize(expected)}'`));
+					}
+				}
+			});
+			if (!this._socket) {	// no timeouts if debugging the tests
+				setTimeout(() => {
+					reject(new Error(`not enough output data received after ${timeout} ms`));
+				}, timeout);
+			}
+		});
+	}
+
+	public assertPath(path: string, expected: string | RegExp, message?: string) {
+
+		if (expected instanceof RegExp) {
+			assert.ok((<RegExp>expected).test(path), message);
+		} else {
+			if (DebugClient.CASE_INSENSITIVE_FILESYSTEM) {
+				if (typeof path === 'string') {
+					path = path.toLowerCase();
+				}
+				if (typeof expected === 'string') {
+					expected = (<string>expected).toLowerCase();
+				}
+			}
+			assert.equal(path, expected, message);
+		}
+	}
+
+	// ---- scenarios ---------------------------------------------------------------------------------------------------------
+
+	/**
+	 * Returns a promise that will resolve if a configurable breakpoint has been hit within some time
+	 * and the event's reason and line number was asserted.
+	 * The promise will be rejected if a timeout occurs, the assertions fail, or if the requests fails.
+	 */
+	public hitBreakpoint(launchArgs: any, location: ILocation, expectedStopLocation?: IPartialLocation, expectedBPLocation?: IPartialLocation): Promise<any> {
+
+		return Promise.all([
+
+			this.waitForEvent('initialized').then(event => {
+				return this.setBreakpointsRequest({
+					lines: [location.line],
+					breakpoints: [{ line: location.line, column: location.column }],
+					source: { path: location.path }
+				});
+			}).then(response => {
+
+				const bp = response.body.breakpoints[0];
+
+				const verified = (typeof location.verified === 'boolean') ? location.verified : true;
+				assert.equal(bp.verified, verified, 'breakpoint verification mismatch: verified');
+
+				const actualLocation: ILocation = {
+					column: bp.column,
+					line: bp.line,
+					path: bp.source && bp.source.path
+				};
+				this.assertPartialLocationsEqual(actualLocation, expectedBPLocation || location);
+
+				return this.configurationDone();
+			}),
+
+			this.launch(launchArgs),
+
+			this.assertStoppedLocation('breakpoint', expectedStopLocation || location)
+
+		]);
+	}
+}

--- a/test/debug_client_ms.ts
+++ b/test/debug_client_ms.ts
@@ -294,7 +294,7 @@ export class DebugClient extends ProtocolClient {
 		timeout = timeout || this.defaultTimeout;
 
 		return new Promise((resolve, reject) => {
-			this.once(eventType, event => {
+			this.once(eventType, (event: any) => {
 				resolve(event);
 			});
 			if (!this._socket) {	// no timeouts if debugging the tests
@@ -389,7 +389,7 @@ export class DebugClient extends ProtocolClient {
 
 		return new Promise((resolve, reject) => {
 			let output = '';
-			this.on('output', event => {
+			this.on('output', (event: any) => {
 				const e = <DebugProtocol.OutputEvent>event;
 				if (e.body.category === category) {
 					output += e.body.output;

--- a/test/debug_client_ms.ts
+++ b/test/debug_client_ms.ts
@@ -460,10 +460,7 @@ export class DebugClient extends ProtocolClient {
 				return this.configurationDone();
 			}),
 
-			this.launch(launchArgs),
-
-			this.assertStoppedLocation('breakpoint', expectedStopLocation || location)
-
+			this.launch(launchArgs).then((_) => this.assertStoppedLocation('breakpoint', expectedStopLocation || location))
 		]);
 	}
 }

--- a/test/debug_helpers.ts
+++ b/test/debug_helpers.ts
@@ -37,12 +37,6 @@ export async function evaluate(dc: DartDebugClient, expression: string): Promise
 	return result.body;
 }
 
-export async function attach(dc: DartDebugClient, config: any): Promise<void> {
-	await dc.initializeRequest();
-	await dc.configurationDoneRequest();
-	await dc.attachRequest(config);
-}
-
 export function ensureVariable(variables: DebugProtocol.Variable[], evaluateName: string, name: string, value: string) {
 	assert.ok(variables);
 	const v = variables.find((v) => v.name === name);

--- a/test/debug_helpers.ts
+++ b/test/debug_helpers.ts
@@ -37,6 +37,12 @@ export async function evaluate(dc: DebugClient, expression: string): Promise<{
 	return result.body;
 }
 
+export async function attach(dc: DebugClient, config: any): Promise<void> {
+	await dc.initializeRequest();
+	await dc.configurationDoneRequest();
+	await dc.attachRequest(config);
+}
+
 export function ensureVariable(variables: DebugProtocol.Variable[], evaluateName: string, name: string, value: string) {
 	assert.ok(variables);
 	const v = variables.find((v) => v.name === name);
@@ -98,7 +104,7 @@ export function spawnProcessPaused(config: DebugConfiguration): DartProcess {
 		config.dartPath,
 		[
 			"--enable-vm-service=0",
-			"-pause_isolates_on_start=true",
+			"--pause_isolates_on_start=true",
 			config.program,
 		],
 	);

--- a/test/flutter_only/debug/flutter_run.test.ts
+++ b/test/flutter_only/debug/flutter_run.test.ts
@@ -4,7 +4,7 @@ import { DebugClient } from "vscode-debugadapter-testsupport";
 import { DebugProtocol } from "vscode-debugprotocol";
 import { fsPath } from "../../../src/utils";
 import { ensureVariable, getTopFrameVariables } from "../../debug_helpers";
-import { activate, defer, delay, ext, flutterHelloWorldBrokenFile, flutterHelloWorldFolder, flutterHelloWorldMainFile, openFile, positionOf } from "../../helpers";
+import { activate, defer, delay, ext, flutterHelloWorldBrokenFile, flutterHelloWorldFolder, flutterHelloWorldMainFile, getLaunchConfiguration, openFile, positionOf } from "../../helpers";
 
 describe("flutter run debugger", () => {
 	beforeEach(function () {
@@ -35,20 +35,8 @@ describe("flutter run debugger", () => {
 		this.timeout(60000); // These tests can be slow due to flutter package fetches when running.
 	});
 
-	// TODO: This is duplicated in three places now (except deviceId).
 	async function startDebugger(script: vs.Uri | string, cwd?: string, throwOnError = true): Promise<vs.DebugConfiguration> {
-		if (script instanceof vs.Uri)
-			script = fsPath(script);
-		const config = await ext.exports.debugProvider.resolveDebugConfiguration(
-			vs.workspace.workspaceFolders[0],
-			{
-				cwd,
-				name: "Dart & Flutter",
-				program: script,
-				request: "launch",
-				type: "dart",
-			},
-		);
+		const config = await getLaunchConfiguration(script, { deviceId: "flutter-tester" });
 		await dc.start(config.debugServer);
 
 		// Throw to fail tests if we get any error output to aid debugging.

--- a/test/flutter_only/debug/flutter_run.test.ts
+++ b/test/flutter_only/debug/flutter_run.test.ts
@@ -1,8 +1,8 @@
 import * as path from "path";
 import * as vs from "vscode";
-import { DebugClient } from "vscode-debugadapter-testsupport";
 import { DebugProtocol } from "vscode-debugprotocol";
 import { fsPath } from "../../../src/utils";
+import { DartDebugClient } from "../../debug_client";
 import { ensureVariable, getTopFrameVariables } from "../../debug_helpers";
 import { activate, defer, delay, ext, flutterHelloWorldBrokenFile, flutterHelloWorldFolder, flutterHelloWorldMainFile, getLaunchConfiguration, openFile, positionOf } from "../../helpers";
 
@@ -22,9 +22,9 @@ describe("flutter run debugger", () => {
 
 	beforeEach(() => activate(flutterHelloWorldMainFile));
 
-	let dc: DebugClient;
+	let dc: DartDebugClient;
 	beforeEach(() => {
-		dc = new DebugClient(process.execPath, path.join(ext.extensionPath, "out/src/debug/flutter_debug_entry.js"), "dart");
+		dc = new DartDebugClient(process.execPath, path.join(ext.extensionPath, "out/src/debug/flutter_debug_entry.js"), "dart");
 		// Spawning flutter tests seem to be kinda slow (and may fetch packages), so we need a higher timeout
 		dc.defaultTimeout = 60000;
 		defer(() => dc.stop());

--- a/test/flutter_only/debug/flutter_test.test.ts
+++ b/test/flutter_only/debug/flutter_test.test.ts
@@ -1,9 +1,9 @@
 import * as assert from "assert";
 import * as path from "path";
 import * as vs from "vscode";
-import { DebugClient } from "vscode-debugadapter-testsupport";
 import { DebugProtocol } from "vscode-debugprotocol";
 import { fsPath } from "../../../src/utils";
+import { DartDebugClient } from "../../debug_client";
 import { getTopFrameVariables } from "../../debug_helpers";
 import { activate, defer, ext, flutterHelloWorldFolder, flutterTestBrokenFile, flutterTestMainFile, flutterTestOtherFile, getLaunchConfiguration, openFile, positionOf } from "../../helpers";
 
@@ -13,9 +13,9 @@ describe("flutter test debugger", () => {
 		this.timeout(60000); // These tests can be slow due to flutter package fetches when running.
 	});
 
-	let dc: DebugClient;
+	let dc: DartDebugClient;
 	beforeEach(() => {
-		dc = new DebugClient(process.execPath, path.join(ext.extensionPath, "out/src/debug/flutter_test_debug_entry.js"), "dart");
+		dc = new DartDebugClient(process.execPath, path.join(ext.extensionPath, "out/src/debug/flutter_test_debug_entry.js"), "dart");
 		// Spawning flutter tests seem to be kinda slow (and may fetch packages), so we need a higher timeout
 		dc.defaultTimeout = 60000;
 		defer(() => dc.stop());

--- a/test/flutter_only/debug/flutter_test.test.ts
+++ b/test/flutter_only/debug/flutter_test.test.ts
@@ -5,7 +5,7 @@ import { DebugClient } from "vscode-debugadapter-testsupport";
 import { DebugProtocol } from "vscode-debugprotocol";
 import { fsPath } from "../../../src/utils";
 import { getTopFrameVariables } from "../../debug_helpers";
-import { activate, defer, ext, flutterHelloWorldFolder, flutterTestBrokenFile, flutterTestMainFile, flutterTestOtherFile, openFile, positionOf } from "../../helpers";
+import { activate, defer, ext, flutterHelloWorldFolder, flutterTestBrokenFile, flutterTestMainFile, flutterTestOtherFile, getLaunchConfiguration, openFile, positionOf } from "../../helpers";
 
 describe("flutter test debugger", () => {
 	beforeEach(() => activate(flutterTestMainFile));
@@ -22,17 +22,7 @@ describe("flutter test debugger", () => {
 	});
 
 	async function startDebugger(script: vs.Uri | string, throwOnError = true): Promise<vs.DebugConfiguration> {
-		if (script instanceof vs.Uri)
-			script = fsPath(script);
-		const config = await ext.exports.debugProvider.resolveDebugConfiguration(
-			vs.workspace.workspaceFolders[0],
-			{
-				name: "Dart & Flutter",
-				program: script,
-				request: "launch",
-				type: "dart",
-			},
-		);
+		const config = await getLaunchConfiguration(script);
 		await dc.start(config.debugServer);
 
 		// Throw to fail tests if we get any error output to aid debugging.

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -339,3 +339,29 @@ export async function waitForEditorChange(action: () => Thenable<void>): Promise
 export function filenameSafe(input: string) {
 	return input.replace(/[^a-z0-9]+/gi, "_").toLowerCase();
 }
+
+async function getResolvedDebugConfiguration(extraConfiguration?: { [key: string]: any }): Promise<vs.DebugConfiguration> {
+	const debugConfig: vs.DebugConfiguration = Object.assign({}, {
+		name: "Dart & Flutter",
+		request: "launch",
+		type: "dart",
+	}, extraConfiguration);
+	return await ext.exports.debugProvider.resolveDebugConfiguration(vs.workspace.workspaceFolders[0], debugConfig);
+}
+
+export async function getLaunchConfiguration(script: vs.Uri | string, extraConfiguration?: { [key: string]: any }): Promise<vs.DebugConfiguration> {
+	if (script instanceof vs.Uri)
+		script = fsPath(script);
+	const launchConfig = Object.assign({}, {
+		program: script,
+	}, extraConfiguration);
+	return await getResolvedDebugConfiguration(launchConfig);
+}
+
+export async function getAttachConfiguration(observatoryUri: string, extraConfiguration?: { [key: string]: any }): Promise<vs.DebugConfiguration> {
+	const attachConfig = Object.assign({}, {
+		observatoryUri,
+		request: "attach",
+	}, extraConfiguration);
+	return await getResolvedDebugConfiguration(attachConfig);
+}


### PR DESCRIPTION
Some notes from initial test:

- [x] Currently unpauses upon attaching; is this the best option for attach, or should we leave it paused for the user to resume?
- [x] We should default the packages file in code to avoid it needing to be in the config
- [x] We should add a `Dart: Attach to Process` command to eliminate the need for the launch.json config
- [x] If you type junk into the observatory box it gives a bad error (seems to get passed to the WebSocket library)
- [x] The prompt for the observatory uri looks a bit weird (large bold text), should check if we can tweak this
- [x] ~~Can we get the packages info/paths from the VM (@stuartmorgan did you already look at this? I won't bother if you concluded it wasn't possible, but it'd be cool if the open project didn't need to match the exact folder that's open)~~ #896
- [x] Url is handled incorrectly if it already ends with `/ws/` (eg. `http://127.0.0.1:8181/ws/`)
- [x] Support relative path for .packages