### PR TITLE
Add custom mocha reporter to write test status to main log files in CI builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2104,27 +2104,6 @@
 				}
 			}
 		},
-		"mocha-multi-reporters": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/mocha-multi-reporters/-/mocha-multi-reporters-1.1.7.tgz",
-			"integrity": "sha1-zH8/TTL0eFIJQdhSq7ZNmYhYfYI=",
-			"dev": true,
-			"requires": {
-				"debug": "^3.1.0",
-				"lodash": "^4.16.4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -811,7 +811,6 @@
 		"@types/sinon": "^4.3.0",
 		"@types/ws": "^0.0.38",
 		"mocha": "^5.1.0",
-		"mocha-multi-reporters": "^1.1.7",
 		"nyc": "^12.0.2",
 		"remap-istanbul": "^0.11.1",
 		"run-for-every-file": "^1.1.0",

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -4,6 +4,7 @@ import { Event, EventEmitter } from "vscode";
 
 export enum LogCategory {
 	General,
+	CI,
 	Analyzer,
 	FlutterDaemon,
 	FlutterRun,

--- a/test/dart_only/commands/complete_statement.test.ts
+++ b/test/dart_only/commands/complete_statement.test.ts
@@ -2,12 +2,11 @@ import * as vs from "vscode";
 import { activate, ensureTestContentWithCursorPos, ext, rangeOf, select, setTestContent, waitForEditorChange } from "../../helpers";
 
 describe("complete statement", () => {
-
-	before(() => activate());
-	beforeEach(function () {
+	beforeEach("skip if not got complete statement fix", function () {
 		if (!ext.exports.analyzerCapabilities.hasCompleteStatementFix)
 			this.skip();
 	});
+	beforeEach(() => activate());
 
 	it("completes a simple print", async () => {
 		await setTestContent(`

--- a/test/dart_only/commands/go_to_super_method.test.ts
+++ b/test/dart_only/commands/go_to_super_method.test.ts
@@ -9,7 +9,7 @@ export const superFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "lib/go
 export const derivedFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "lib/go_to_super_method/derived.dart"));
 
 describe("go_to_super_method", () => {
-	before("activate and wait for outline", async () => {
+	beforeEach("activate and wait for outline", async () => {
 		await activate(derivedFile);
 		await waitFor(() => !!OpenFileTracker.getOutlineFor(derivedFile));
 	});

--- a/test/dart_only/commands/organize_imports.test.ts
+++ b/test/dart_only/commands/organize_imports.test.ts
@@ -3,7 +3,7 @@ import { activate, ensureTestContent, setTestContent, waitForEditorChange } from
 
 describe("organize imports", () => {
 
-	before("activate", () => activate());
+	beforeEach("activate", () => activate());
 
 	it("sorts imports", async () => {
 		await setTestContent(`

--- a/test/dart_only/commands/sort_members.test.ts
+++ b/test/dart_only/commands/sort_members.test.ts
@@ -3,7 +3,7 @@ import { activate, ensureTestContent, setTestContent, waitForEditorChange } from
 
 describe("sort members", () => {
 
-	before("activate", () => activate());
+	beforeEach("activate", () => activate());
 
 	it("sorts members", async () => {
 		await setTestContent(`

--- a/test/dart_only/debug/debug_config_provider.test.ts
+++ b/test/dart_only/debug/debug_config_provider.test.ts
@@ -16,7 +16,7 @@ describe.skip("debug_config_provider", () => {
 		type: "dart",
 	};
 
-	before("activate", () => activate());
+	beforeEach("activate", () => activate());
 
 	it("runs a Dart script to completion", async () => {
 		await vs.debug.startDebugging(vs.workspace.workspaceFolders[0], debugConfig);

--- a/test/dart_only/outline_tracking.test.ts
+++ b/test/dart_only/outline_tracking.test.ts
@@ -7,12 +7,13 @@ import { activate, closeAllOpenFiles, closeFile, ext, helloWorldFolder, openFile
 export const outlineTrackingFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "lib/outline_tracking/empty.dart"));
 
 describe("file tracker", () => {
-	before("activate", () => activate());
 	beforeEach("skip if not Dart 2", function () {
 		// https://github.com/dart-lang/sdk/issues/30238
 		if (!ext.exports.analyzerCapabilities.isDart2)
 			this.skip();
 	});
+	beforeEach("activate", () => activate());
+
 	it("has a tracked outline when a file is opened", async () => {
 		await closeAllOpenFiles();
 		await waitFor(() => !OpenFileTracker.getOutlineFor(outlineTrackingFile), "Outline was already present");

--- a/test/dart_only/providers/dart_diagnotics_provider.test.ts
+++ b/test/dart_only/providers/dart_diagnotics_provider.test.ts
@@ -4,7 +4,7 @@ import { activate, emptyFile, ensureError, setTestContent, waitForDiagnosticChan
 
 describe("diagnostics_provider", () => {
 
-	before("activate emptyFile", () => activate(emptyFile));
+	beforeEach("activate emptyFile", () => activate(emptyFile));
 
 	it("returns no errors for a valid file", async () => {
 		await setTestContent(`
@@ -18,7 +18,7 @@ main() {
 	});
 
 	it("returns errors for an invalid file", async () => {
-		// Set up a handler for when the diagnostics change.)
+		// Set up a handler for when the diagnostics change.
 		const diagnosticChange = waitForDiagnosticChange(emptyFile);
 
 		await setTestContent(`

--- a/test/dart_only/providers/dart_document_symbol_provider.test.ts
+++ b/test/dart_only/providers/dart_document_symbol_provider.test.ts
@@ -4,7 +4,7 @@ import { activate, ensureSymbol, everythingFile, getDocumentSymbols } from "../.
 
 describe("document_symbol_provider", () => {
 
-	before("activate everythingFile", () => activate(everythingFile));
+	beforeEach("activate everythingFile", () => activate(everythingFile));
 
 	it("returns expected items for 'everything.dart'", async () => {
 		const symbols = await getDocumentSymbols();

--- a/test/dart_only/providers/dart_formatting_edit_provider.test.ts
+++ b/test/dart_only/providers/dart_formatting_edit_provider.test.ts
@@ -1,10 +1,10 @@
 import * as assert from "assert";
 import * as vs from "vscode";
-import { activate, doc, editor, documentEol, setTestContent } from "../../helpers";
+import { activate, doc, documentEol, editor, setTestContent } from "../../helpers";
 
 describe("dart_formatting_edit_provider", () => {
 
-	before("activate", () => activate());
+	beforeEach("activate", () => activate());
 
 	async function formatDocument(): Promise<void> {
 		const formatResult = await (vs.commands.executeCommand("vscode.executeFormatDocumentProvider", doc.uri) as Thenable<vs.TextEdit[]>);

--- a/test/dart_only/providers/dart_hover_provider.test.ts
+++ b/test/dart_only/providers/dart_hover_provider.test.ts
@@ -6,7 +6,7 @@ describe("dart_hover_provider", () => {
 
 	// We have tests that read tooltips from external packages so we need to ensure packages have been fetched.
 	before("get packages", () => getPackages());
-	before("activate everythingFile", () => activate(everythingFile));
+	beforeEach("activate everythingFile", () => activate(everythingFile));
 
 	async function getHoversAt(searchText: string): Promise<Array<{ displayText: string, documentation?: string, range: vs.Range }>> {
 		const position = positionOf(searchText);

--- a/test/dart_only/providers/dart_rename_provider.test.ts
+++ b/test/dart_only/providers/dart_rename_provider.test.ts
@@ -4,7 +4,7 @@ import { activate, doc, ensureTestContent, ext, positionOf, setTestContent } fro
 
 describe("rename_provider", () => {
 
-	before("activate", () => activate());
+	beforeEach("activate", () => activate());
 
 	it("renames all exact references but not other items with same name", async () => {
 		await setTestContent(`

--- a/test/dart_only/providers/dart_type_formatting_edit_provider.test.ts
+++ b/test/dart_only/providers/dart_type_formatting_edit_provider.test.ts
@@ -1,10 +1,10 @@
 import * as assert from "assert";
 import * as vs from "vscode";
-import { activate, doc, editor, documentEol, positionOf, setTestContent } from "../../helpers";
+import { activate, doc, documentEol, editor, positionOf, setTestContent } from "../../helpers";
 
 describe("dart_type_formatting_edit_provider", () => {
 
-	before("activate", () => activate());
+	beforeEach("activate", () => activate());
 
 	async function formatAtLocation(searchText: string, character: string): Promise<void> {
 		const position = positionOf(searchText);

--- a/test/dart_only/providers/dart_workspace_symbol_provider.test.ts
+++ b/test/dart_only/providers/dart_workspace_symbol_provider.test.ts
@@ -5,7 +5,7 @@ import { activate, ensureSymbol, everythingFile, ext, getWorkspaceSymbols } from
 
 describe("workspace_symbol_provider", () => {
 
-	before("activate", () => activate());
+	beforeEach("activate", () => activate());
 
 	it("includes nothing given no query", async () => {
 		const symbols = await getWorkspaceSymbols("");

--- a/test/dart_only/providers/fix_code_action_provider.test.ts
+++ b/test/dart_only/providers/fix_code_action_provider.test.ts
@@ -4,7 +4,7 @@ import { activate, doc, helloWorldCreateMethodClassAFile, helloWorldCreateMethod
 
 describe("fix_code_action_provider", () => {
 
-	before("activate helloWorldCreateMethodClassBFile", async () => {
+	beforeEach("activate helloWorldCreateMethodClassBFile", async () => {
 		await activate(helloWorldCreateMethodClassBFile);
 	});
 

--- a/test/dart_only/providers/snippet_provider.test.ts
+++ b/test/dart_only/providers/snippet_provider.test.ts
@@ -2,7 +2,7 @@ import { activate, ensureNoSnippet, ensureSnippet, getSnippetCompletionsAt, setT
 
 describe("snippet_provider", () => {
 
-	before("activate", () => activate());
+	beforeEach("activate", () => activate());
 
 	it("returns dart items", async () => {
 		await setTestContent("mai");

--- a/test/dart_only/refactors/extract_method.test.ts
+++ b/test/dart_only/refactors/extract_method.test.ts
@@ -7,7 +7,7 @@ import { activate, doc, ensureTestContent, positionOf, rangeOf, sb, setTestConte
 
 describe("refactor", () => {
 
-	before("activate", () => activate());
+	beforeEach("activate", () => activate());
 
 	it("can extract simple code into a method", async () => {
 		const showInputBox = sb.stub(vs.window, "showInputBox");

--- a/test/flutter_only/providers/completion_item_provider.test.ts
+++ b/test/flutter_only/providers/completion_item_provider.test.ts
@@ -3,7 +3,7 @@ import { activate, ensureCompletion, flutterHelloWorldMainFile, getCompletionsAt
 
 describe("completion_item_provider", () => {
 
-	before("activate flutterHelloWorldMainFile", () => activate(flutterHelloWorldMainFile));
+	beforeEach("activate flutterHelloWorldMainFile", () => activate(flutterHelloWorldMainFile));
 
 	it("returns expected items", async () => {
 		const completions = await getCompletionsAt("new ^Text");

--- a/test/flutter_only/providers/dart_document_symbol_provider.test.ts
+++ b/test/flutter_only/providers/dart_document_symbol_provider.test.ts
@@ -4,7 +4,7 @@ import { activate, ensureSymbol, flutterHelloWorldMainFile, getDocumentSymbols }
 
 describe("dart_document_symbol_provider", () => {
 
-	before("activate flutterHelloWorldMainFile", () => activate(flutterHelloWorldMainFile));
+	beforeEach("activate flutterHelloWorldMainFile", () => activate(flutterHelloWorldMainFile));
 
 	it("returns expected items for 'flutter/hello_world'", async () => {
 		const symbols = await getDocumentSymbols();

--- a/test/flutter_only/providers/fix_code_action_provider.test.ts
+++ b/test/flutter_only/providers/fix_code_action_provider.test.ts
@@ -4,7 +4,7 @@ import { activate, doc, flutterEmptyFile, rangeOf, setTestContent } from "../../
 
 describe("fix_code_action_provider", () => {
 
-	before("activate flutterEmptyFile and add test content", async () => {
+	beforeEach("activate flutterEmptyFile and add test content", async () => {
 		await activate(flutterEmptyFile);
 		await setTestContent(`
 			import 'package:flutter/widgets.dart';

--- a/test/flutter_only/providers/snippet_provider.test.ts
+++ b/test/flutter_only/providers/snippet_provider.test.ts
@@ -2,7 +2,7 @@ import { activate, ensureSnippet, flutterEmptyFile, getSnippetCompletionsAt, set
 
 describe("snippet_provider", () => {
 
-	before("activate flutterEmptyFile", () => activate(flutterEmptyFile));
+	beforeEach("activate flutterEmptyFile", () => activate(flutterEmptyFile));
 
 	it("returns dart items", async () => {
 		await setTestContent("mai");

--- a/test/flutter_only/refactors/extract_widget.test.ts
+++ b/test/flutter_only/refactors/extract_widget.test.ts
@@ -7,12 +7,12 @@ import { activate, doc, ensureTestContent, ext, rangeOf, sb, setTestContent, wai
 
 describe("refactor", () => {
 
-	before("activate", () => activate());
 	// tslint:disable-next-line:only-arrow-functions
 	beforeEach("skip if not updated widget snippets", function () {
 		if (!ext.exports.analyzerCapabilities.hasUpdatedWidgetSnippets)
 			this.skip();
 	});
+	beforeEach("activate", () => activate());
 
 	it("can extract simple code into a widget", async () => {
 		const showInputBox = sb.stub(vs.window, "showInputBox");

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -9,7 +9,7 @@ import { AnalyzerCapabilities } from "../src/analysis/analyzer";
 import { DartRenameProvider } from "../src/providers/dart_rename_provider";
 import { DebugConfigProvider } from "../src/providers/debug_config_provider";
 import { Sdks, fsPath, vsCodeVersionConstraint } from "../src/utils";
-import { logTo } from "../src/utils/log";
+import { log, logTo } from "../src/utils/log";
 import sinon = require("sinon");
 
 export const ext = vs.extensions.getExtension<{
@@ -61,14 +61,17 @@ export let documentEol: string;
 export let platformEol: string;
 
 export async function activate(file: vs.Uri = emptyFile): Promise<void> {
+	log("Activating and waiting for any initial/in-progress analysis");
 	await ext.activate();
 	await ext.exports.initialAnalysis;
 	await ext.exports.currentAnalysis();
+	log(`Closing all open files and opening ${fsPath(file)}`);
 	await closeAllOpenFiles();
 	doc = await vs.workspace.openTextDocument(file);
 	editor = await vs.window.showTextDocument(doc);
 	documentEol = doc.eol === vs.EndOfLine.CRLF ? "\r\n" : "\n";
 	platformEol = isWin ? "\r\n" : "\n";
+	log(`Ready to start test`);
 }
 
 export async function getPackages() {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -370,6 +370,7 @@ export async function waitForEditorChange(action: () => Thenable<void>): Promise
 	await waitFor(() => doc.version !== oldVersion);
 }
 
+// This same logic exists in the website to link back to logs.
 export function filenameSafe(input: string) {
 	return input.replace(/[^a-z0-9]+/gi, "_").toLowerCase();
 }

--- a/test/mocha_logging_reporter.ts
+++ b/test/mocha_logging_reporter.ts
@@ -1,0 +1,34 @@
+import { ITest, reporters } from "mocha";
+import { LogCategory, log } from "../src/utils/log";
+import testRunner = require("vscode/lib/testrunner");
+
+export class LoggingReporter extends reporters.Base {
+	constructor(runner: any, options: any) {
+		super(runner);
+
+		// runner.on("start", () => { });
+
+		runner.on("test", (test: ITest) => {
+			log(`Starting test ${test.fullTitle()}...`, LogCategory.CI);
+		});
+
+		runner.on("pending", (test: ITest) => {
+			log(`Test ${test.fullTitle()} pending/skipped`, LogCategory.CI);
+		});
+
+		runner.on("pass", (test: ITest) => {
+			log(`Test ${test.fullTitle()} passed after ${test.duration}ms`, LogCategory.CI);
+		});
+
+		runner.on("fail", (test: ITest) => {
+			log(`Test ${test.fullTitle()} failed after ${test.duration}ms`, LogCategory.CI);
+			const err = (test as any).err;
+			if (err) {
+				log(err.message, LogCategory.CI);
+				log(err.stack, LogCategory.CI);
+			}
+		});
+
+		// runner.once("end", () => { });
+	}
+}

--- a/test/mocha_multi_reporter.ts
+++ b/test/mocha_multi_reporter.ts
@@ -1,7 +1,7 @@
 import { IRunner, reporters } from "mocha";
 import { LoggingReporter } from "./mocha_logging_reporter";
 
-class MultiReporter extends reporters.Base {
+export class MultiReporter extends reporters.Base {
 	constructor(runner: IRunner, options: any) {
 		// These have to be any because the TS defs don't have the options argument.
 		// TODO: Send a PR to fix?

--- a/test/mocha_multi_reporter.ts
+++ b/test/mocha_multi_reporter.ts
@@ -1,0 +1,18 @@
+import { IRunner, reporters } from "mocha";
+import { LoggingReporter } from "./mocha_logging_reporter";
+
+class MultiReporter extends reporters.Base {
+	constructor(runner: IRunner, options: any) {
+		// These have to be any because the TS defs don't have the options argument.
+		// TODO: Send a PR to fix?
+		const reporterConstructors: any[] = [];
+		reporterConstructors.push(reporters.Spec);
+		reporterConstructors.push(LoggingReporter);
+		if (process.env.TEST_XML_OUTPUT)
+			reporterConstructors.push(reporters.XUnit);
+
+		// Create all reporters; they'll subscribe to the events on runner.
+		const rs = reporterConstructors.map((r) => new r(runner, options));
+		super(runner);
+	}
+}

--- a/test/test_runner.ts
+++ b/test/test_runner.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import { IRunner, reporters } from "mocha";
+import { MultiReporter } from "./mocha_multi_reporter";
 import testRunner = require("vscode/lib/testrunner");
 const onExit = require("signal-exit"); // tslint:disable-line:no-var-requires
 
@@ -16,14 +16,6 @@ onExit(() => {
 		process.exit(1);
 	}
 });
-
-class MultiReporter extends reporters.Base {
-	constructor(runner: IRunner, options: any) {
-		const reporterConstructors: any[] = process.env.TEST_XML_OUTPUT ? [reporters.Spec, reporters.XUnit] : [reporters.Spec];
-		const rs = reporterConstructors.map((r) => new r(runner, options));
-		super(runner);
-	}
-}
 
 testRunner.configure({
 	forbidOnly: !!process.env.MOCHA_FORBID_ONLY,


### PR DESCRIPTION
This swaps the multi-reporter package for a custom class which allows us to add our own reporters easily, and adds a reporter that writes the test events to the main logfile (this is so we can see the test exceptions in the log files linked from the test dashboard since we can't easily link to the Travis/AppVeyor results because they don't have guessable URLs).