### PR TITLE
Add Flutter screenshot command

### DIFF
--- a/package.json
+++ b/package.json
@@ -433,6 +433,10 @@
 				{
 					"command": "flutter.openInXcode",
 					"when": "false"
+				},
+				{
+					"command": "flutter.screenshot",
+					"when": "dart-code:flutterProjectLoaded && inDebugMode"
 				}
 			],
 			"editor/title": [
@@ -705,8 +709,7 @@
 				},
 				"dart.flutterScreenshotPath": {
 					"type": "string",
-					"default": "",
-					"description": "The location where screenshots will be stored. If blank, Dart Code will attempt to store it in the user's home directory.",
+					"description": "The path to a directory to save Flutter screenshots.",
 					"scope": "window"
 				},
 				"dart.flutterSdkPath": {

--- a/package.json
+++ b/package.json
@@ -238,6 +238,11 @@
 				"category": "Flutter"
 			},
 			{
+				"command": "flutter.screenshot",
+				"title": "Save Screenshot",
+				"category": "Flutter"
+			},
+			{
 				"command": "flutter.hotRestart",
 				"title": "Hot Restart",
 				"category": "Flutter"

--- a/package.json
+++ b/package.json
@@ -703,6 +703,12 @@
 					"description": "Whether to show the names of linter rules in the problems panel to make it easier to `// ignore:`.",
 					"scope": "window"
 				},
+				"dart.flutterScreenshotPath": {
+					"type": "string",
+					"default": "",
+					"description": "The location where screenshots will be stored. If blank, Dart Code will attempt to store it in the user's home directory.",
+					"scope": "window"
+				},
 				"dart.flutterSdkPath": {
 					"type": "string",
 					"description": "The location of the Flutter SDK to use. If blank, Dart Code will attempt to find it from the project folder, FLUTTER_ROOT environment variable and the PATH environment variable.",

--- a/src/commands/sdk.ts
+++ b/src/commands/sdk.ts
@@ -264,8 +264,6 @@ export class SdkCommands {
 	}
 
 	private async createFlutterScreenshot(): Promise<void> {
-		// TODO: default screenshot path to a sane default on Windows, Linux, Mac OS
-
 		// get screenshot path
 		let screenshotPath = config.flutterScreenshotPath;
 

--- a/src/commands/sdk.ts
+++ b/src/commands/sdk.ts
@@ -89,7 +89,8 @@ export class SdkCommands {
 			if (!uri || !(uri instanceof Uri)) {
 
 				// If there is no path for this session, or it differs from config, use the one from config.
-				if (!this.flutterScreenshotPath || this.flutterScreenshotPath !== config.flutterScreenshotPath) {
+				if (!this.flutterScreenshotPath ||
+					(config.flutterScreenshotPath && this.flutterScreenshotPath !== config.flutterScreenshotPath)) {
 					this.flutterScreenshotPath = config.flutterScreenshotPath;
 					shouldNotify = true;
 				}

--- a/src/commands/sdk.ts
+++ b/src/commands/sdk.ts
@@ -270,16 +270,14 @@ export class SdkCommands {
 		let screenshotPath = config.flutterScreenshotPath;
 
 		// if it's not valid or missing, save it in the user's home directory
-		if (screenshotPath === "")
+		if (screenshotPath == null) {
 			screenshotPath = os.homedir();
+		}
 
 		// if folder doesn't exist, create it
 		if (!fs.existsSync(screenshotPath)) {
 			fs.mkdirSync(screenshotPath);
 		}
-
-		// construct a filename in format Screenshot %yyyy-mm-dd at %hh:mm
-		// const screenshotFilename = "Screenshot " + Date.now.toString();
 
 		// invoke flutter screenshot with the Uri
 		const screenshotUri = vs.Uri.file(screenshotPath);

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,8 @@ class Config {
 	get flutterCreateOrganization() { return this.getConfig<string>("flutterCreateOrganization"); }
 	get flutterDaemonLogFile() { return createFolderForFile(resolvePaths(this.getConfig<string>("flutterDaemonLogFile"))); }
 	get flutterHotReloadOnSave() { return this.getConfig<boolean>("flutterHotReloadOnSave"); }
+	get flutterScreenshotPath() { return resolvePaths(this.getConfig<string>("flutterScreenshotPath")); }
+	public setFlutterScreenshotPath(value: string): Thenable<void> { return this.setConfig("flutterScreenshotPath", value, ConfigurationTarget.Workspace); }
 	get flutterSdkPath() { return resolvePaths(this.getConfig<string>("flutterSdkPath")); }
 	public setFlutterSdkPath(value: string): Thenable<void> { return this.setConfig("flutterSdkPath", value, ConfigurationTarget.Workspace); }
 	get flutterSdkPaths() { return (this.getConfig<string[]>("flutterSdkPaths") || []).map(resolvePaths); }


### PR DESCRIPTION
- [x] make the command only valid during a debug session
- [x] only show the notification on the first screenshot, showing just the folder name and a button to open that folder - if you're taking lots the notifications might otherwise be a bit noisey
- [x] maybe prompt the user when there's no screenshot path in config, but open the save dialog in their home dir, so they can just hit <enter> if that's where they want it, but otherwise they feel they have some control over it (not many people review the settings)