### PR TITLE
Change providers to create instances of types rather than returning objects that implement them

### DIFF
--- a/src/providers/assist_code_action_provider.ts
+++ b/src/providers/assist_code_action_provider.ts
@@ -33,14 +33,12 @@ export class AssistCodeActionProvider implements CodeActionProvider {
 		const refactorId = change.id
 			? CodeActionKind.Refactor.append(change.id.replace("dart.assist.", ""))
 			: CodeActionKind.Refactor;
-		return {
-			command: {
-				arguments: [document, change],
-				command: "_dart.applySourceChange",
-				title,
-			},
-			kind: refactorId,
+		const action = new CodeAction(title, refactorId);
+		action.command = {
+			arguments: [document, change],
+			command: "_dart.applySourceChange",
 			title,
 		};
+		return action;
 	}
 }

--- a/src/providers/dart_reference_provider.ts
+++ b/src/providers/dart_reference_provider.ts
@@ -22,10 +22,10 @@ export class DartReferenceProvider implements ReferenceProvider, DefinitionProvi
 		});
 
 		const locations = resp.results.map((result) => {
-			return {
-				range: util.toRangeOnLine(result.location),
-				uri: Uri.file(result.location.file),
-			};
+			return new Location(
+				Uri.file(result.location.file),
+				util.toRangeOnLine(result.location),
+			);
 		});
 
 		return definition
@@ -46,10 +46,10 @@ export class DartReferenceProvider implements ReferenceProvider, DefinitionProvi
 			if (target.startColumn === 0)
 				target.startColumn = 1;
 
-			return {
-				range: util.toRangeOnLine(target),
-				uri: Uri.file(resp.files[target.fileIndex]),
-			};
+			return new Location(
+				Uri.file(resp.files[target.fileIndex]),
+				util.toRangeOnLine(target),
+			);
 		});
 	}
 }

--- a/src/providers/fix_code_action_provider.ts
+++ b/src/providers/fix_code_action_provider.ts
@@ -39,15 +39,13 @@ export class FixCodeActionProvider implements CodeActionProvider {
 	private convertResult(document: TextDocument, change: as.SourceChange, error: as.AnalysisError): CodeAction {
 		const title = change.message;
 		const diagnostics = error ? [DartDiagnosticProvider.createDiagnostic(error)] : undefined;
-		return {
-			command: {
-				arguments: [document, change],
-				command: "_dart.applySourceChange",
-				title,
-			},
-			diagnostics,
-			kind: CodeActionKind.QuickFix,
+		const action = new CodeAction(title, CodeActionKind.QuickFix);
+		action.command = {
+			arguments: [document, change],
+			command: "_dart.applySourceChange",
 			title,
 		};
+		action.diagnostics = diagnostics;
+		return action;
 	}
 }

--- a/src/providers/legacy_dart_workspace_symbol_provider.ts
+++ b/src/providers/legacy_dart_workspace_symbol_provider.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { CancellationToken, SymbolInformation, Uri, WorkspaceSymbolProvider, workspace } from "vscode";
+import { CancellationToken, Location, SymbolInformation, Uri, workspace, WorkspaceSymbolProvider } from "vscode";
 import * as as from "../analysis/analysis_server_types";
 import { Analyzer, getSymbolKindForElementKind } from "../analysis/analyzer";
 import { fsPath, isWithinWorkspace, toRangeOnLine } from "../utils";
@@ -94,15 +94,15 @@ export class LegacyDartWorkspaceSymbolProvider implements WorkspaceSymbolProvide
 			? result.path[0].parameters
 			: "";
 
-		return {
+		return new SymbolInformation(
+			elementPathDescription + parameters,
+			getSymbolKindForElementKind(result.path[0].kind),
 			containerName,
-			kind: getSymbolKindForElementKind(result.path[0].kind),
-			location: {
-				range: toRangeOnLine(result.location),
-				uri: Uri.file(result.location.file),
-			},
-			name: elementPathDescription + parameters,
-		};
+			new Location(
+				Uri.file(result.location.file),
+				toRangeOnLine(result.location),
+			),
+		);
 	}
 
 	private createDisplayPath(inputPath: string): string {

--- a/src/providers/refactor_code_action_provider.ts
+++ b/src/providers/refactor_code_action_provider.ts
@@ -39,15 +39,12 @@ export class RefactorCodeActionProvider implements CodeActionProvider {
 			return;
 
 		const title = supportedRefactors[k];
-
-		return {
-			command: {
-				arguments: [document, range, k],
-				command: "_dart.performRefactor",
-				title,
-			},
-			kind: CodeActionKind.Refactor,
+		const action = new CodeAction(title, CodeActionKind.Refactor);
+		action.command = {
+			arguments: [document, range, k],
+			command: "_dart.performRefactor",
 			title,
 		};
+		return action;
 	}
 }


### PR DESCRIPTION
Similar to the fix for #930. Sometimes Code changes break our providers because the shape of an object changes. If we use the constructors provided, any type checks will continue to pass.