### PR TITLE
Add basic global expression evaluation

### DIFF
--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -1291,49 +1291,71 @@ export class DartDebugSession extends DebugSession {
 		const frameId = args.frameId;
 		// const context: string = args.context; // "watch", "repl", "hover"
 
-		if (!frameId) {
-			this.errorResponse(response, "global evaluation not supported");
-			return;
-		}
-
-		const data = this.threadManager.getStoredData(frameId);
-		const thread = data.thread;
-		const frame: VMFrame = data.data as VMFrame;
+		const data = frameId ? this.threadManager.getStoredData(frameId) : undefined;
+		const thread = data ? data.thread : this.threadManager.threads[0];
 
 		try {
 			let result: DebuggerResult | undefined;
-			if ((expression === "$e" || expression.startsWith("$e.")) && thread.exceptionReference) {
-				const exceptionData = this.threadManager.getStoredData(thread.exceptionReference);
-				const exceptionInstanceRef = exceptionData && exceptionData.data as VMInstanceRef;
-
-				if (expression === "$e") {
-					response.body = {
-						result: await this.fullValueAsString(thread.ref, exceptionInstanceRef) || "<unknown>",
-						variablesReference: thread.exceptionReference,
-					};
-					this.sendResponse(response);
+			if (!data) {
+				if (!this.observatory || !thread) {
+					this.errorResponse(response, "global evaluation requires a thread to have been loaded");
 					return;
 				}
 
-				const exceptionId = exceptionInstanceRef && exceptionInstanceRef.id;
+				const isolate = (await this.observatory.getIsolate(thread.ref.id)).result as VMIsolate;
+				const rootLib = isolate.rootLib;
 
-				if (exceptionId)
-					result = await this.observatory!.evaluate(thread.ref.id, exceptionId, expression.substr(3), true);
-			}
-			if (!result) {
+				if (!rootLib) {
+					this.errorResponse(response, "global evaluation requires a rootLib on the initial thread");
+					return;
+				}
+
 				// Don't wait more than a second for the response:
 				//   1. VS Code's watch window behaves badly when there are incomplete evaluate requests
 				//      https://github.com/Microsoft/vscode/issues/52317
 				//   2. The VM sometimes doesn't respond to your requests at all
 				//      https://github.com/flutter/flutter/issues/18595
 				result = await Promise.race([
-					this.observatory!.evaluateInFrame(thread.ref.id, frame.index, expression, true),
+					this.observatory!.evaluate(thread.ref.id, rootLib.id, expression, true),
 					new Promise<never>((resolve, reject) => setTimeout(() => reject(new Error("<timed out>")), 1000)),
 				]);
+			} else {
+				const frame = data.data as VMFrame;
+				if ((expression === "$e" || expression.startsWith("$e.")) && thread.exceptionReference) {
+					const exceptionData = this.threadManager.getStoredData(thread.exceptionReference);
+					const exceptionInstanceRef = exceptionData && exceptionData.data as VMInstanceRef;
+
+					if (expression === "$e") {
+						response.body = {
+							result: await this.fullValueAsString(thread.ref, exceptionInstanceRef) || "<unknown>",
+							variablesReference: thread.exceptionReference,
+						};
+						this.sendResponse(response);
+						return;
+					}
+
+					const exceptionId = exceptionInstanceRef && exceptionInstanceRef.id;
+
+					if (exceptionId)
+						result = await this.observatory!.evaluate(thread.ref.id, exceptionId, expression.substr(3), true);
+				}
+				if (!result) {
+					// Don't wait more than a second for the response:
+					//   1. VS Code's watch window behaves badly when there are incomplete evaluate requests
+					//      https://github.com/Microsoft/vscode/issues/52317
+					//   2. The VM sometimes doesn't respond to your requests at all
+					//      https://github.com/flutter/flutter/issues/18595
+					result = await Promise.race([
+						this.observatory!.evaluateInFrame(thread.ref.id, frame.index, expression, true),
+						new Promise<never>((resolve, reject) => setTimeout(() => reject(new Error("<timed out>")), 1000)),
+					]);
+				}
 			}
 
-			// InstanceRef or ErrorRef
-			if (result.result.type === "@Error") {
+			if (!result) {
+				this.errorResponse(response, "No evaluation result");
+			} else if (result.result.type === "@Error") {
+				// InstanceRef or ErrorRef
 				const error: VMErrorRef = result.result as VMErrorRef;
 				let str: string = error.message;
 				if (str)

--- a/src/test/dart_debug/debug/dart_cli.test.ts
+++ b/src/test/dart_debug/debug/dart_cli.test.ts
@@ -8,7 +8,7 @@ import { grey } from "../../../shared/utils/colors";
 import { fsPath, getRandomInt } from "../../../shared/utils/fs";
 import { DartDebugClient } from "../../dart_debug_client";
 import { ensureFrameCategories, ensureMapEntry, ensureVariable, ensureVariableWithIndex, isExternalPackage, isLocalPackage, isSdkFrame, isUserCode, spawnDartProcessPaused } from "../../debug_helpers";
-import { activate, breakpointFor, closeAllOpenFiles, defer, delay, ext, extApi, getAttachConfiguration, getDefinition, getLaunchConfiguration, getPackages, helloWorldBrokenFile, helloWorldDeferredEntryFile, helloWorldDeferredScriptFile, helloWorldExampleSubFolder, helloWorldExampleSubFolderMainFile, helloWorldFolder, helloWorldGettersFile, helloWorldGoodbyeFile, helloWorldHttpFile, helloWorldLocalPackageFile, helloWorldMainFile, helloWorldPartEntryFile, helloWorldPartFile, helloWorldThrowInExternalPackageFile, helloWorldThrowInLocalPackageFile, helloWorldThrowInSdkFile, logger, openFile, positionOf, sb, uriFor, waitForResult, watchPromise, writeBrokenDartCodeIntoFileForTest } from "../../helpers";
+import { activate, breakpointFor, closeAllOpenFiles, defer, delay, ext, extApi, getAttachConfiguration, getDefinition, getLaunchConfiguration, getPackages, helloWorldBrokenFile, helloWorldDeferredEntryFile, helloWorldDeferredScriptFile, helloWorldExampleSubFolder, helloWorldExampleSubFolderMainFile, helloWorldFolder, helloWorldGettersFile, helloWorldGoodbyeFile, helloWorldHttpFile, helloWorldLocalPackageFile, helloWorldLongRunningFile, helloWorldMainFile, helloWorldPartEntryFile, helloWorldPartFile, helloWorldThrowInExternalPackageFile, helloWorldThrowInLocalPackageFile, helloWorldThrowInSdkFile, logger, openFile, positionOf, sb, uriFor, waitForResult, watchPromise, writeBrokenDartCodeIntoFileForTest } from "../../helpers";
 
 describe("dart cli debugger", () => {
 	// We have tests that require external packages.
@@ -900,6 +900,105 @@ describe("dart cli debugger", () => {
 			]);
 
 			const error = await dc.evaluateForFrame("DateTime.now().ye", "watch").catch((e) => e);
+			assert.equal(error.message, "not available");
+		});
+	});
+
+	describe("can evaluate when not at a breakpoint", () => {
+		it("simple expressions", async () => {
+			await openFile(helloWorldLongRunningFile);
+			const config = await startDebugger(helloWorldLongRunningFile);
+			await Promise.all([
+				dc.configurationSequence(),
+				dc.launch(config),
+			]);
+
+			await dc.tryWaitUntilGlobalEvaluationIsAvailable();
+
+			const evaluateResult = await dc.evaluateRequest({ expression: `"test"` });
+			assert.ok(evaluateResult);
+			assert.ok(evaluateResult.body);
+			assert.equal(evaluateResult.body.result, `"test"`);
+			assert.equal(evaluateResult.body.variablesReference, 0);
+		});
+
+		it("complex expression expressions", async () => {
+			await openFile(helloWorldLongRunningFile);
+			const config = await startDebugger(helloWorldLongRunningFile);
+			await Promise.all([
+				dc.configurationSequence(),
+				dc.launch(config),
+			]);
+
+			await dc.tryWaitUntilGlobalEvaluationIsAvailable();
+
+			const evaluateResult = await dc.evaluateRequest({ expression: `(new DateTime.now()).year` });
+			assert.ok(evaluateResult);
+			assert.ok(evaluateResult.body);
+			assert.equal(evaluateResult.body.result, (new Date()).getFullYear());
+			assert.equal(evaluateResult.body.variablesReference, 0);
+		});
+
+		it("an expression that returns a variable", async () => {
+			await openFile(helloWorldLongRunningFile);
+			const config = await startDebugger(helloWorldLongRunningFile);
+			await Promise.all([
+				dc.configurationSequence(),
+				dc.launch(config),
+			]);
+
+			await dc.tryWaitUntilGlobalEvaluationIsAvailable();
+
+			const evaluateResult = await dc.evaluateRequest({ expression: `new DateTime.now()` });
+			const thisYear = new Date().getFullYear().toString();
+			assert.ok(evaluateResult);
+			assert.ok(evaluateResult.body);
+			assert.ok(evaluateResult.body.result.startsWith("DateTime (" + thisYear), `Result '${evaluateResult.body.result}' did not start with ${thisYear}`);
+			assert.ok(evaluateResult.body.variablesReference);
+		});
+
+		it("can evaluate expressions with trailing semicolons", async () => {
+			await openFile(helloWorldLongRunningFile);
+			const config = await startDebugger(helloWorldLongRunningFile);
+			await Promise.all([
+				dc.configurationSequence(),
+				dc.launch(config),
+			]);
+
+			await dc.tryWaitUntilGlobalEvaluationIsAvailable();
+
+			const evaluateResult = await dc.evaluateRequest({ expression: `(new DateTime.now()).year;` });
+			assert.ok(evaluateResult);
+			assert.ok(evaluateResult.body);
+			assert.equal(evaluateResult.body.result, (new Date()).getFullYear());
+			assert.equal(evaluateResult.body.variablesReference, 0);
+		});
+
+		it("returns a full error message for repl context", async () => {
+			await openFile(helloWorldLongRunningFile);
+			const config = await startDebugger(helloWorldLongRunningFile);
+			await Promise.all([
+				dc.configurationSequence(),
+				dc.launch(config),
+			]);
+
+			await dc.tryWaitUntilGlobalEvaluationIsAvailable();
+
+			const error = await dc.evaluateRequest({ expression: "DateTime.now().ye", context: "repl" }).catch((e) => e);
+			assert.notEqual(error.message.indexOf("The getter 'ye' isn't defined for the class 'DateTime'"), -1);
+		});
+
+		it("returns a short error message for watch context", async () => {
+			await openFile(helloWorldLongRunningFile);
+			const config = await startDebugger(helloWorldLongRunningFile);
+			await Promise.all([
+				dc.configurationSequence(),
+				dc.launch(config),
+			]);
+
+			await dc.tryWaitUntilGlobalEvaluationIsAvailable();
+
+			const error = await dc.evaluateRequest({ expression: "DateTime.now().ye", context: "watch" }).catch((e) => e);
 			assert.equal(error.message, "not available");
 		});
 	});

--- a/src/test/flutter_debug/debug/flutter_run.test.ts
+++ b/src/test/flutter_debug/debug/flutter_run.test.ts
@@ -1022,6 +1022,74 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		});
 	});
 
