### PR TITLE
Allow creation of files that don't exist if the edit range is 0/0 (Requires VS Code 1.26)

### DIFF
--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -151,10 +151,10 @@ export class EditCommands implements vs.Disposable {
 				continue;
 			}
 			const document = fs.existsSync(edit.file) ? await vs.workspace.openTextDocument(uri) : undefined;
-			changes.createFile(uri, { ignoreIfExists: true });
 			for (const e of edit.edits) {
 				if (!changes)
 					changes = new vs.WorkspaceEdit();
+				changes.createFile(uri, { ignoreIfExists: true });
 				const range = document
 					? new vs.Range(
 						document.positionAt(e.offset),

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -151,10 +151,13 @@ export class EditCommands implements vs.Disposable {
 				continue;
 			}
 			const document = fs.existsSync(edit.file) ? await vs.workspace.openTextDocument(uri) : undefined;
-			for (const e of edit.edits) {
-				if (!changes)
-					changes = new vs.WorkspaceEdit();
+			if (changes)
 				changes.createFile(uri, { ignoreIfExists: true });
+			for (const e of edit.edits) {
+				if (!changes) {
+					changes = new vs.WorkspaceEdit();
+					changes.createFile(uri, { ignoreIfExists: true });
+				}
 				const range = document
 					? new vs.Range(
 						document.positionAt(e.offset),
@@ -187,6 +190,7 @@ export class EditCommands implements vs.Disposable {
 				editor.selection = selection;
 			}
 		}
+	}
 
 	private async applyEditsWithSnippets(initiatingDocument: vs.TextDocument, change: as.SourceChange): Promise<void> {
 		const edit = change.edits[0];

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -177,18 +177,17 @@ export class EditCommands implements vs.Disposable {
 		}
 
 		// If we weren't applying sequentially
-		if (changes) {
+		if (changes)
 			await vs.workspace.applyEdit(changes);
 
-			// Set the cursor position.
-			if (change.selection) {
-				const uri = vs.Uri.file(change.selection.file);
-				const document = await vs.workspace.openTextDocument(uri);
-				const editor = await vs.window.showTextDocument(document);
-				const pos = document.positionAt(change.selection.offset);
-				const selection = new vs.Selection(pos, pos);
-				editor.selection = selection;
-			}
+		// Set the cursor position.
+		if (change.selection) {
+			const uri = vs.Uri.file(change.selection.file);
+			const document = await vs.workspace.openTextDocument(uri);
+			const editor = await vs.window.showTextDocument(document);
+			const pos = document.positionAt(change.selection.offset);
+			const selection = new vs.Selection(pos, pos);
+			editor.selection = selection;
 		}
 	}
 

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -1,9 +1,10 @@
+import * as fs from "fs";
 import * as vs from "vscode";
 import * as as from "../analysis/analysis_server_types";
 import { Analyzer } from "../analysis/analyzer";
 import * as editors from "../editors";
 import { fsPath } from "../utils";
-import { logWarn } from "../utils/log";
+import { logError, logWarn } from "../utils/log";
 
 export class EditCommands implements vs.Disposable {
 	private commands: vs.Disposable[] = [];
@@ -141,17 +142,28 @@ export class EditCommands implements vs.Disposable {
 		let changes = applyEditsSequentially ? undefined : new vs.WorkspaceEdit();
 
 		for (const edit of change.edits) {
+			const uri = vs.Uri.file(edit.file);
+			// We can only create files with edits that are at 0/0 because we can't open the document if it doesn't exist.
+			// If we create the file ourselves, it won't go into the single undo buffer.
+			if (!fs.existsSync(edit.file) && edit.edits.find((e) => e.offset !== 1 || e.length !== 0)) {
+				logError(`Unable to edit file ${edit.file} because it does not exist and had an edit that was not the start of the file`);
+				vs.window.showErrorMessage(`Enable to edit file ${edit.file} because it does not exist and had an edit that was not the start of the file`);
+				continue;
+			}
+			const document = fs.existsSync(edit.file) ? await vs.workspace.openTextDocument(uri) : undefined;
+			changes.createFile(uri, { ignoreIfExists: true });
 			for (const e of edit.edits) {
-				const uri = vs.Uri.file(edit.file);
-				const document = await vs.workspace.openTextDocument(uri);
 				if (!changes)
 					changes = new vs.WorkspaceEdit();
-				changes.replace(
-					vs.Uri.file(edit.file),
-					new vs.Range(
+				const range = document
+					? new vs.Range(
 						document.positionAt(e.offset),
 						document.positionAt(e.offset + e.length),
-					),
+					)
+					: new vs.Range(new vs.Position(0, 0), new vs.Position(0, 0));
+				changes.replace(
+					uri,
+					range,
 					e.replacement,
 				);
 				if (applyEditsSequentially) {
@@ -164,18 +176,17 @@ export class EditCommands implements vs.Disposable {
 		// If we weren't applying sequentially
 		if (changes) {
 			await vs.workspace.applyEdit(changes);
-		}
 
-		// Set the cursor position.
-		if (change.selection) {
-			const uri = vs.Uri.file(change.selection.file);
-			const document = await vs.workspace.openTextDocument(uri);
-			const editor = await vs.window.showTextDocument(document);
-			const pos = document.positionAt(change.selection.offset);
-			const selection = new vs.Selection(pos, pos);
-			editor.selection = selection;
+			// Set the cursor position.
+			if (change.selection) {
+				const uri = vs.Uri.file(change.selection.file);
+				const document = await vs.workspace.openTextDocument(uri);
+				const editor = await vs.window.showTextDocument(document);
+				const pos = document.positionAt(change.selection.offset);
+				const selection = new vs.Selection(pos, pos);
+				editor.selection = selection;
+			}
 		}
-	}
 
 	private async applyEditsWithSnippets(initiatingDocument: vs.TextDocument, change: as.SourceChange): Promise<void> {
 		const edit = change.edits[0];


### PR DESCRIPTION
We can't calculate a range for a file that's not open and we don't want to create the file manually because it won't be atomic with the edits. We hope we'll never get edits for a new file that aren't at 0/0.

Fixes #339.