### PR TITLE
Initial implementation of `Debug: Attach to Flutter Process`

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,11 @@
 				"category": "Debug"
 			},
 			{
+				"command": "flutter.attach",
+				"title": "Attach to Flutter Process",
+				"category": "Debug"
+			},
+			{
 				"command": "dart.goToSuper",
 				"title": "Go to Super Class/Method",
 				"category": "Dart"
@@ -352,6 +357,10 @@
 				{
 					"command": "dart.attach",
 					"when": "dart-code:dartProjectLoaded && !inDebugMode"
+				},
+				{
+					"command": "flutter.attach",
+					"when": "dart-code:flutterProjectLoaded && !inDebugMode && dart-code:flutterSupportsAttach"
 				},
 				{
 					"command": "dart.sortMembers",

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -18,6 +18,7 @@ let debugModeBannerEnabled = true;
 let paintBaselinesEnabled = false;
 let widgetInspectorEnabled = false;
 const debugSessions: DartDebugSessionInformation[] = [];
+export let mostRecentAttachedProbablyReusableObservatoryUri: string;
 
 export class LastDebugSession {
 	public static workspaceFolder: vs.WorkspaceFolder = null;
@@ -67,6 +68,11 @@ export class DebugCommands {
 				}
 			} else if (e.event === "dart.observatoryUri") {
 				session.observatoryUri = e.body.observatoryUri;
+				if (e.body.isProbablyReconnectable) {
+					mostRecentAttachedProbablyReusableObservatoryUri = session.observatoryUri;
+				} else {
+					mostRecentAttachedProbablyReusableObservatoryUri = undefined;
+				}
 			} else if (e.event === "dart.log") {
 				handleDebugLogEvent(e.event, e.body);
 			} else if (e.event === "dart.restartRequest") {

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -253,6 +253,14 @@ export class DebugCommands {
 				type: "dart",
 			});
 		}));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.attach", () => {
