### PR TITLE
Support launching the analysis server on a remote machine over SSH

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -199,12 +199,6 @@
 			"integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
 			"dev": true
 		},
-		"@types/shell-escape": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@types/shell-escape/-/shell-escape-0.2.0.tgz",
-			"integrity": "sha512-7kUdtJtUylvyISJbe9FMcvMTjRdP0EvNDO1WbT0lT22k/IPBiPRTpmWaKu5HTWLCGLQRWVHrzVHZktTDvvR23g==",
-			"dev": true
-		},
 		"@types/sinon": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.3.1.tgz",
@@ -4625,11 +4619,6 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
 			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-		},
-		"shell-escape": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
-			"integrity": "sha1-aP0CXrBJC09WegJ/C/IkgLX4QTM="
 		},
 		"signal-exit": {
 			"version": "3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -199,6 +199,12 @@
 			"integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
 			"dev": true
 		},
+		"@types/shell-escape": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@types/shell-escape/-/shell-escape-0.2.0.tgz",
+			"integrity": "sha512-7kUdtJtUylvyISJbe9FMcvMTjRdP0EvNDO1WbT0lT22k/IPBiPRTpmWaKu5HTWLCGLQRWVHrzVHZktTDvvR23g==",
+			"dev": true
+		},
 		"@types/sinon": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.3.1.tgz",
@@ -4619,6 +4625,11 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
 			"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+		},
+		"shell-escape": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
+			"integrity": "sha1-aP0CXrBJC09WegJ/C/IkgLX4QTM="
 		},
 		"signal-exit": {
 			"version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -905,7 +905,6 @@
 		"glob": "^7.1.2",
 		"lodash": "^4.17.10",
 		"semver": "^5.5.0",
-		"shell-escape": "^0.2.0",
 		"vscode-debugadapter": "^1.29.0",
 		"vscode-debugprotocol": "^1.29.0",
 		"ws": "^1.1.5"
@@ -916,7 +915,6 @@
 		"@types/mocha": "^5.1.0",
 		"@types/node": "^6.0.107",
 		"@types/semver": "^5.5.0",
-		"@types/shell-escape": "^0.2.0",
 		"@types/sinon": "^4.3.0",
 		"@types/ws": "^0.0.38",
 		"mocha": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -700,6 +700,12 @@
 					"description": "The path to a log file for the Dart analysis server built-in instrumentation.\nThis is a diagnostic setting that should not normally be set.",
 					"scope": "window"
 				},
+				"dart.analyzerSshHost": {
+					"type": "string",
+					"default": null,
+					"description": "An SSH host to run the analysis server.\nThis can be useful when modifying code on a remote machine using SSHFS.",
+					"scope": "window"
+				},
 				"dart.extensionLogFile": {
 					"type": "string",
 					"description": "The path to a log file for the Dart Code extension.\nThis is a diagnostic setting that should not normally be set.",
@@ -717,6 +723,7 @@
 				},
 				"dart.analyzerPath": {
 					"type": "string",
+					"default": null,
 					"description": "The path to a custom Dart analysis server.\nThis is a diagnostic setting that should not normally be set.",
 					"scope": "window"
 				},
@@ -898,6 +905,7 @@
 		"glob": "^7.1.2",
 		"lodash": "^4.17.10",
 		"semver": "^5.5.0",
+		"shell-escape": "^0.2.0",
 		"vscode-debugadapter": "^1.29.0",
 		"vscode-debugprotocol": "^1.29.0",
 		"ws": "^1.1.5"
@@ -908,6 +916,7 @@
 		"@types/mocha": "^5.1.0",
 		"@types/node": "^6.0.107",
 		"@types/semver": "^5.5.0",
+		"@types/shell-escape": "^0.2.0",
 		"@types/sinon": "^4.3.0",
 		"@types/ws": "^0.0.38",
 		"mocha": "^5.1.0",

--- a/src/analysis/analyzer.ts
+++ b/src/analysis/analyzer.ts
@@ -1,9 +1,8 @@
 import * as _ from "lodash";
-import * as shellEscape from "shell-escape";
 import * as vs from "vscode";
 import { config } from "../config";
 import { PromiseCompleter } from "../debug/utils";
-import { extensionVersion, reloadExtension, versionIsAtLeast } from "../utils";
+import { escapeShell, extensionVersion, reloadExtension, versionIsAtLeast } from "../utils";
 import { logError } from "../utils/log";
 import * as as from "./analysis_server_types";
 import { AnalyzerGen } from "./analyzer_gen";
