### PR TITLE
Attach to dart without declaring a path to the .packages file

### DIFF
--- a/package.json
+++ b/package.json
@@ -691,10 +691,6 @@
 								"type": "string",
 								"description": "Workspace root."
 							},
-							"packages": {
-								"type": "string",
-								"description": "Path to the packages file, if it's not at the workspace root."
-							},
 							"observatoryUri": {
 								"type": "string",
 								"description": "URI (or port) of the Observatory instance to attach to."

--- a/package.json
+++ b/package.json
@@ -691,6 +691,10 @@
 								"type": "string",
 								"description": "Workspace root."
 							},
+							"packages": {
+								"type": "string",
+								"description": "Path to the packages file (only required if cannot be discovered from the running process automatically)."
+							},
 							"observatoryUri": {
 								"type": "string",
 								"description": "URI (or port) of the Observatory instance to attach to."

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,7 +52,7 @@ class Config {
 	get previewDart2() { return this.getConfig<boolean>("previewDart2"); }
 	get previewExperimentalWindowsDriveLetterHandling() { return this.getConfig<boolean>("previewExperimentalWindowsDriveLetterHandling"); }
 
-	public for(uri: Uri): ResourceConfig {
+	public for(uri?: Uri): ResourceConfig {
 		return new ResourceConfig(uri);
 	}
 }

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -19,7 +19,7 @@ export class DartDebugSession extends DebugSession {
 	protected childProcess: child_process.ChildProcess;
 	private processExited: boolean = false;
 	public observatory: ObservatoryConnection;
-	protected cwd: string;
+	protected cwd?: string;
 	private observatoryLogFile: string;
 	private observatoryLogStream: fs.WriteStream;
 	private debugSdkLibraries: boolean;
@@ -916,7 +916,8 @@ export class DartDebugSession extends DebugSession {
 	private convertVMUriToUserName(uri: string): string {
 		if (uri.startsWith("file:")) {
 			uri = uriToFilePath(uri);
-			uri = path.relative(this.cwd, uri);
+			if (this.cwd)
+				uri = path.relative(this.cwd, uri);
 		}
 
 		return uri;

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -114,6 +114,20 @@ export class DartDebugSession extends DebugSession {
 		this.debugExternalLibraries = args.debugExternalLibraries;
 		this.observatoryLogFile = args.observatoryLogFile;
 
+		// If we were given an explicity packages path, use it (otherwise we'll try
+		// to extract from the VM)
+		if (args.packages) {
+			// Support relative paths
+			if (args.packages && !path.isAbsolute(args.packages))
+				args.packages = path.join(args.cwd, args.packages);
+
+			try {
+				this.packageMap = new PackageMap(PackageMap.findPackagesFile(args.packages));
+			} catch (e) {
+				this.errorResponse(response, `Unable to load packages file: ${e}`);
+			}
+		}
+
 		try {
 			await this.initObservatory(this.websocketUriForObservatoryUri(args.observatoryUri));
 			this.sendResponse(response);

--- a/src/debug/dart_debug_protocol.ts
+++ b/src/debug/dart_debug_protocol.ts
@@ -46,14 +46,13 @@ export interface VMIsolateRef extends VMResponse {
 	name: string;
 }
 
-export interface VMIsolate extends VMResponse {
-	id: string;
+export interface VMIsolate extends VMResponse, VMIsolateRef {
 	number: string;
-	name: string;
 	runnable: boolean;
 	pauseEvent: VMEvent;
 	libraries: VMLibraryRef[];
 	_heaps?: { new: VMHeapSpace, old: VMHeapSpace };
+	rootLib?: VMLibraryRef;
 }
 
 export interface VMObjectRef extends VMResponse {

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -89,17 +89,19 @@ export class FlutterDebugSession extends DartDebugSession {
 	 */
 	protected getPossibleSourceUris(sourcePath: string): string[] {
 		const allUris = super.getPossibleSourceUris(sourcePath);
-		const projectUri = formatPathForVm(this.cwd);
+		if (this.cwd) {
+			const projectUri = formatPathForVm(this.cwd);
 
-		// Map any paths over to the device-local paths.
-		allUris.slice().forEach((uri) => {
-			if (uri.startsWith(projectUri)) {
-				const relativePath = uri.substr(projectUri.length);
-				const mappedPath = path.join(this.baseUri, relativePath);
-				const newUri = formatPathForVm(mappedPath);
-				allUris.push(newUri);
-			}
-		});
+			// Map any paths over to the device-local paths.
+			allUris.slice().forEach((uri) => {
+				if (uri.startsWith(projectUri)) {
+					const relativePath = uri.substr(projectUri.length);
+					const mappedPath = path.join(this.baseUri, relativePath);
+					const newUri = formatPathForVm(mappedPath);
+					allUris.push(newUri);
+				}
+			});
+		}
 
 		return allUris;
 	}
@@ -113,7 +115,7 @@ export class FlutterDebugSession extends DartDebugSession {
 
 		// If the path is the baseUri given by flutter, we need to rewrite it into a local path for this machine.
 		const basePath = uriToFilePath(this.baseUri, false);
-		if (localPathLinux.startsWith(basePath))
+		if (localPathLinux.startsWith(basePath) && this.cwd)
 			localPath = path.join(this.cwd, path.relative(basePath, localPathLinux));
 
 		return localPath;

--- a/src/debug/utils.ts
+++ b/src/debug/utils.ts
@@ -132,6 +132,7 @@ export interface DartAttachRequestArguments extends DebugProtocol.AttachRequestA
 	cwd: string;
 	debugSdkLibraries: boolean;
 	debugExternalLibraries: boolean;
+	packages: string;
 	observatoryUri: string;
 	observatoryLogFile: string;
 }

--- a/src/debug/utils.ts
+++ b/src/debug/utils.ts
@@ -132,7 +132,6 @@ export interface DartAttachRequestArguments extends DebugProtocol.AttachRequestA
 	cwd: string;
 	debugSdkLibraries: boolean;
 	debugExternalLibraries: boolean;
-	packages: string;
 	observatoryUri: string;
 	observatoryLogFile: string;
 }


### PR DESCRIPTION
@devoncarew @stuartmorgan I made some changes to the debugger to support finding the `.packages` file from the `rootLib` (to aid attaching) but it's based on the assumption that we'll always get an isolate with a `rootLib` (and that the first one that does, if there are many, is the one we're interested in). Does this sound like a valid assumption?

Another option is we always use the `.packages` from the open folder, but this means if you attach a project you don't have open, weird things might happen.

Assuming this is ok, it might also be a step towards being able to open VS Code and attach to a Dart project (and from there, debug the source) without first opening the folder (however, that'll obviously come with limitations, as you won't have the folder open in explorer, and I don't think we could open it without restarting the debug session).