### PR TITLE
Support terminateRequest for better handling of graceful/forced shutdown of debugger

### DIFF
--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -104,7 +104,7 @@ export class FlutterDebugSession extends DartDebugSession {
 		} catch {
 			// Ignore failures here (see comment above).
 		}
-		super.terminateRequest(response, args);
+		await super.terminateRequest(response, args);
 	}
 
 	protected restartRequest(

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -89,22 +89,22 @@ export class FlutterDebugSession extends DartDebugSession {
 		return this.flutter.process;
 	}
 
-	protected async disconnectRequest(
+	protected async terminateRequest(
 		response: DebugProtocol.DisconnectResponse,
 		args: DebugProtocol.DisconnectArguments,
 	): Promise<void> {
 		try {
 			if (this.currentRunningAppId && this.appHasStarted)
-				// Wait up to 500ms for app to quit since we often don't get a
+				// Wait up to 1000ms for app to quit since we often don't get a
 				// response here because the processes terminate immediately.
 				await Promise.race([
 					this.flutter.stop(this.currentRunningAppId),
-					new Promise((resolve) => setTimeout(resolve, 500)),
+					new Promise((resolve) => setTimeout(resolve, 1000)),
 				]);
 		} catch {
 			// Ignore failures here (see comment above).
 		}
-		super.disconnectRequest(response, args);
+		super.terminateRequest(response, args);
 	}
 
 	protected restartRequest(


### PR DESCRIPTION
This fixes #1155 though I'm not entirely sure why (I don't understand what caused it). This splits out disconnect code into the two requests VS Code now sends (terminateRequest when the user first hits stop then disconnectRequest if they hit it again to force a kill).

We were already assuming disconnectRequest could be called twice to handle this so it wasn't much of a change.

One thing I had to remove was our eager sending of TermiantedRequest when the Observatory port closed. This was resulting in VS Code moving on to the disconnectRequest even though terminateRequest was still ongoing. I'm not sure why this code was added, it doesn't seem like we should be considering the process to be exited if it hasn't (if Observatory dies but the process remains running, probably we want to know something has gone wrong and figure out how to handle those cases).