@@ -83,22 +82,22 @@ export class Analyzer extends AnalyzerGen {
 		// Register for version.
 		this.registerForServerConnected((e) => { this.version = e.version; this.capabilities.version = this.version; });
 
-		var binaryPath = dartVMPath;
-		var processArgs = _.clone(analyzerArgs);
+		let binaryPath = dartVMPath;
+		let processArgs = _.clone(analyzerArgs);
 
 		// Since we communicate with the analysis server over STDOUT/STDIN, it is trivial for us
 		// to support launching it on a remote machine over SSH. This can be useful if the codebase
 		// is being modified remotely over SSHFS, and running the analysis server locally would
 		// result in excessive file reading over SSHFS.
 		if (config.analyzerSshHost) {
-			binaryPath = 'ssh';
+			binaryPath = "ssh";
 			processArgs.unshift(dartVMPath);
 			processArgs = [
 				// SSH quiet mode, which prevents SSH from interfering with the STDOUT/STDIN communication
 				// with the analysis server.
 				"-q",
 				config.analyzerSshHost,
-				shellEscape(processArgs)
+				escapeShell(processArgs),
 			];
 		}
 

--- a/src/analysis/analyzer.ts
+++ b/src/analysis/analyzer.ts
@@ -1,3 +1,5 @@
+import * as _ from "lodash";
+import * as shellEscape from "shell-escape";
 import * as vs from "vscode";
 import { config } from "../config";
 import { PromiseCompleter } from "../debug/utils";
@@ -48,31 +50,31 @@ export class Analyzer extends AnalyzerGen {
 	constructor(dartVMPath: string, analyzerPath: string) {
 		super(() => config.analyzerLogFile);
 
-		let args = [];
+		let analyzerArgs = [];
 
 		// Optionally start Observatory for the analyzer.
 		if (config.analyzerObservatoryPort)
-			args.push(`--observe=${config.analyzerObservatoryPort}`);
+			analyzerArgs.push(`--observe=${config.analyzerObservatoryPort}`);
 
-		args.push(analyzerPath);
+		analyzerArgs.push(analyzerPath);
 
 		// Optionally start the analyzer's diagnostic web server on the given port.
 		if (config.analyzerDiagnosticsPort)
-			args.push(`--port=${config.analyzerDiagnosticsPort}`);
+			analyzerArgs.push(`--port=${config.analyzerDiagnosticsPort}`);
 
 		// Add info about the extension that will be collected for crash reports etc.
-		args.push(`--client-id=Dart-Code.dart-code`);
-		args.push(`--client-version=${extensionVersion}`);
+		analyzerArgs.push(`--client-id=Dart-Code.dart-code`);
+		analyzerArgs.push(`--client-version=${extensionVersion}`);
 
 		// The analysis server supports a verbose instrumentation log file.
 		if (config.analyzerInstrumentationLogFile)
-			args.push(`--instrumentation-log-file=${config.analyzerInstrumentationLogFile}`);
+			analyzerArgs.push(`--instrumentation-log-file=${config.analyzerInstrumentationLogFile}`);
 
 		// Allow arbitrary args to be passed to the analysis server.
 		if (config.analyzerAdditionalArgs)
-			args = args.concat(config.analyzerAdditionalArgs);
+			analyzerArgs = analyzerArgs.concat(config.analyzerAdditionalArgs);
 
-		this.launchArgs = args;
+		this.launchArgs = analyzerArgs;
 
 		// Hook error subscriptions so we can try and get diagnostic info if this happens.
 		this.registerForServerError((e) => this.requestDiagnosticsUpdate());
@@ -81,7 +83,26 @@ export class Analyzer extends AnalyzerGen {
 		// Register for version.
 		this.registerForServerConnected((e) => { this.version = e.version; this.capabilities.version = this.version; });
 
-		this.createProcess(undefined, dartVMPath, args);
+		var binaryPath = dartVMPath;
+		var processArgs = _.clone(analyzerArgs);
+
+		// Since we communicate with the analysis server over STDOUT/STDIN, it is trivial for us
+		// to support launching it on a remote machine over SSH. This can be useful if the codebase
+		// is being modified remotely over SSHFS, and running the analysis server locally would
+		// result in excessive file reading over SSHFS.
+		if (config.analyzerSshHost) {
+			binaryPath = 'ssh';
+			processArgs.unshift(dartVMPath);
+			processArgs = [
+				// SSH quiet mode, which prevents SSH from interfering with the STDOUT/STDIN communication
+				// with the analysis server.
+				"-q",
+				config.analyzerSshHost,
+				shellEscape(processArgs)
+			];
+		}
+
+		this.createProcess(undefined, binaryPath, processArgs);
 
 		this.serverSetSubscriptions({
 			subscriptions: ["STATUS"],

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { ConfigurationTarget, Uri, WorkspaceConfiguration, workspace } from "vscode";
+import { ConfigurationTarget, Uri, workspace, WorkspaceConfiguration } from "vscode";
 import { createFolderIfRequired, resolvePaths } from "./utils";
 
 class Config {
@@ -31,6 +31,7 @@ class Config {
 	get analysisServerFolding() { return this.getConfig<boolean>("analysisServerFolding"); }
 	get analyzerInstrumentationLogFile() { return createFolderIfRequired(resolvePaths(this.getConfig<string>("analyzerInstrumentationLogFile"))); }
 	get analyzerAdditionalArgs() { return this.getConfig<string[]>("analyzerAdditionalArgs"); }
+	get analyzerSshHost() { return this.getConfig<string>("analyzerSshHost"); }
 	get checkForSdkUpdates() { return this.getConfig<boolean>("checkForSdkUpdates"); }
 	get closingLabels() { return this.getConfig<boolean>("closingLabels"); }
 	get flutterDaemonLogFile() { return createFolderIfRequired(resolvePaths(this.getConfig<string>("flutterDaemonLogFile"))); }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,7 @@ import { analyzerSnapshotPath, dartVMPath, findSdks, flutterPath, handleMissingS
 import { showUserPrompts } from "./user_prompts";
 import * as util from "./utils";
 import { fsPath } from "./utils";
-import { LogCategory, addToLogHeader, clearLogHeader, log, logError, logTo } from "./utils/log";
+import { addToLogHeader, clearLogHeader, log, LogCategory, logError, logTo } from "./utils/log";
 import { DartPackagesProvider } from "./views/packages_view";
 import { TestResultsProvider } from "./views/test_view";
 
@@ -121,7 +121,9 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 	// Fire up the analyzer process.
 	const analyzerStartTime = new Date();
 	const analyzerPath = config.analyzerPath || path.join(sdks.dart, analyzerSnapshotPath);
-	if (!fs.existsSync(analyzerPath)) {
+	// If the ssh host is set, then we are running the analyzer on a remote machine, that same analyzer
+	// might not exist on the local machine.
+	if (!config.analyzerSshHost && !fs.existsSync(analyzerPath)) {
 		vs.window.showErrorMessage("Could not find a Dart Analysis Server at " + analyzerPath);
 		return;
 	}

--- a/src/sdk/utils.ts
+++ b/src/sdk/utils.ts
@@ -137,7 +137,7 @@ export function findSdks(): Sdks {
 			flutter: null,
 			fuchsia: null,
 			projectType: ProjectType.Dart,
-		}
+		};
 	}
 
 	let fuchsiaRoot: string;

--- a/src/sdk/utils.ts
+++ b/src/sdk/utils.ts
@@ -1,11 +1,11 @@
 import * as fs from "fs";
 import * as path from "path";
-import { ExtensionContext, commands, window } from "vscode";
+import { commands, ExtensionContext, window } from "vscode";
 import { Analytics } from "../analytics";
 import { config } from "../config";
 import { PackageMap } from "../debug/package_map";
 import { isWin, platformName } from "../debug/utils";
-import { FLUTTER_CREATE_PROJECT_TRIGGER_FILE, ProjectType, Sdks, fsPath, getDartWorkspaceFolders, openInBrowser, reloadExtension, resolvePaths } from "../utils";
+import { FLUTTER_CREATE_PROJECT_TRIGGER_FILE, fsPath, getDartWorkspaceFolders, openInBrowser, ProjectType, reloadExtension, resolvePaths, Sdks } from "../utils";
 import { log } from "../utils/log";
 
 const dartExecutableName = isWin ? "dart.exe" : "dart";
@@ -127,6 +127,18 @@ export function findSdks(): Sdks {
 	log("Environment PATH:");
 	for (const p of paths)
 		log(`    ${p}`);
+
+	// If we are running the analyzer remotely over SSH, we only support an analyzer, since none
+	// of the other SDKs will work remotely. Also, there is no need to validate the sdk path,
+	// since that file will exist on a remote machine.
+	if (config.analyzerSshHost) {
+		return {
+			dart: config.sdkPath,
+			flutter: null,
+			fuchsia: null,
+			projectType: ProjectType.Dart,
+		}
+	}
 
 	let fuchsiaRoot: string;
 	let flutterProject: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import * as https from "https";
 import * as os from "os";
 import * as path from "path";
 import * as semver from "semver";
-import { Position, Range, TextDocument, Uri, WorkspaceFolder, commands, window, workspace } from "vscode";
+import { commands, Position, Range, TextDocument, Uri, window, workspace, WorkspaceFolder } from "vscode";
 import { config } from "./config";
 import { forceWindowsDriveLetterToUppercase } from "./debug/utils";
 import { referencesFlutterSdk } from "./sdk/utils";
@@ -217,6 +217,22 @@ export function escapeRegExp(input: string) {
 	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 	return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
 }
+
+// return a shell compatible format
+export function escapeShell(args : string[]) {
+	let ret : string[] = [];
+  
+	args.forEach(function(arg) {
+	  if (/[^A-Za-z0-9_\/:=-]/.test(arg)) {
+		arg = "'"+arg.replace(/'/g,"'\\''")+"'";
+		arg = arg.replace(/^(?:'')+/g, '') // unduplicate single-quote at the beginning
+		  .replace(/\\'''/g, "\\'" ); // remove non-escaped single-quote if there are enclosed between 2 escaped
+	  }
+	  ret.push(arg);
+	});
+  
+	return ret.join(' ');
+  }
 
 export function openInBrowser(url: string) {
 	commands.executeCommand("vscode.open", Uri.parse(url));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -218,21 +218,21 @@ export function escapeRegExp(input: string) {
 	return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // $& means the whole matched string
 }
 
-// return a shell compatible format
-export function escapeShell(args : string[]) {
-	let ret : string[] = [];
-  
-	args.forEach(function(arg) {
-	  if (/[^A-Za-z0-9_\/:=-]/.test(arg)) {
-		arg = "'"+arg.replace(/'/g,"'\\''")+"'";
-		arg = arg.replace(/^(?:'')+/g, '') // unduplicate single-quote at the beginning
-		  .replace(/\\'''/g, "\\'" ); // remove non-escaped single-quote if there are enclosed between 2 escaped
-	  }
-	  ret.push(arg);
+// Escapes a set of command line arguments so that the escaped string is suitable for passing as an argument
+// to another shell command.
+// Implementation is taken from https://github.com/xxorax/node-shell-escape
+export function escapeShell(args: string[]) {
+	const ret: string[] = [];
+	args.forEach((arg) => {
+		if (/[^A-Za-z0-9_\/:=-]/.test(arg)) {
+			arg = "'" + arg.replace(/'/g, "'\\''") + "'";
+			arg = arg.replace(/^(?:'')+/g, "") // unduplicate single-quote at the beginning
+				.replace(/\\'''/g, "\\'" ); // remove non-escaped single-quote if there are enclosed between 2 escaped
+		}
+		ret.push(arg);
 	});
-  
-	return ret.join(' ');
-  }
+	return ret.join(" ");
+}
 
 export function openInBrowser(url: string) {
 	commands.executeCommand("vscode.open", Uri.parse(url));


### PR DESCRIPTION
In certain environments, it is preferable to modify files remotely over
SSHFS, rather than copying dart files locally. In my case, corporate
policies prevent me from copying source files to a laptop. However, I am
allowed to mount directories from my workstation using SSHFS. Dart-Code
works out of the box this way, but its performance is severely limited
by the analysis server needing to crawl the entire source tree over
SSHFS.

Because the analysis server communicates over STDIN/STDOUT, it is
trivial to instead launch the analysis server on a remote machine using
SSHFS. Other SDK integrations such as flutter and fuschia will not work
properly in these environments, but just launching the analysis server
for code intelligence works wonderfully. The only additional limitation
for such an environment is that the mounted SSHFS file system is present
at the exact same directory path on both the local and remote machines.

VSCode's typescript support is automatically re-arranging some of the import orders. If you would prefer me to undo these changes I will.