+	describe("can evaluate when not at a breakpoint (global expression evaluation)", function () {
+		this.beforeEach(function () {
+			if (flutterTestDeviceIsWeb)
+				this.skip();
+		});
+
+		it("simple expressions", async () => {
+			await openFile(flutterHelloWorldMainFile);
+			const config = await startDebugger(dc, flutterHelloWorldMainFile);
+			await Promise.all([
+				dc.configurationSequence(),
+				dc.launch(config),
+			]);
+
+			const evaluateResult = await dc.evaluateRequest({ expression: `"test"` });
+			assert.ok(evaluateResult);
+			assert.ok(evaluateResult.body);
+			assert.equal(evaluateResult.body.result, `"test"`);
+			assert.equal(evaluateResult.body.variablesReference, 0);
+
+			await Promise.all([
+				dc.waitForEvent("terminated"),
+				dc.terminateRequest(),
+			]);
+		});
+
+		it("complex expression expressions", async () => {
+			await openFile(flutterHelloWorldMainFile);
+			const config = await startDebugger(dc, flutterHelloWorldMainFile);
+			await Promise.all([
+				dc.configurationSequence(),
+				dc.launch(config),
+			]);
+
+			const evaluateResult = await dc.evaluateRequest({ expression: `(new DateTime.now()).year` });
+			assert.ok(evaluateResult);
+			assert.ok(evaluateResult.body);
+			assert.equal(evaluateResult.body.result, (new Date()).getFullYear());
+			assert.equal(evaluateResult.body.variablesReference, 0);
+
+			await Promise.all([
+				dc.waitForEvent("terminated"),
+				dc.terminateRequest(),
+			]);
+		});
+
+		it("an expression that returns a variable", async () => {
+			await openFile(flutterHelloWorldMainFile);
+			const config = await startDebugger(dc, flutterHelloWorldMainFile);
+			await Promise.all([
+				dc.configurationSequence(),
+				dc.launch(config),
+			]);
+
+			const evaluateResult = await dc.evaluateRequest({ expression: `new DateTime.now()` });
+			const thisYear = new Date().getFullYear().toString();
+			assert.ok(evaluateResult);
+			assert.ok(evaluateResult.body);
+			assert.ok(evaluateResult.body.result.startsWith("DateTime (" + thisYear), `Result '${evaluateResult.body.result}' did not start with ${thisYear}`);
+			assert.ok(evaluateResult.body.variablesReference);
+
+			await Promise.all([
+				dc.waitForEvent("terminated"),
+				dc.terminateRequest(),
+			]);
+		});
+	});
+
 	// Skipped due to https://github.com/flutter/flutter/issues/17007.
 	it.skip("stops on exception", async () => {
 		await openFile(flutterHelloWorldBrokenFile);

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -35,6 +35,7 @@ const testFolder = path.join(ext.extensionPath, "src/test");
 // Dart
 export const helloWorldFolder = vs.Uri.file(path.join(testFolder, "test_projects/hello_world"));
 export const helloWorldMainFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "bin/main.dart"));
+export const helloWorldLongRunningFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "bin/long_running.dart"));
 export const helloWorldMainLibFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "lib/basic.dart"));
 export const helloWorldDeferredEntryFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "bin/deferred_entry.dart"));
 export const helloWorldPartEntryFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "bin/part.dart"));

--- a/src/test/test_projects/hello_world/bin/long_running.dart
+++ b/src/test/test_projects/hello_world/bin/long_running.dart
@@ -1,0 +1,7 @@
+import 'dart:async';
+
+main() async {
+  while (true) {
+    await Future.delayed(Duration(milliseconds: 100));
+  }
+}


### PR DESCRIPTION
Use first thread, since we can't evaluate without one.

Fixes #906.