### PR TITLE
Track paused state so we don't unpause twice at startup

### DIFF
--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -1132,6 +1132,7 @@ class ThreadInfo {
 	public breakpoints: { [key: string]: DebugProtocol.SourceBreakpoint } = {};
 	public atAsyncSuspension: boolean = false;
 	public exceptionReference = 0;
+	public paused: boolean = false;
 
 	constructor(manager: ThreadManager, ref: VMIsolateRef, num: number) {
 		this.manager = manager;
@@ -1181,6 +1182,7 @@ class ThreadInfo {
 
 	public receivedPauseStart() {
 		this.gotPauseStart = true;
+		this.paused = true;
 		this.checkResume();
 	}
 
@@ -1195,8 +1197,8 @@ class ThreadInfo {
 	}
 
 	public checkResume() {
-		if (this.gotPauseStart && this.initialBreakpoints && this.hasConfigurationDone)
-			this.manager.debugSession.observatory.resume(this.ref.id);
+		if (this.paused && this.gotPauseStart && this.initialBreakpoints && this.hasConfigurationDone)
+			this.manager.debugSession.observatory.resume(this.ref.id).then((_) => this.handleResumed());
 	}
 
 	public handleResumed() {
@@ -1205,6 +1207,7 @@ class ThreadInfo {
 		// this.storedIds = [];
 		this.atAsyncSuspension = false;
 		this.exceptionReference = 0;
+		this.paused = false;
 	}
 
 	public getScript(scriptRef: VMScriptRef): Promise<VMScript> {
@@ -1237,6 +1240,7 @@ class ThreadInfo {
 		this.atAsyncSuspension = atAsyncSuspension;
 		if (exception)
 			this.exceptionReference = this.storeData(exception);
+		this.paused = true;
 	}
 }
 

--- a/test/dart_only/debug/dart_cli.test.ts
+++ b/test/dart_only/debug/dart_cli.test.ts
@@ -266,13 +266,7 @@ describe("dart cli debugger", () => {
 		}
 	});
 
-	it("stops on exception", async function () {
-		// This test is flaky on Dart v1. Sometimes we hit the exception and it inexplicably resumes
-		// https://gist.github.com/DanTup/3a70795cdb82d6a74a9e0c5c82c5b374
-		// If we ever see this on a recent SDK, we should open an issue.
-		if (!ext.exports.analyzerCapabilities.isDart2)
-			this.skip();
-
+	it("stops on exception", async () => {
 		await openFile(helloWorldBrokenFile);
 		const config = await startDebugger(helloWorldBrokenFile);
 		await Promise.all([


### PR DESCRIPTION
This seems to be the cause of flaky tests; we sometimes get a PuseStart event after we just resumed at startup. If we hit an exception quickly, then that rogue resume causes a resume from the exception, messing up tests.

Fixes #831.