### PR TITLE
WIP - Flutter screenshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -256,6 +256,11 @@
 				"command": "flutter.openInXcode",
 				"title": "Open in Xcode",
 				"category": "Flutter"
+			},
+			{
+				"command": "flutter.screenshot",
+				"title": "Save Screenshot",
+				"category": "Flutter"
 			}
 		],
 		"keybindings": [
@@ -402,6 +407,10 @@
 				{
 					"command": "flutter.openInXcode",
 					"when": "false"
+				},
+				{
+					"command": "flutter.screenshot",
+					"when": "dart-code:flutterProjectLoaded && inDebugMode"
 				}
 			],
 			"editor/title": [

--- a/src/commands/sdk.ts
+++ b/src/commands/sdk.ts
@@ -20,6 +20,7 @@ const flutterNameRegex = new RegExp("^[a-z][a-z0-9_]*$");
 export class SdkCommands {
 	private sdks: Sdks;
 	private analytics: Analytics;
+	private screenshotUri: string;
 	// A map of any in-progress commands so we can terminate them if we want to run another.
 	private runningCommands: { [workspaceUriAndCommand: string]: child_process.ChildProcess; } = {};
 	constructor(context: vs.ExtensionContext, sdks: Sdks, analytics: Analytics) {
@@ -85,18 +86,21 @@ export class SdkCommands {
 		}));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.screenshot", async (uri) => {
 			if (!uri || !(uri instanceof Uri)) {
-				var selectedFolder =
-					await window.showOpenDialog({ canSelectFolders: true, canSelectMany: false, openLabel: "Select folder to save screenshot" });
 
-				if (selectedFolder && selectedFolder.length > 0) {
-					uri = selectedFolder[0].path
-				} else {
-					// Do nothing if the user canceled the folder selection
-					return
+				// Only prompt the user if variable has never been set
+				if (!this.screenshotUri) {
+					var selectedFolder =
+						await window.showOpenDialog({ canSelectFolders: true, canSelectMany: false, openLabel: "Select folder to save screenshot" });
+					if (selectedFolder && selectedFolder.length > 0) {
+						this.screenshotUri = selectedFolder[0].path
+					} else {
+						// Do nothing if the user canceled the folder selection
+						return
+					}
 				}
 			}
 
-			return this.runFlutterInFolder(uri, ["screenshot"], "screenshot");
+			return this.runFlutterInFolder(this.screenshotUri, ["screenshot"], "screenshot");
 		}));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.packages.upgrade", (selection) => {
 			return vs.commands.executeCommand("dart.upgradePackages", selection);

--- a/src/commands/sdk.ts
+++ b/src/commands/sdk.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as vs from "vscode";
-import { ProgressLocation, Uri } from "vscode";
+import { ProgressLocation, Uri, window } from "vscode";
 import { Analytics } from "../analytics";
 import { config } from "../config";
 import { globalFlutterArgs, safeSpawn } from "../debug/utils";
@@ -12,7 +12,7 @@ import { DartHoverProvider } from "../providers/dart_hover_provider";
 import { DartSdkManager, FlutterSdkManager } from "../sdk/sdk_manager";
 import { dartPubPath, flutterPath, showFlutterActivationFailure } from "../sdk/utils";
 import * as util from "../utils";
-import { ProjectType, Sdks, fsPath, isFlutterWorkspaceFolder } from "../utils";
+import { fsPath, isFlutterWorkspaceFolder, ProjectType, Sdks } from "../utils";
 import * as channels from "./channels";
 
 const flutterNameRegex = new RegExp("^[a-z][a-z0-9_]*$");
@@ -82,6 +82,21 @@ export class SdkCommands {
 				// TODO: Move this to a reusable event.
 				DartHoverProvider.clearPackageMapCaches();
 			}
+		}));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.screenshot", async (uri) => {
+			if (!uri || !(uri instanceof Uri)) {
+				var selectedFolder =
+					await window.showOpenDialog({ canSelectFolders: true, canSelectMany: false, openLabel: "Select folder to save screenshot" });
+
+				if (selectedFolder && selectedFolder.length > 0) {
+					uri = selectedFolder[0].path
+				} else {
+					// Do nothing if the user canceled the folder selection
+					return
+				}
+			}
+
+			return this.runFlutterInFolder(uri, ["screenshot"], "screenshot");
 		}));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.packages.upgrade", (selection) => {
 			return vs.commands.executeCommand("dart.upgradePackages", selection);


### PR DESCRIPTION
This is another approach to the screenshot issue in #657. Its a work in progress, but what's working so far is:
- On command activation the folder selection pops up (only the first time);
-  If a selection has been triggered before, the folder selection does not popup and it saves to the latest location selected.

TODO:
- Change `screenshotUri` to be a setting and configurable by the user;
- Guarantee that if the setting is filled, the folder selection popup does not appear and the screenshot file goes to the settings path.

Any ideas or suggestions please let me know!