### PR TITLE
Implement go to implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
 			},
 			{
 				"command": "dart.goToSuper",
-				"title": "Go to Super Method",
+				"title": "Go to Super Class/Method",
 				"category": "Dart"
 			},
 			{

--- a/src/commands/go_to_super.ts
+++ b/src/commands/go_to_super.ts
@@ -25,7 +25,7 @@ export class GoToSuperCommand implements vs.Disposable {
 		const document = editor.document;
 		const position = editor.selection.start;
 
-		const outlineNode = findNearestOutlineNode(document, position, ["CLASS", "METHOD", "GETTER", "SETTER"]);
+		const outlineNode = findNearestOutlineNode(document, position);
 		const offset = outlineNode ? outlineNode.element.location.offset : document.offsetAt(position);
 
 		const hierarchy = await this.analyzer.searchGetTypeHierarchy({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,7 @@ import { DartFoldingProvider } from "./providers/dart_folding_provider";
 import { DartFormattingEditProvider } from "./providers/dart_formatting_edit_provider";
 import { DartDocumentHighlightProvider } from "./providers/dart_highlighting_provider";
 import { DartHoverProvider } from "./providers/dart_hover_provider";
+import { DartImplementationProvider } from "./providers/dart_implementation_provider";
 import { DartLanguageConfiguration } from "./providers/dart_language_configuration";
 import { DartReferenceProvider } from "./providers/dart_reference_provider";
 import { DartRenameProvider } from "./providers/dart_rename_provider";
@@ -161,6 +162,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 	const refactorCodeActionProvider = new RefactorCodeActionProvider(analyzer);
 	const sourceCodeActionProvider = new SourceCodeActionProvider(analyzer);
 	const renameProvider = new DartRenameProvider(analyzer);
+	const implementationProvider = new DartImplementationProvider(analyzer);
 
 	const activeFileFilters = [DART_MODE];
 	if (config.analyzeAngularTemplates && analyzer.capabilities.supportsAnalyzingHtmlFiles) {
@@ -185,6 +187,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 	// Some actions only apply to Dart.
 	context.subscriptions.push(vs.languages.registerOnTypeFormattingEditProvider(DART_MODE, typeFormattingEditProvider, "}", ";"));
 	context.subscriptions.push(vs.languages.registerCodeActionsProvider(DART_MODE, sourceCodeActionProvider, sourceCodeActionProvider.metadata));
+	context.subscriptions.push(vs.languages.registerImplementationProvider(DART_MODE, implementationProvider));
 
 	// Snippets are language-specific
 	context.subscriptions.push(vs.languages.registerCompletionItemProvider(DART_MODE, new SnippetCompletionItemProvider("snippets/dart.json", (_) => true)));

--- a/src/providers/dart_implementation_provider.ts
+++ b/src/providers/dart_implementation_provider.ts
@@ -16,7 +16,7 @@ export class DartImplementationProvider implements vs.ImplementationProvider {
 		//
 		// The search.getTypeHierarchy call will only work over "b" but by using outline we
 		// can support the whole "void b();".
-		const outlineNode = findNearestOutlineNode(document, position, ["CLASS", "METHOD", "GETTER", "SETTER"]);
+		const outlineNode = findNearestOutlineNode(document, position);
 		const offset = outlineNode ? outlineNode.element.location.offset : document.offsetAt(position);
 
 		const hierarchy = await this.analyzer.searchGetTypeHierarchy({

--- a/src/providers/dart_implementation_provider.ts
+++ b/src/providers/dart_implementation_provider.ts
@@ -1,0 +1,60 @@
+import * as _ from "lodash";
+import * as vs from "vscode";
+import * as as from "../analysis/analysis_server_types";
+import { Analyzer } from "../analysis/analyzer";
+import { fsPath, toRange } from "../utils";
+import { findNearestOutlineNode } from "../utils/outline";
+
+export class DartImplementationProvider implements vs.ImplementationProvider {
+	constructor(readonly analyzer: Analyzer) { }
+
+	public async provideImplementation(document: vs.TextDocument, position: vs.Position, token: vs.CancellationToken): Promise<vs.Definition> {
+		// Try to use the Outline data to snap our location to a node.
+		// For example in:
+		//
+		//     void b();
+		//
+		// The search.getTypeHierarchy call will only work over "b" but by using outline we
+		// can support the whole "void b();".
+		const outlineNode = findNearestOutlineNode(document, position, ["CLASS", "METHOD", "GETTER", "SETTER"]);
+		const offset = outlineNode ? outlineNode.element.location.offset : document.offsetAt(position);
+
+		const hierarchy = await this.analyzer.searchGetTypeHierarchy({
+			file: fsPath(document.uri),
+			offset,
+		});
+
+		if (!hierarchy || !hierarchy.hierarchyItems || !hierarchy.hierarchyItems.length || hierarchy.hierarchyItems.length === 1)
+			return;
+
+		// Find the element we started with, since we only want implementations (not super classes).
+		const currentItem = hierarchy.hierarchyItems.find((h) => {
+			const elm = h.memberElement || h.classElement;
+			return elm.location.offset <= offset && elm.location.offset + elm.location.length >= offset;
+		});
+
+		const isClass = !currentItem.memberElement;
+		function getDescendants(item: as.TypeHierarchyItem): as.TypeHierarchyItem[] {
+			return _.concat(
+				item.subclasses.map((i) => hierarchy.hierarchyItems[i]),
+				_.flatMap(item.subclasses, (i) => getDescendants(hierarchy.hierarchyItems[i])),
+			);
+		}
+		const descendants = getDescendants(currentItem)
+			.map((d) => isClass ? d.classElement : d.memberElement)
+			.filter((d) => d);
+
+		const locations: vs.Location[] = [];
+		for (const element of descendants) {
+			const range = toRange(
+				await vs.workspace.openTextDocument(element.location.file),
+				element.location.offset,
+				element.location.length,
+			);
+
+			locations.push(new vs.Location(vs.Uri.file(element.location.file), range));
+		}
+
+		return locations;
+	}
+}

--- a/src/utils/outline.ts
+++ b/src/utils/outline.ts
@@ -1,0 +1,23 @@
+import * as vs from "vscode";
+import * as as from "../analysis/analysis_server_types";
+import { OpenFileTracker } from "../analysis/open_file_tracker";
+
+function findNode(outlines: as.Outline[], offset: number, kinds: as.ElementKind[]): as.Outline | undefined {
+	if (!outlines)
+		return null;
+	for (const outline of outlines) {
+		const outlineStart = outline.offset;
+		const outlineEnd = outline.offset + outline.length;
+
+		// Bail if this node is not spanning us.
+		if (outlineStart > offset || outlineEnd < offset)
+			continue;
+
+		return findNode(outline.children, offset, kinds) || (kinds.indexOf(outline.element.kind) !== -1 ? outline : null);
+	}
+}
+
+export function findNearestOutlineNode(document: vs.TextDocument, position: vs.Position, kinds: as.ElementKind[]) {
+	const outline = OpenFileTracker.getOutlineFor(document.uri);
+	return outline && findNode([outline], document.offsetAt(position), kinds);
+}

--- a/src/utils/outline.ts
+++ b/src/utils/outline.ts
@@ -17,7 +17,7 @@ function findNode(outlines: as.Outline[], offset: number, kinds: as.ElementKind[
 	}
 }
 
-export function findNearestOutlineNode(document: vs.TextDocument, position: vs.Position, kinds: as.ElementKind[]) {
+export function findNearestOutlineNode(document: vs.TextDocument, position: vs.Position, kinds: as.ElementKind[] = ["CLASS", "METHOD", "GETTER", "SETTER"]) {
 	const outline = OpenFileTracker.getOutlineFor(document.uri);
 	return outline && findNode([outline], document.offsetAt(position), kinds);
 }

--- a/test/dart_only/providers/dart_implementation_provider.test.ts
+++ b/test/dart_only/providers/dart_implementation_provider.test.ts
@@ -1,0 +1,90 @@
+import * as assert from "assert";
+import * as path from "path";
+import * as vs from "vscode";
+import { fsPath } from "../../../src/utils";
+import { activate, doc, ensureLocation, ensureNoLocation, helloWorldFolder, positionOf, rangeOf } from "../../helpers";
+
+const testFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "lib/go_to_implementation.dart"));
+
+describe("dart_implementation_provider", () => {
+	beforeEach("activate everythingFile", () => activate(testFile));
+
+	async function getImplementationsAt(searchText: string): Promise<vs.Location[]> {
+		const position = positionOf(searchText);
+		const definitionResults = await (vs.commands.executeCommand("vscode.executeImplementationProvider", doc.uri, position) as Thenable<vs.Location[]>);
+
+		return definitionResults || [];
+	}
+
+	it("does not return anything for blank areas of the document", async () => {
+		const impls = await getImplementationsAt("\n^\n");
+		assert.equal(impls.length, 0);
+	});
+
+	it("returns direct class implementations", async () => {
+		const impls = await getImplementationsAt("abstract class ^A");
+		ensureLocation(impls, testFile, rangeOf("class |B| extends A"));
+		ensureLocation(impls, testFile, rangeOf("class |C| extends A"));
+	});
+
+	it("returns indirect class implementations", async () => {
+		const impls = await getImplementationsAt("abstract class ^A");
+		ensureLocation(impls, testFile, rangeOf("class |D| extends B"));
+		ensureLocation(impls, testFile, rangeOf("class |E| extends B"));
+		ensureLocation(impls, testFile, rangeOf("class |F| extends E"));
+	});
+
+	it("does not return self (class)", async () => {
+		const impls = await getImplementationsAt("abstract class ^A");
+		ensureNoLocation(impls, testFile, rangeOf("abstract class |A|"));
+	});
+
+	it("does not return super classes", async () => {
+		const impls = await getImplementationsAt("class ^B extends A");
+		ensureNoLocation(impls, testFile, rangeOf("abstract class |A|"));
+	});
+
+	it("returns implementations of concrete classes", async () => {
+		const impls = await getImplementationsAt("class ^B extends A");
+		ensureLocation(impls, testFile, rangeOf("class |E| extends B"));
+	});
+
+	it("returns even if selection is not on class name", async () => {
+		const impls = await getImplementationsAt("^abstract class A");
+		ensureLocation(impls, testFile, rangeOf("class |B| extends A"));
+		ensureLocation(impls, testFile, rangeOf("class |C| extends A"));
+	});
+
+	it("returns direct method implementations", async () => {
+		const impls = await getImplementationsAt("void ^b();");
+		ensureLocation(impls, testFile, rangeOf("void |b|() /* B */ {"));
+		ensureLocation(impls, testFile, rangeOf("void |b|() /* C */ {"));
+	});
+
+	it("returns indirect method implementations", async () => {
+		const impls = await getImplementationsAt("void ^b();");
+		ensureLocation(impls, testFile, rangeOf("void |b|() /* D */ {"));
+		ensureLocation(impls, testFile, rangeOf("void |b|() /* F */ {"));
+	});
+
+	it("does not return self (method)", async () => {
+		const impls = await getImplementationsAt("void ^b();");
+		ensureNoLocation(impls, testFile, rangeOf("void |b|();"));
+	});
+
+	it("does not return super method", async () => {
+		const impls = await getImplementationsAt("void ^b() /* B */ {");
+		ensureNoLocation(impls, testFile, rangeOf("void |b|();"));
+	});
+
+	it("returns overrides of concrete method", async () => {
+		const impls = await getImplementationsAt("void ^b() /* B */ {");
+		ensureLocation(impls, testFile, rangeOf("void |b|() /* D */ {"));
+	});
+
+	it("returns even if selection is not on method name", async () => {
+		const impls = await getImplementationsAt("^void b();");
+		ensureLocation(impls, testFile, rangeOf("void |b|() /* B */ {"));
+		ensureLocation(impls, testFile, rangeOf("void |b|() /* C */ {"));
+	});
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -271,6 +271,33 @@ export function ensureSymbol(symbols: vs.SymbolInformation[], name: string, kind
 	assert.ok(symbol.location.range.end.line);
 }
 
+function rangeString(range: vs.Range) {
+	return `${range.start.line}:${range.start.character}-${range.end.line}:${range.end.character}`;
+}
+
+export function ensureLocation(locations: vs.Location[], uri: vs.Uri, range: vs.Range): void {
+	const location = locations.find((l) =>
+		l.uri.toString() === uri.toString()
+		&& l.range.isEqual(range),
+	);
+	assert.ok(
+		location,
+		`Couldn't find location for ${uri}/${rangeString(range)} in\n`
+		+ locations.map((l) => `        ${l.uri}/${rangeString(l.range)}`).join("\n"),
+	);
+}
+
+export function ensureNoLocation(locations: vs.Location[], uri: vs.Uri, range: vs.Range): void {
+	const location = locations.find((l) =>
+		l.uri.toString() === uri.toString()
+		&& l.range.isEqual(range),
+	);
+	assert.ok(
+		!location,
+		`Unexpectedly found location for ${uri}/${rangeString(range)}`,
+	);
+}
+
 export function ensureIsRange(actual: vs.Range, expected: vs.Range) {
 	assert.ok(actual);
 	assert.equal(actual.start.line, expected.start.line, "Start lines did not match");

--- a/test/test_projects/hello_world/lib/go_to_implementation.dart
+++ b/test/test_projects/hello_world/lib/go_to_implementation.dart
@@ -1,0 +1,29 @@
+abstract class A {
+  void b();
+}
+
+class B extends A {
+  void b() /* B */ {
+    print("test");
+  }
+}
+
+class C extends A {
+  void b() /* C */ {
+    print("test");
+  }
+}
+
+class D extends B {
+  void b() /* D */ {
+    print("test");
+  }
+}
+
+class E extends B {}
+
+class F extends E {
+  void b() /* F */ {
+    print("test");
+  }
+}


### PR DESCRIPTION
cc @xster :-)

Not sure if I did this exactly as you desired, so feel free to review the tests below and add comments. It will return all implementations (including where the implementation is overridden, or the class is extended multiple levels). It only ever looks down the hierarchy. 

I also improved up Go to Super to support classes while I was at it (so if you're in a long class you can jump to the super class easily) since there was a lot of overlap in these and code extracted/shared.