### PR TITLE
Always send file:/// for URIs to VM

### DIFF
--- a/src/debug/utils.ts
+++ b/src/debug/utils.ts
@@ -106,9 +106,7 @@ export function formatPathForVm(file: string): string {
 	if (file.startsWith("dart:"))
 		return file;
 	else
-		// TODO: Add file:// prefix and remove the "removeFilePrefix" workaround in coverage markers
-		// code when https://github.com/flutter/flutter/issues/18441 is fixed.
-		return `/${encodeURI(file)}`;
+		return `file:///${encodeURI(file)}`;
 }
 
 export function forceWindowsDriveLetterToUppercase(p: string): string {


### PR DESCRIPTION
We removed this in #479 because it was causing breakpoint misses; however those issues appear to all be fixed. Manual testing on macOS and Windows shows hitting breakpoints before, after hot reload, after hot restart on both platforms (I haven't verified Linux, but this PR will run all the tests at least).