### PR TITLE
Improvements to call stack rendering

### DIFF
--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -459,14 +459,15 @@ export class DartDebugSession extends DebugSession {
 				levels = totalFrames - startFrame;
 			vmFrames = vmFrames.slice(startFrame, startFrame + levels);
 
-			const stackFrames: StackFrame[] = [];
+			const stackFrames: DebugProtocol.StackFrame[] = [];
 			const promises: Array<Promise<void>> = [];
 
 			vmFrames.forEach((frame: VMFrame) => {
 				const frameId = thread.storeData(frame);
 
 				if (frame.kind === "AsyncSuspensionMarker") {
-					const stackFrame: StackFrame = new StackFrame(frameId, "<asynchronous gap>");
+					const stackFrame: DebugProtocol.StackFrame = new StackFrame(frameId, "<asynchronous gap>");
+					stackFrame.presentationHint = "label";
 					stackFrames.push(stackFrame);
 					return;
 				}

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -477,7 +477,7 @@ export class DartDebugSession extends DebugSession {
 
 				if (location == null) {
 					const stackFrame: DebugProtocol.StackFrame = new StackFrame(frameId, frameName);
-					stackFrame.presentationHint = "label";
+					stackFrame.presentationHint = "subtle";
 					stackFrames.push(stackFrame);
 					return;
 				}

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -485,20 +485,23 @@ export class DartDebugSession extends DebugSession {
 				const uri = location.script.uri;
 				const shortName = this.convertVMUriToUserName(uri);
 				let sourcePath = this.convertVMUriToSourcePath(uri);
+				let hint: "normal" | "subtle" = "normal";
 
 				// Download the source if from a "dart:" uri.
 				let sourceReference: number;
 				if (uri.startsWith("dart:")) {
 					sourcePath = null;
 					sourceReference = thread.storeData(location.script);
+					hint = "subtle";
 				}
 
-				const stackFrame: StackFrame = new StackFrame(
+				const stackFrame: DebugProtocol.StackFrame = new StackFrame(
 					frameId,
 					frameName,
 					new Source(shortName, sourcePath, sourceReference, null, location.script),
 					0, 0,
 				);
+				stackFrame.presentationHint = hint;
 				stackFrames.push(stackFrame);
 
 				// Resolve the line and column information.

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -485,23 +485,20 @@ export class DartDebugSession extends DebugSession {
 				const uri = location.script.uri;
 				const shortName = this.convertVMUriToUserName(uri);
 				let sourcePath = this.convertVMUriToSourcePath(uri);
-				let hint: "normal" | "subtle" = "normal";
 
 				// Download the source if from a "dart:" uri.
 				let sourceReference: number;
 				if (uri.startsWith("dart:")) {
 					sourcePath = null;
 					sourceReference = thread.storeData(location.script);
-					hint = "subtle";
 				}
 
-				const stackFrame: DebugProtocol.StackFrame = new StackFrame(
+				const stackFrame: StackFrame = new StackFrame(
 					frameId,
 					frameName,
 					new Source(shortName, sourcePath, sourceReference, null, location.script),
 					0, 0,
 				);
-				stackFrame.presentationHint = hint;
 				stackFrames.push(stackFrame);
 
 				// Resolve the line and column information.

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import { DebugSession, Event, InitializedEvent, OutputEvent, Scope, Source, StackFrame, StoppedEvent, TerminatedEvent, Thread, ThreadEvent } from "vscode-debugadapter";
 import { DebugProtocol } from "vscode-debugprotocol";
 import { logError } from "../utils";
-import { DebuggerResult, ObservatoryConnection, VM, VMBreakpoint, VMErrorRef, VMEvent, VMFrame, VMInstance, VMInstanceRef, VMIsolate, VMIsolateRef, VMLibraryRef, VMMapEntry, VMObj, VMResponse, VMScript, VMScriptRef, VMSentinel, VMSourceLocation, VMStack } from "./dart_debug_protocol";
+import { DebuggerResult, ObservatoryConnection, VM, VMBreakpoint, VMErrorRef, VMEvent, VMFrame, VMInstance, VMInstanceRef, VMIsolate, VMIsolateRef, VMMapEntry, VMObj, VMResponse, VMScript, VMScriptRef, VMSentinel, VMSourceLocation, VMStack } from "./dart_debug_protocol";
 import { PackageMap } from "./package_map";
 import { DartAttachRequestArguments, DartLaunchRequestArguments, PromiseCompleter, formatPathForVm, safeSpawn, uriToFilePath } from "./utils";
 
@@ -493,12 +493,20 @@ export class DartDebugSession extends DebugSession {
 					sourceReference = thread.storeData(location.script);
 				}
 
-				const stackFrame: StackFrame = new StackFrame(
+				const stackFrame: DebugProtocol.StackFrame = new StackFrame(
 					frameId,
 					frameName,
 					new Source(shortName, sourcePath, sourceReference, null, location.script),
 					0, 0,
 				);
+				// If we wouldn't debug this source, then deemphasize in the stack.
+				if (
+					!this.isValidToDebug(uri)
+					|| (this.isSdkLibrary(uri) && !this.debugSdkLibraries)
+					|| (this.isExternalLibrary(uri) && !this.debugExternalLibraries)
+				) {
+					stackFrame.source.presentationHint = "deemphasize";
+				}
 				stackFrames.push(stackFrame);
 
 				// Resolve the line and column information.
@@ -1035,6 +1043,20 @@ export class DartDebugSession extends DebugSession {
 		}
 	}
 
+	public isValidToDebug(uri: string) {
+		// TODO: See https://github.com/dart-lang/sdk/issues/29813
+		return !uri.startsWith("dart:_");
+	}
+
+	public isSdkLibrary(uri: string) {
+		return uri.startsWith("dart:");
+	}
+
+	public isExternalLibrary(uri: string) {
+		// If we don't know the local package name, we have to assume nothing is external, else we might disable debugging for the local library.
+		return uri.startsWith("package:") && this.packageMap.localPackageName && !uri.startsWith(`package:${this.packageMap.localPackageName}/`);
+	}
+
 	private resolveFileLocation(script: VMScript, tokenPos: number): FileLocation {
 		const table: number[][] = script.tokenPosTable;
 		for (const entry of table) {
@@ -1160,20 +1182,16 @@ class ThreadManager {
 
 	private async setLibrariesDebuggable(isolateRef: VMIsolateRef): Promise<void> {
 		// Helpers to categories libraries as SDK/ExternalLibrary/not.
-		const isValidToDebug = (l: VMLibraryRef) => !l.uri.startsWith("dart:_"); // TODO: See https://github.com/dart-lang/sdk/issues/29813
-		const isSdkLibrary = (l: VMLibraryRef) => l.uri.startsWith("dart:");
-		// If we don't know the local package name, we have to assume nothing is external, else we might disable debugging for the local library.
-		const isExternalLibrary = (l: VMLibraryRef) => l.uri.startsWith("package:") && this.debugSession.packageMap.localPackageName && !l.uri.startsWith(`package:${this.debugSession.packageMap.localPackageName}/`);
 		// Set whether libraries should be debuggable based on user settings.
 		const response = await this.debugSession.observatory.getIsolate(isolateRef.id);
 		const isolate: VMIsolate = response.result as VMIsolate;
 		await Promise.all(
-			isolate.libraries.filter(isValidToDebug).map((library) => {
+			isolate.libraries.filter((l) => this.debugSession.isValidToDebug(l.uri)).map((library) => {
 				// Note: Condition is negated.
 				const shouldDebug = !(
 					// Inside here is shouldNotDebug!
-					(isSdkLibrary(library) && !this.debugSession.debugSdkLibraries)
-					|| (isExternalLibrary(library) && !this.debugSession.debugExternalLibraries));
+					(this.debugSession.isSdkLibrary(library.uri) && !this.debugSession.debugSdkLibraries)
+					|| (this.debugSession.isExternalLibrary(library.uri) && !this.debugSession.debugExternalLibraries));
 				return this.debugSession.observatory.setLibraryDebuggable(isolate.id, library.id, shouldDebug);
 			}));
 	}

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -476,7 +476,8 @@ export class DartDebugSession extends DebugSession {
 				const location: VMSourceLocation = frame.location;
 
 				if (location == null) {
-					const stackFrame: StackFrame = new StackFrame(frameId, frameName);
+					const stackFrame: DebugProtocol.StackFrame = new StackFrame(frameId, frameName);
+					stackFrame.presentationHint = "label";
 					stackFrames.push(stackFrame);
 					return;
 				}


### PR DESCRIPTION
- `<async gaps>` are now centered labels
- frames with no source are left-aligned italic labels (I don't know in what cases these exist)
- non-debuggable sources are greyed out (see https://github.com/Dart-Code/Dart-Code/issues/713#issuecomment-391296941)