+			vs.debug.startDebugging(undefined, {
+				name: "Flutter: Attach to Process",
+				previewFlutterAttach: true,
+				request: "attach",
+				type: "dart",
+			});
+		}));
 	}
 
 	private async promptForDebugSession(): Promise<DartDebugSessionInformation | undefined> {

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -18,7 +18,7 @@ let debugModeBannerEnabled = true;
 let paintBaselinesEnabled = false;
 let widgetInspectorEnabled = false;
 const debugSessions: DartDebugSessionInformation[] = [];
-export let mostRecentAttachedProbablyReusableObservatoryUri: string;
+// export let mostRecentAttachedProbablyReusableObservatoryUri: string;
 
 export class LastDebugSession {
 	public static workspaceFolder: vs.WorkspaceFolder = null;
@@ -68,11 +68,11 @@ export class DebugCommands {
 				}
 			} else if (e.event === "dart.observatoryUri") {
 				session.observatoryUri = e.body.observatoryUri;
-				if (e.body.isProbablyReconnectable) {
-					mostRecentAttachedProbablyReusableObservatoryUri = session.observatoryUri;
-				} else {
-					mostRecentAttachedProbablyReusableObservatoryUri = undefined;
-				}
+				// if (e.body.isProbablyReconnectable) {
+				// 	mostRecentAttachedProbablyReusableObservatoryUri = session.observatoryUri;
+				// } else {
+				// 	mostRecentAttachedProbablyReusableObservatoryUri = undefined;
+				// }
 			} else if (e.event === "dart.log") {
 				handleDebugLogEvent(e.event, e.body);
 			} else if (e.event === "dart.restartRequest") {

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -256,7 +256,6 @@ export class DebugCommands {
 		context.subscriptions.push(vs.commands.registerCommand("flutter.attach", () => {
 			vs.debug.startDebugging(undefined, {
 				name: "Flutter: Attach to Process",
-				previewFlutterAttach: true,
 				request: "attach",
 				type: "dart",
 			});

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -304,7 +304,7 @@ export class DartDebugSession extends DebugSession {
 		});
 	}
 
-	private async terminate(force: boolean): Promise<void> {
+	protected async terminate(force: boolean): Promise<void> {
 		const signal = force ? "SIGKILL" : "SIGINT";
 		const request = force ? "DISC" : "TERM";
 		if (!this.didAttach && this.childProcess != null && !this.processExited) {
@@ -382,7 +382,10 @@ export class DartDebugSession extends DebugSession {
 	): Promise<void> {
 		this.log(`Disconnect requested!`);
 		try {
-			await this.terminate(true);
+			await Promise.race([
+				this.terminate(false),
+				new Promise((resolve) => setTimeout(resolve, 2000)).then(() => this.terminate(true)),
+			]);
 		} catch (e) {
 			return this.errorResponse(response, `${e}`);
 		}

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -40,7 +40,7 @@ export class DartDebugSession extends DebugSession {
 	protected processExit: Promise<void> = Promise.resolve();
 	protected maxLogLineLength: number;
 	protected shouldKillProcessOnTerminate = true;
-	protected observatoryUriIsProbablyReconnectable = false;
+	// protected observatoryUriIsProbablyReconnectable = false;
 
 	public constructor() {
 		super();
@@ -130,7 +130,7 @@ export class DartDebugSession extends DebugSession {
 			return this.errorResponse(response, "Unable to attach; no Observatory address provided.");
 		}
 
-		this.observatoryUriIsProbablyReconnectable = true;
+		// this.observatoryUriIsProbablyReconnectable = true;
 		this.shouldKillProcessOnTerminate = false;
 		this.cwd = args.cwd;
 		this.debugSdkLibraries = args.debugSdkLibraries;
@@ -231,7 +231,7 @@ export class DartDebugSession extends DebugSession {
 					// If we won't be killing the process on terminate, then it's likely the
 					// process will remain around and can be reconnected to, so let the
 					// editor know that it should stash this URL for easier re-attaching.
-					isProbablyReconnectable: this.observatoryUriIsProbablyReconnectable,
+					// isProbablyReconnectable: this.observatoryUriIsProbablyReconnectable,
 					observatoryUri: browserFriendlyUri.toString(),
 				}));
 			}

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -39,7 +39,7 @@ export class DartDebugSession extends DebugSession {
 	protected pollforMemoryMs?: number; // If set, will poll for memory usage and send events back.
 	protected processExit: Promise<void> = Promise.resolve();
 	protected maxLogLineLength: number;
-	protected didAttach = false;
+	protected shouldKillProcessOnTerminate = true;
 
 	public constructor() {
 		super();
@@ -75,7 +75,7 @@ export class DartDebugSession extends DebugSession {
 		// Force relative paths to absolute.
 		if (args.program && !path.isAbsolute(args.program))
 			args.program = path.join(args.cwd, args.program);
-		this.didAttach = false;
+		this.shouldKillProcessOnTerminate = true;
 		this.cwd = args.cwd;
 		this.packageMap = new PackageMap(PackageMap.findPackagesFile(args.program || args.cwd));
 		this.debugSdkLibraries = args.debugSdkLibraries;
@@ -129,7 +129,7 @@ export class DartDebugSession extends DebugSession {
 			return this.errorResponse(response, "Unable to attach; no Observatory address provided.");
 		}
 
-		this.didAttach = true;
+		this.shouldKillProcessOnTerminate = false;
 		this.cwd = args.cwd;
 		this.debugSdkLibraries = args.debugSdkLibraries;
 		this.debugExternalLibraries = args.debugExternalLibraries;
@@ -307,7 +307,8 @@ export class DartDebugSession extends DebugSession {
 	protected async terminate(force: boolean): Promise<void> {
 		const signal = force ? "SIGKILL" : "SIGINT";
 		const request = force ? "DISC" : "TERM";
-		if (!this.didAttach && this.childProcess != null && !this.processExited) {
+		this.log(`${request}: Going to terminate with ${signal}...`);
+		if (this.shouldKillProcessOnTerminate && this.childProcess != null && !this.processExited) {
 			for (const pid of this.additionalPidsToTerminate) {
 				try {
 					this.log(`${request}: Terminating related process ${pid} with ${signal}...`);
@@ -329,7 +330,7 @@ export class DartDebugSession extends DebugSession {
 			// test finish) so we may need to send again it we get another disconnectRequest.
 			// We also use childProcess == null to mean we're attached.
 			// this.childProcess = undefined;
-		} else if (this.didAttach && this.observatory) {
+		} else if (!this.shouldKillProcessOnTerminate && this.observatory) {
 			try {
 				this.log(`${request}: Disconnecting from process...`);
 				// Remove all breakpoints from the VM.

--- a/src/debug/dart_debug_protocol.ts
+++ b/src/debug/dart_debug_protocol.ts
@@ -53,6 +53,7 @@ export interface VMIsolate extends VMResponse, VMIsolateRef {
 	libraries: VMLibraryRef[];
 	_heaps?: { new: VMHeapSpace, old: VMHeapSpace };
 	rootLib?: VMLibraryRef;
+	extensionRPCs?: string[];
 }
 
 export interface VMObjectRef extends VMResponse {

--- a/src/debug/dart_debug_protocol.ts
+++ b/src/debug/dart_debug_protocol.ts
@@ -317,7 +317,7 @@ export class RPCError {
 }
 
 export class ObservatoryConnection {
-	public static bannerRegex: RegExp = new RegExp("Observatory listening on (http:.+)");
+	public static bannerRegex: RegExp = new RegExp("Observatory (?:listening on|.* is available at:) (http:.+)");
 	public static httpLinkRegex: RegExp = new RegExp("(http://[\\d\\.:]+/)");
 
 	public socket: WebSocket;

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -38,7 +38,7 @@ export class FlutterDebugSession extends DartDebugSession {
 	protected async attachRequest(response: DebugProtocol.AttachResponse, args: any): Promise<void> {
 		// For flutter attach, we actually do the same thing as launch - we run a flutter process
 		// (flutter attach instead of flutter run).
-		this.observatoryUriIsProbablyReconnectable = true;
+		// this.observatoryUriIsProbablyReconnectable = true;
 		this.launchRequest(response, args);
 	}
 

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -38,6 +38,7 @@ export class FlutterDebugSession extends DartDebugSession {
 	protected async attachRequest(response: DebugProtocol.AttachResponse, args: any): Promise<void> {
 		// For flutter attach, we actually do the same thing as launch - we run a flutter process
 		// (flutter attach instead of flutter run).
+		this.observatoryUriIsProbablyReconnectable = true;
 		this.launchRequest(response, args);
 	}
 

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -113,10 +113,7 @@ export class FlutterDebugSession extends DartDebugSession {
 			this.initObservatory(this.observatoryUri);
 	}
 
-	protected async terminateRequest(
-		response: DebugProtocol.DisconnectResponse,
-		args: DebugProtocol.DisconnectArguments,
-	): Promise<void> {
+	protected async terminate(force: boolean): Promise<void> {
 		try {
 			if (this.currentRunningAppId && this.appHasStarted && this.flutter.mode === RunMode.Run)
 				// Wait up to 1000ms for app to quit since we often don't get a
@@ -128,7 +125,7 @@ export class FlutterDebugSession extends DartDebugSession {
 		} catch {
 			// Ignore failures here (see comment above).
 		}
-		await super.terminateRequest(response, args);
+		super.terminate(force);
 	}
 
 	protected restartRequest(

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -79,11 +79,12 @@ export class FlutterDebugSession extends DartDebugSession {
 			if (debug) {
 				appArgs.push("--start-paused");
 			}
+
+			if (this.flutterTrackWidgetCreation) {
+				appArgs.push("--track-widget-creation");
+			}
 		}
 
-		if (this.flutterTrackWidgetCreation) {
-			appArgs.push("--track-widget-creation");
-		}
 
 		if (args.args) {
 			appArgs = appArgs.concat(args.args);

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -85,7 +85,6 @@ export class FlutterDebugSession extends DartDebugSession {
 			}
 		}
 
-
 		if (args.args) {
 			appArgs = appArgs.concat(args.args);
 		}

--- a/src/debug/flutter_run.ts
+++ b/src/debug/flutter_run.ts
@@ -70,6 +70,10 @@ export class FlutterRun extends StdIOService<UnknownNotification> {
 		return this.sendRequest("app.restart", { appId, fullRestart: hotRestart === true, pause });
 	}
 
+	public detach(appId: string): Thenable<UnknownResponse> {
+		return this.sendRequest("app.detach", { appId });
+	}
+
 	public stop(appId: string): Thenable<UnknownResponse> {
 		return this.sendRequest("app.stop", { appId });
 	}

--- a/src/debug/flutter_run.ts
+++ b/src/debug/flutter_run.ts
@@ -3,10 +3,12 @@ import { StdIOService, UnknownNotification, UnknownResponse } from "../services/
 import { globalFlutterArgs, IAmDisposable, LogSeverity } from "./utils";
 
 export class FlutterRun extends StdIOService<UnknownNotification> {
-	constructor(flutterBinPath: string, projectFolder: string, args: string[], envOverrides: any, logFile: string, logger: (message: string, severity: LogSeverity) => void, maxLogLineLength: number) {
+	constructor(public mode: RunMode, flutterBinPath: string, projectFolder: string, args: string[], envOverrides: any, logFile: string, logger: (message: string, severity: LogSeverity) => void, maxLogLineLength: number) {
 		super(() => logFile, logger, maxLogLineLength, true, true);
 
-		this.createProcess(projectFolder, flutterBinPath, globalFlutterArgs.concat(["run", "--machine"]).concat(args), envOverrides);
+		const command = mode === RunMode.Attach ? "attach" : "run";
+
+		this.createProcess(projectFolder, flutterBinPath, globalFlutterArgs.concat([command, "--machine"]).concat(args), envOverrides);
 	}
 
 	protected shouldHandleMessage(message: string): boolean {
@@ -105,4 +107,9 @@ export class FlutterRun extends StdIOService<UnknownNotification> {
 	public registerForError(subscriber: (error: string) => void): IAmDisposable {
 		return this.subscribe(this.errorSubscriptions, subscriber);
 	}
+}
+
+export enum RunMode {
+	Run,
+	Attach,
 }

--- a/src/debug/utils.ts
+++ b/src/debug/utils.ts
@@ -175,6 +175,11 @@ export interface DartAttachRequestArguments extends DebugProtocol.AttachRequestA
 	observatoryLogFile: string;
 }
 
+export interface FlutterAttachRequestArguments extends DartAttachRequestArguments {
+	deviceId: string;
+	flutterPath: string;
+}
+
 export interface CoverageData {
 	scriptPath: string;
 	// Lines that were it. These are 1-based, unlike VS Code!

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,6 +62,7 @@ const HTML_MODE: vs.DocumentFilter[] = [{ language: "html", scheme: "file" }];
 
 const DART_PROJECT_LOADED = "dart-code:dartProjectLoaded";
 const FLUTTER_PROJECT_LOADED = "dart-code:flutterProjectLoaded";
+export const FLUTTER_SUPPORTS_ATTACH = "dart-code:flutterSupportsAttach";
 const DART_PLATFORM_NAME = "dart-code:platformName";
 export const SERVICE_EXTENSION_CONTEXT_PREFIX = "dart-code:serviceExtension.";
 export let extensionPath: string | undefined;
@@ -495,6 +496,7 @@ function getSettingsThatRequireRestart() {
 
 export async function deactivate(isRestart: boolean = false): Promise<void> {
 	setCommandVisiblity(false, null);
+	vs.commands.executeCommand("setContext", FLUTTER_SUPPORTS_ATTACH, false);
 	if (!isRestart) {
 		vs.commands.executeCommand("setContext", HAS_LAST_DEBUG_CONFIG, false);
 		await analytics.logExtensionShutdown();

--- a/src/flutter/device_manager.ts
+++ b/src/flutter/device_manager.ts
@@ -188,7 +188,6 @@ export class FlutterDeviceManager implements vs.Disposable {
 	private async launchEmulator(emulator: { id: string, name: string }): Promise<boolean> {
 		try {
 			await vs.window.withProgress({
-				cancellable: false,
 				location: vs.ProgressLocation.Notification,
 				title: `Launching ${emulator.name}...`,
 			}, async (progress) => {

--- a/src/flutter/flutter_daemon.ts
+++ b/src/flutter/flutter_daemon.ts
@@ -2,6 +2,7 @@ import * as vs from "vscode";
 import { ProgressLocation } from "vscode";
 import { config } from "../config";
 import { LogCategory, PromiseCompleter } from "../debug/utils";
+import { FLUTTER_SUPPORTS_ATTACH } from "../extension";
 import { StdIOService, UnknownNotification, UnknownResponse } from "../services/stdio_service";
 import { reloadExtension, versionIsAtLeast } from "../utils";
 import { log } from "../utils/log";
@@ -18,6 +19,7 @@ export class DaemonCapabilities {
 	}
 
 	get canCreateEmulators() { return versionIsAtLeast(this.version, "0.4.0"); }
+	get canFlutterAttach() { return versionIsAtLeast(this.version, "0.4.1"); }
 
 	// TODO: Remove this after the next beta update. We have some flakes (flutter run tests)
 	// due to the test device not starting up properly. Never seen on master, so assumed to be an
@@ -119,6 +121,7 @@ export class FlutterDaemon extends StdIOService<UnknownNotification> {
 				const params = evt.params as f.DaemonConnected;
 				this.additionalPidsToTerminate.push(params.pid);
 				this.capabilities.version = params.version;
+				vs.commands.executeCommand("setContext", FLUTTER_SUPPORTS_ATTACH, this.capabilities.canFlutterAttach);
 				break;
 			case "device.added":
 				this.notify(this.deviceAddedSubscriptions, evt.params as f.Device);

--- a/src/providers/debug_config_provider.ts
+++ b/src/providers/debug_config_provider.ts
@@ -91,7 +91,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 				}
 				return null; // null means open launch.json.
 			}
-		} else {
+		} else if (!debugConfig.previewFlutterAttach) {
 			// For attaching, the Observatory address must be specified. If it's not provided already, prompt for it.
 			debugConfig.observatoryUri = await this.getObservatoryUri(debugConfig.observatoryUri);
 
@@ -131,9 +131,11 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			}
 		}
 
-		// Disable Flutter mode for attach.
-		// TODO: Update FlutterDebugSession to understand attach mode, and remove this limitation.
-		const isFlutter = !isAttachRequest && this.sdks.projectType !== ProjectType.Dart
+		// Ensure we have a full path.
+		if (debugConfig.program && debugConfig.cwd && !path.isAbsolute(debugConfig.program))
+			debugConfig.program = path.join(debugConfig.cwd, debugConfig.program);
+
+		const isFlutter = (!isAttachRequest || debugConfig.previewFlutterAttach) && this.sdks.projectType !== ProjectType.Dart
 			&& debugConfig.cwd && isFlutterProjectFolder(debugConfig.cwd as string)
 			&& !isInsideFolderNamed(debugConfig.program, "bin") && !isInsideFolderNamed(debugConfig.program, "tool");
 		log(`Detected launch project as ${isFlutter ? "Flutter" : "Dart"}`);

--- a/src/providers/debug_config_provider.ts
+++ b/src/providers/debug_config_provider.ts
@@ -142,7 +142,9 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		// If we're attaching to Dart, ensure we get an observatory URI.
 		if (isAttachRequest) {
 			// For attaching, the Observatory address must be specified. If it's not provided already, prompt for it.
-			debugConfig.observatoryUri = await this.getObservatoryUri(debugConfig.observatoryUri, mostRecentAttachedProbablyReusableObservatoryUri);
+			if (!isFlutter) { // TEMP Condition because there's no point asking yet as the user doesn't know how to get this..
+				debugConfig.observatoryUri = await this.getObservatoryUri(debugConfig.observatoryUri, mostRecentAttachedProbablyReusableObservatoryUri);
+			}
 
 			if (!debugConfig.observatoryUri && !isFlutter) {
 				logWarn("No Observatory URI/port was provided");

--- a/src/providers/debug_config_provider.ts
+++ b/src/providers/debug_config_provider.ts
@@ -5,7 +5,7 @@ import * as vs from "vscode";
 import { CancellationToken, DebugConfiguration, DebugConfigurationProvider, ProviderResult, Uri, window, workspace, WorkspaceFolder } from "vscode";
 import { DebugSession } from "vscode-debugadapter";
 import { Analytics } from "../analytics";
-import { LastDebugSession, mostRecentAttachedProbablyReusableObservatoryUri } from "../commands/debug";
+import { LastDebugSession } from "../commands/debug";
 import { config, vsCodeVersion } from "../config";
 import { DartDebugSession } from "../debug/dart_debug_impl";
 import { DartTestDebugSession } from "../debug/dart_test_debug_impl";
@@ -143,7 +143,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		if (isAttachRequest) {
 			// For attaching, the Observatory address must be specified. If it's not provided already, prompt for it.
 			if (!isFlutter) { // TEMP Condition because there's no point asking yet as the user doesn't know how to get this..
-				debugConfig.observatoryUri = await this.getObservatoryUri(debugConfig.observatoryUri, mostRecentAttachedProbablyReusableObservatoryUri);
+				debugConfig.observatoryUri = await this.getObservatoryUri(debugConfig.observatoryUri/*, mostRecentAttachedProbablyReusableObservatoryUri*/);
 			}
 
 			if (!debugConfig.observatoryUri && !isFlutter) {

--- a/src/providers/debug_config_provider.ts
+++ b/src/providers/debug_config_provider.ts
@@ -71,6 +71,10 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			folder = workspace.getWorkspaceFolder(Uri.file(openFile));
 			if (folder)
 				log(`Setting workspace based on open file: ${fsPath(folder.uri)}`);
+		} else if (!folder && vs.workspace.workspaceFolders && vs.workspace.workspaceFolders.length === 1) {
+			folder = vs.workspace.workspaceFolders[0];
+			if (folder)
+				log(`Setting workspace based on single open workspace: ${fsPath(folder.uri)}`);
 		}
 
 		const isAttachRequest = debugConfig.request === "attach";

--- a/test/dart_only/debug/dart_cli.test.ts
+++ b/test/dart_only/debug/dart_cli.test.ts
@@ -5,7 +5,7 @@ import { isLinux, platformEol } from "../../../src/debug/utils";
 import { fsPath } from "../../../src/utils";
 import { log } from "../../../src/utils/log";
 import { DartDebugClient } from "../../dart_debug_client";
-import { ensureMapEntry, ensureVariable, ensureVariableWithIndex, spawnProcessPaused } from "../../debug_helpers";
+import { ensureMapEntry, ensureVariable, ensureVariableWithIndex, spawnDartProcessPaused } from "../../debug_helpers";
 import { activate, closeAllOpenFiles, defer, ext, extApi, getAttachConfiguration, getDefinition, getLaunchConfiguration, getPackages, helloWorldBrokenFile, helloWorldFolder, helloWorldGettersFile, helloWorldGoodbyeFile, helloWorldHttpFile, helloWorldMainFile, openFile, positionOf, sb } from "../../helpers";
 
 describe("dart cli debugger", () => {
@@ -28,7 +28,7 @@ describe("dart cli debugger", () => {
 	}
 
 	async function attachDebugger(observatoryUri: string, extraConfiguration?: { [key: string]: any }): Promise<vs.DebugConfiguration> {
-		const config = await getAttachConfiguration(observatoryUri, extraConfiguration);
+		const config = await getAttachConfiguration(Object.assign({ observatoryUri }, extraConfiguration));
 		await dc.start(config.debugServer);
 		return config;
 	}
@@ -510,7 +510,7 @@ describe("dart cli debugger", () => {
 		});
 
 		it("to a paused Dart script and can unpause to run it to completion", async () => {
-			const process = spawnProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
+			const process = spawnDartProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
 			const observatoryUri = await process.observatoryUri;
 
 			const config = await attachDebugger(observatoryUri);
@@ -522,7 +522,7 @@ describe("dart cli debugger", () => {
 		});
 
 		it("when provided only a port in launch.config", async () => {
-			const process = spawnProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
+			const process = spawnDartProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
 			const observatoryUri = await process.observatoryUri;
 			const observatoryPort = /:([0-9]+)\/?$/.exec(observatoryUri)[1];
 
@@ -536,7 +536,7 @@ describe("dart cli debugger", () => {
 		});
 
 		it("to the observatory uri provided by the user when not specified in launch.json", async () => {
-			const process = spawnProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
+			const process = spawnDartProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
 			const observatoryUri = await process.observatoryUri;
 
 			const showInputBox = sb.stub(vs.window, "showInputBox");
@@ -557,7 +557,7 @@ describe("dart cli debugger", () => {
 			if (!extApi.analyzerCapabilities.isDart2)
 				this.skip();
 
-			const process = spawnProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
+			const process = spawnDartProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
 			const observatoryUri = await process.observatoryUri;
 
 			const config = await attachDebugger(observatoryUri);
@@ -568,7 +568,7 @@ describe("dart cli debugger", () => {
 		});
 
 		it("and removes breakpoints and unpauses on detach", async () => {
-			const process = spawnProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
+			const process = spawnDartProcessPaused(await getLaunchConfiguration(helloWorldMainFile));
 			const observatoryUri = await process.observatoryUri;
 
 			const config = await attachDebugger(observatoryUri);

--- a/test/flutter_only/debug/flutter_run.test.ts
+++ b/test/flutter_only/debug/flutter_run.test.ts
@@ -14,11 +14,12 @@ import { activate, defer, delay, ext, extApi, flutterHelloWorldBrokenFile, flutt
 // https://github.com/flutter/flutter/issues/17838
 const disableDebuggingToAvoidBreakingOnCaughtException = true;
 
-describe("flutter run debugger", () => {
+describe("flutter run debugger (launch)", () => {
+	beforeEach("activate flutterHelloWorldMainFile", () => activate(flutterHelloWorldMainFile));
 	beforeEach("set timeout", function () {
 		this.timeout(60000); // These tests can be slow due to flutter package fetches when running.
 	});
-	beforeEach("activate flutterHelloWorldMainFile", () => activate(flutterHelloWorldMainFile));
+
 	beforeEach("skip if no test device", function () {
 		if (extApi.daemonCapabilities.flutterTesterMayBeFlaky)
 			this.skip();
@@ -49,7 +50,7 @@ describe("flutter run debugger", () => {
 	afterEach(() => watchPromise("Killing flutter_tester processes", killFlutterTester()));
 
 	async function startDebugger(script?: vs.Uri | string, cwd?: string): Promise<vs.DebugConfiguration> {
-		const config = await getLaunchConfiguration(script, { deviceId: "flutter-tester" });
+		const config = await getLaunchConfiguration(script, { deviceId: "flutter-tester", cwd });
 		await watchPromise("startDebugger->start", dc.start(config.debugServer));
 		// Make sure any stdErr is logged to console + log file for debugging.
 		dc.on("output", (event: DebugProtocol.OutputEvent) => {

--- a/test/flutter_only/debug/flutter_run_attach.test.ts
+++ b/test/flutter_only/debug/flutter_run_attach.test.ts
@@ -1,0 +1,100 @@
+import * as assert from "assert";
+import * as path from "path";
+import * as vs from "vscode";
+import { DebugProtocol } from "vscode-debugprotocol";
+import { isWin } from "../../../src/debug/utils";
+import { fsPath } from "../../../src/utils";
+import { logError } from "../../../src/utils/log";
+import { DartDebugClient } from "../../dart_debug_client";
+import { spawnFlutterProcess } from "../../debug_helpers";
+import { activate, defer, delay, ext, extApi, flutterHelloWorldExampleSubFolder, flutterHelloWorldFolder, flutterHelloWorldMainFile, getAttachConfiguration, getLaunchConfiguration } from "../../helpers";
+
+describe.only("flutter run debugger (attach)", () => {
+	beforeEach("activate flutterHelloWorldMainFile", () => activate(flutterHelloWorldMainFile));
+	beforeEach("set timeout", function () {
+		this.timeout(60000); // These tests can be slow due to flutter package fetches when running.
+	});
+
+	beforeEach("skip if no test device", function () {
+		if (extApi.daemonCapabilities.flutterTesterMayBeFlaky)
+			this.skip();
+		// Skip on Windows due to https://github.com/flutter/flutter/issues/17833
+		if (isWin)
+			this.skip();
+	});
+
+	// We don't commit all the iOS/Android stuff to this repo to save space, but we can bring it back with
+	// `flutter create .`!
+	before("run 'flutter create'", () => vs.commands.executeCommand("_flutter.create", path.join(fsPath(flutterHelloWorldFolder), "dummy"), "."));
+	before("run 'flutter create' for example", () => vs.commands.executeCommand("_flutter.create", path.join(fsPath(flutterHelloWorldExampleSubFolder), "dummy"), "."));
+
+	let dc: DartDebugClient;
+	beforeEach("create debug client", () => {
+		dc = new DartDebugClient(process.execPath, path.join(ext.extensionPath, "out/src/debug/flutter_debug_entry.js"), "dart");
+		dc.defaultTimeout = 30000;
+		defer(() => dc.stop());
+	});
+
+	async function startDebugger(script?: vs.Uri): Promise<vs.DebugConfiguration> {
+		const config = await getLaunchConfiguration(script, { deviceId: "flutter-tester" });
+		await dc.start(config.debugServer);
+		// Make sure any stdErr is logged to console + log file for debugging.
+		dc.on("output", (event: DebugProtocol.OutputEvent) => {
+			if (event.body.category === "stderr")
+				logError(event.body.output);
+		});
+		return config;
+	}
+
+	async function attachDebugger(observatoryUri?: string): Promise<vs.DebugConfiguration> {
+		const config = await getAttachConfiguration({ deviceId: "flutter-tester", observatoryUri });
+		await dc.start(config.debugServer);
+		// Make sure any stdErr is logged to console + log file for debugging.
+		dc.on("output", (event: DebugProtocol.OutputEvent) => {
+			if (event.body.category === "stderr")
+				logError(event.body.output);
+		});
+		return config;
+	}
+
+	it("attaches to a Flutter application and remains active until told to detach", async () => {
+		const process = spawnFlutterProcess(await getLaunchConfiguration(flutterHelloWorldMainFile));
+		const observatoryUri = await process.observatoryUri;
+		const config = await attachDebugger(observatoryUri);
+
+		await Promise.all([
+			watchPromise("attaches_and_waits->configurationSequence", dc.configurationSequence()),
+			watchPromise("attaches_and_waits->launch", dc.launch(config)),
+		]);
+
+		// Ensure we're still responsive after 10 seconds.
+		await delay(10000);
+		await watchPromise("attaches_and_waits->threadsRequest", dc.threadsRequest());
+
+		await Promise.all([
+			watchPromise("attaches_and_waits->waitForEvent:terminated", dc.waitForEvent("terminated")),
+			watchPromise("attaches_and_waits->terminateRequest", dc.terminateRequest()),
+		]);
+	});
+
+	it("detaches without terminating the app", async () => {
+		const process = spawnFlutterProcess(await getLaunchConfiguration(flutterHelloWorldMainFile));
+		const observatoryUri = await process.observatoryUri;
+		const config = await attachDebugger(observatoryUri);
+
+		await Promise.all([
+			watchPromise("attaches_and_waits->configurationSequence", dc.configurationSequence()),
+			watchPromise("attaches_and_waits->launch", dc.launch(config)),
+		]);
+
+		await Promise.all([
+			watchPromise("attaches_and_waits->waitForEvent:terminated", dc.waitForEvent("terminated")),
+			watchPromise("attaches_and_waits->terminateRequest", dc.terminateRequest()),
+		]);
+
+		// Ensure the main process is still alive.
+		await delay(10000);
+		assert.equal(process.hasExited, false);
+
+	});
+});

--- a/test/flutter_only/debug/flutter_run_attach.test.ts
+++ b/test/flutter_only/debug/flutter_run_attach.test.ts
@@ -7,9 +7,9 @@ import { fsPath } from "../../../src/utils";
 import { logError } from "../../../src/utils/log";
 import { DartDebugClient } from "../../dart_debug_client";
 import { spawnFlutterProcess } from "../../debug_helpers";
-import { activate, defer, delay, ext, extApi, flutterHelloWorldExampleSubFolder, flutterHelloWorldFolder, flutterHelloWorldMainFile, getAttachConfiguration, getLaunchConfiguration } from "../../helpers";
+import { activate, defer, delay, ext, extApi, flutterHelloWorldExampleSubFolder, flutterHelloWorldFolder, flutterHelloWorldMainFile, getAttachConfiguration, getLaunchConfiguration, watchPromise } from "../../helpers";
 
-describe.only("flutter run debugger (attach)", () => {
+describe("flutter run debugger (attach)", () => {
 	beforeEach("activate flutterHelloWorldMainFile", () => activate(flutterHelloWorldMainFile));
 	beforeEach("set timeout", function () {
 		this.timeout(60000); // These tests can be slow due to flutter package fetches when running.
@@ -34,17 +34,6 @@ describe.only("flutter run debugger (attach)", () => {
 		dc.defaultTimeout = 30000;
 		defer(() => dc.stop());
 	});
-
-	async function startDebugger(script?: vs.Uri): Promise<vs.DebugConfiguration> {
-		const config = await getLaunchConfiguration(script, { deviceId: "flutter-tester" });
-		await dc.start(config.debugServer);
-		// Make sure any stdErr is logged to console + log file for debugging.
-		dc.on("output", (event: DebugProtocol.OutputEvent) => {
-			if (event.body.category === "stderr")
-				logError(event.body.output);
-		});
-		return config;
-	}
 
 	async function attachDebugger(observatoryUri?: string): Promise<vs.DebugConfiguration> {
 		const config = await getAttachConfiguration({ deviceId: "flutter-tester", observatoryUri });
@@ -93,7 +82,7 @@ describe.only("flutter run debugger (attach)", () => {
 		]);
 
 		// Ensure the main process is still alive.
-		await delay(10000);
+		await delay(4000);
 		assert.equal(process.hasExited, false);
 
 	});


### PR DESCRIPTION
This adds a new command: `Debug: Attach to Flutter Process` (Fixes #1056).