### PR TITLE
Reduce memory usage

### DIFF
--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -1328,9 +1328,10 @@ class ThreadManager {
 		return this.storedData[id];
 	}
 
-	public removeStoredIds(ids: number[]) {
-		for (const id of ids) {
-			delete this.storedData[id];
+	public removeStoredData(thread: ThreadInfo) {
+		for (const id of Object.keys(this.storedData).map((k) => parseInt(k, 10))) {
+			if (this.storedData[id].thread.num === thread.num)
+				delete this.storedData[id];
 		}
 	}
 
@@ -1339,6 +1340,7 @@ class ThreadManager {
 		if (threadInfo) {
 			this.debugSession.sendEvent(new ThreadEvent("exited", threadInfo.num));
 			this.threads.splice(this.threads.indexOf(threadInfo), 1);
+			this.removeStoredData(threadInfo);
 		} else {
 			console.error(`Failed to find thread for ${ref.id} during exit`);
 		}
@@ -1356,7 +1358,6 @@ class StoredData {
 }
 
 class ThreadInfo {
-	public storedIds: number[] = [];
 	public scriptCompleters: { [key: string]: PromiseCompleter<VMScript> } = {};
 	public runnable: boolean = false;
 	public vmBps: { [uri: string]: VMBreakpoint[] } = {};
@@ -1450,9 +1451,7 @@ class ThreadInfo {
 	}
 
 	public handleResumed() {
-		// TODO: I don"t think we want to do this...
-		// this.manager.removeStoredIds(this.storedIds);
-		// this.storedIds = [];
+		this.manager.removeStoredData(this);
 		// TODO: Should we be waiting for acknowledgement before doing this?
 		this.atAsyncSuspension = false;
 		this.exceptionReference = 0;

--- a/src/services/stdio_service.ts
+++ b/src/services/stdio_service.ts
@@ -141,6 +141,7 @@ export abstract class StdIOService<T> implements Disposable {
 
 	private handleResponse(evt: UnknownResponse) {
 		const handler = this.activeRequests[evt.id];
+		delete this.activeRequests[evt.id];
 		const method: string = handler[2];
 		const error = evt.error;
 


### PR DESCRIPTION
@devoncarew I don't expect you to remember this, but hopefully you can sanity check...

In the original debug impl there was some commented out code for removing stored data from the thread manager on `resume`. It passed a list of IDs for data that was stored for that thread, but this list was never populated. It had a comment that said `// TODO: I don"t think we want to do this...`!

This results in the `storedData` building up over a long debug session. I think we *did* want to do what was in the commented code, so I uncommented it and tweaked it so we just loop through the collection of stored data looking for anything that's for that given thread and deleting that.

Tests are passing and everything seems good in manual testing so I think all is good, but I'm not sure what the reason for the original comment/commenting out was. Ring any bells?