### PR TITLE
Allow creation of Flutter samples from the command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -330,7 +330,8 @@
 					"command": "flutter.createProject"
 				},
 				{
-					"command": "flutter.createSampleProject"
+					"command": "flutter.createSampleProject",
+					"when": "config.dart.flutterDocsHost"
 				},
 				{
 					"command": "pub.get",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
 			},
 			{
 				"command": "flutter.createSampleProject",
-				"title": "Create Sample Project",
+				"title": "New Project From Docs",
 				"category": "Flutter"
 			},
 			{

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"workspaceContains:**/pubspec.yaml",
 		"workspaceContains:**/*.dart",
 		"onCommand:flutter.createProject",
+		"onCommand:flutter.createSampleProject",
 		"onCommand:flutter.doctor",
 		"onUri"
 	],
@@ -75,6 +76,11 @@
 			{
 				"command": "flutter.createProject",
 				"title": "New Project",
+				"category": "Flutter"
+			},
+			{
+				"command": "flutter.createSampleProject",
+				"title": "Create Sample Project",
 				"category": "Flutter"
 			},
 			{
@@ -322,6 +328,9 @@
 			"commandPalette": [
 				{
 					"command": "flutter.createProject"
+				},
+				{
+					"command": "flutter.createSampleProject"
 				},
 				{
 					"command": "pub.get",

--- a/package.json
+++ b/package.json
@@ -670,6 +670,12 @@
 					"description": "Whether to pass --track-widget-creation to Flutter apps (required to support 'Inspect Widget'). If this setting is not set, it will default to true for Flutter >= 10.2 and false for any previous versions of Flutter.",
 					"scope": "resource"
 				},
+				"dart.flutterDocsHost": {
+					"type": "string",
+					"default": "docs.flutter.io",
+					"description": "The hostname to use for Flutter Docs, for example when fetching available samples.",
+					"scope": "window"
+				},
 				"dart.evaluateGettersInDebugViews": {
 					"type": "boolean",
 					"default": true,

--- a/package.json
+++ b/package.json
@@ -672,7 +672,6 @@
 				},
 				"dart.flutterDocsHost": {
 					"type": "string",
-					"default": "docs.flutter.io",
 					"description": "The hostname to use for Flutter Docs, for example when fetching available samples.",
 					"scope": "window"
 				},

--- a/src/analysis/analyzer_gen.ts
+++ b/src/analysis/analyzer_gen.ts
@@ -14,6 +14,13 @@ export abstract class AnalyzerGen extends StdIOService<UnknownNotification> {
 		super(getLogFile, (message, severity) => log(message, severity, LogCategory.Analyzer), maxLogLineLength);
 	}
 
+	protected buildRequest<TReq>(id: number, method: string, params?: TReq): { id: string, method: string, params: TReq } {
+		return Object.assign(
+			super.buildRequest(id, method, params),
+			{ clientRequestTime: Date.now() },
+		);
+	}
+
 	private serverConnectedSubscriptions: ((notification: as.ServerConnectedNotification) => void)[] = [];
 	private serverErrorSubscriptions: ((notification: as.ServerErrorNotification) => void)[] = [];
 	private serverStatusSubscriptions: ((notification: as.ServerStatusNotification) => void)[] = [];

--- a/src/commands/sdk.ts
+++ b/src/commands/sdk.ts
@@ -22,10 +22,8 @@ import { log } from "../utils/log";
 import * as channels from "./channels";
 
 const flutterNameRegex = new RegExp("^[a-z][a-z0-9_]*$");
-// TODO: This needs fixing when the snippets indexs is on the live site.
 // TODO: Automated Tests
 // TODO: Test missing SDKs, etc.
-const flutterDocsHost = "master-docs.flutter.io";
 
 export class SdkCommands {
 	private flutterScreenshotPath?: string;
@@ -395,8 +393,10 @@ export class SdkCommands {
 
 	private getFlutterSnippets(): Promise<FlutterSampleSnippet[]> {
 		return new Promise<FlutterSampleSnippet[]>((resolve, reject) => {
+			if (!config.flutterDocsHost)
+				reject("No Flutter docs host set");
 			const options: https.RequestOptions = {
-				hostname: flutterDocsHost,
+				hostname: config.flutterDocsHost,
 				method: "GET",
 				path: "/snippets/index.json",
 				port: 443,

--- a/src/commands/sdk.ts
+++ b/src/commands/sdk.ts
@@ -22,7 +22,6 @@ import { log } from "../utils/log";
 import * as channels from "./channels";
 
 const flutterNameRegex = new RegExp("^[a-z][a-z0-9_]*$");
-// TODO: Test missing SDKs, etc.
 
 export class SdkCommands {
 	private flutterScreenshotPath?: string;

--- a/src/commands/sdk.ts
+++ b/src/commands/sdk.ts
@@ -391,7 +391,6 @@ export class SdkCommands {
 	}
 
 	private getFlutterSnippets(): Promise<FlutterSampleSnippet[]> {
-		const flutterDocsSamplesIndex = `https://${flutterDocsHost}`;
 		return new Promise<FlutterSampleSnippet[]>((resolve, reject) => {
 			const options: https.RequestOptions = {
 				hostname: flutterDocsHost,

--- a/src/commands/sdk.ts
+++ b/src/commands/sdk.ts
@@ -22,7 +22,6 @@ import { log } from "../utils/log";
 import * as channels from "./channels";
 
 const flutterNameRegex = new RegExp("^[a-z][a-z0-9_]*$");
-// TODO: Automated Tests
 // TODO: Test missing SDKs, etc.
 
 export class SdkCommands {
@@ -348,7 +347,7 @@ export class SdkCommands {
 		vs.commands.executeCommand("vscode.openFolder", projectFolderUri, openInNewWindow);
 	}
 
-	private async createFlutterSampleProject(): Promise<void> {
+	private async createFlutterSampleProject(): Promise<vs.Uri> {
 		if (!this.sdks || !this.sdks.flutter) {
 			showFlutterActivationFailure("flutter.createSampleProject");
 			return;
@@ -380,7 +379,7 @@ export class SdkCommands {
 		if (!selectedSnippet)
 			return;
 
-		createFlutterSampleInTempFolder(this.flutterCapabilities, selectedSnippet.snippet.id);
+		return createFlutterSampleInTempFolder(this.flutterCapabilities, selectedSnippet.snippet.id);
 	}
 
 	private validateFlutterProjectName(input: string) {
@@ -453,7 +452,7 @@ class ChainedProcess {
 	}
 }
 
-interface FlutterSampleSnippet {
+export interface FlutterSampleSnippet {
 	readonly sourcePath: string;
 	readonly sourceLine: number;
 	readonly package: string;

--- a/src/commands/sdk.ts
+++ b/src/commands/sdk.ts
@@ -17,6 +17,7 @@ import { DartSdkManager, FlutterSdkManager } from "../sdk/sdk_manager";
 import { flutterPath, pubPath, showFlutterActivationFailure } from "../sdk/utils";
 import * as util from "../utils";
 import { fsPath, ProjectType, Sdks } from "../utils";
+import { sortBy } from "../utils/array";
 import { log } from "../utils/log";
 import * as channels from "./channels";
 
@@ -365,8 +366,10 @@ export class SdkCommands {
 			return;
 		}
 
+		const sortedSnippets = sortBy(snippets, (s) => s.element);
+
 		const selectedSnippet = await vs.window.showQuickPick(
-			snippets.map((s) => ({
+			sortedSnippets.map((s) => ({
 				description: `${s.package}/${s.library}`,
 				detail: s.description,
 				label: s.element,

--- a/src/commands/sdk.ts
+++ b/src/commands/sdk.ts
@@ -362,6 +362,7 @@ export class SdkCommands {
 			snippets = await this.getFlutterSnippets();
 		} catch {
 			vs.window.showErrorMessage("Unable to download Flutter documentation snippets");
+			return;
 		}
 
 		const selectedSnippet = await vs.window.showQuickPick(

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,7 @@ class Config {
 	get flutterCreateIOSLanguage() { return this.getConfig<string>("flutterCreateIOSLanguage"); }
 	get flutterCreateOrganization() { return this.getConfig<string>("flutterCreateOrganization"); }
 	get flutterDaemonLogFile() { return createFolderForFile(resolvePaths(this.getConfig<string>("flutterDaemonLogFile"))); }
+	get flutterDocsHost() { return this.getConfig<string>("flutterDocsHost"); }
 	get flutterHotReloadOnSave() { return this.getConfig<boolean>("flutterHotReloadOnSave"); }
 	get flutterScreenshotPath() { return resolvePaths(this.getConfig<string>("flutterScreenshotPath")); }
 	get flutterSdkPath() { return resolvePaths(this.getConfig<string>("flutterSdkPath")); }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -313,7 +313,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 	}));
 
 	// Register SDK commands.
-	const sdkCommands = new SdkCommands(context, sdks, analytics, flutterDaemon && flutterDaemon.deviceManager);
+	const sdkCommands = new SdkCommands(context, sdks, analytics, flutterCapabilities, flutterDaemon && flutterDaemon.deviceManager);
 	const debug = new DebugCommands(context, analytics);
 
 	// Register URI handler.

--- a/src/sdk/flutter_samples.ts
+++ b/src/sdk/flutter_samples.ts
@@ -6,7 +6,7 @@ import { dartCodeExtensionIdentifier } from "../debug/utils";
 import { FlutterCapabilities } from "../flutter/capabilities";
 import * as util from "../utils";
 
-export function createFlutterSampleInTempFolder(flutterCapabilities: FlutterCapabilities, sampleID: string) {
+export function createFlutterSampleInTempFolder(flutterCapabilities: FlutterCapabilities, sampleID: string): vs.Uri {
 	// Ensure we're on at least Flutter v1 so we know creating samples works.
 	if (!flutterCapabilities.supportsCreatingSamples) {
 		vs.window.showErrorMessage("Opening sample projects requires Flutter v1.0 or later");
@@ -24,5 +24,8 @@ export function createFlutterSampleInTempFolder(flutterCapabilities: FlutterCapa
 
 	const hasFoldersOpen = !!(vs.workspace.workspaceFolders && vs.workspace.workspaceFolders.length);
 	const openInNewWindow = hasFoldersOpen;
-	vs.commands.executeCommand("vscode.openFolder", vs.Uri.file(tempSamplePath), openInNewWindow);
+	const folderUri = vs.Uri.file(tempSamplePath);
+	vs.commands.executeCommand("vscode.openFolder", folderUri, openInNewWindow);
+
+	return folderUri;
 }

--- a/src/sdk/flutter_samples.ts
+++ b/src/sdk/flutter_samples.ts
@@ -1,0 +1,28 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as vs from "vscode";
+import { dartCodeExtensionIdentifier } from "../debug/utils";
+import { FlutterCapabilities } from "../flutter/capabilities";
+import * as util from "../utils";
+
+export function createFlutterSampleInTempFolder(flutterCapabilities: FlutterCapabilities, sampleID: string) {
+	// Ensure we're on at least Flutter v1 so we know creating samples works.
+	if (!flutterCapabilities.supportsCreatingSamples) {
+		vs.window.showErrorMessage("Opening sample projects requires Flutter v1.0 or later");
+		return;
+	}
+
+	// Create a temp folder for the sample.
+	const tempSamplePath = path.join(os.tmpdir(), dartCodeExtensionIdentifier, "flutter", "sample", sampleID, util.getRandomInt(0x1000, 0x10000).toString(16));
+
+	// Create the empty folder so we can open it.
+	util.mkDirRecursive(tempSamplePath);
+
+	// Create a temp dart file to force extension to load when we open this folder.
+	fs.writeFileSync(path.join(tempSamplePath, util.FLUTTER_CREATE_PROJECT_TRIGGER_FILE), sampleID);
+
+	const hasFoldersOpen = !!(vs.workspace.workspaceFolders && vs.workspace.workspaceFolders.length);
+	const openInNewWindow = hasFoldersOpen;
+	vs.commands.executeCommand("vscode.openFolder", vs.Uri.file(tempSamplePath), openInNewWindow);
+}

--- a/src/sdk/utils.ts
+++ b/src/sdk/utils.ts
@@ -32,6 +32,10 @@ export function handleMissingSdks(context: ExtensionContext, analytics: Analytic
 		sdks.projectType = ProjectType.Flutter;
 		commandToReRun = "flutter.createProject";
 	}));
+	context.subscriptions.push(commands.registerCommand("flutter.createSampleProject", (_) => {
+		sdks.projectType = ProjectType.Flutter;
+		commandToReRun = "flutter.createSampleProject";
+	}));
 	context.subscriptions.push(commands.registerCommand("flutter.doctor", (_) => {
 		sdks.projectType = ProjectType.Flutter;
 		commandToReRun = "flutter.doctor";

--- a/src/services/stdio_service.ts
+++ b/src/services/stdio_service.ts
@@ -55,6 +55,14 @@ export abstract class StdIOService<T> implements IAmDisposable {
 		});
 	}
 
+	protected buildRequest<TReq>(id: number, method: string, params?: TReq): { id: string, method: string, params: TReq } {
+		return {
+			id: id.toString(),
+			method,
+			params,
+		};
+	}
+
 	protected sendRequest<TReq, TResp>(method: string, params?: TReq): Thenable<TResp> {
 		// Generate an ID for this request so we can match up the response.
 		const id = this.nextRequestID++;
@@ -63,11 +71,7 @@ export abstract class StdIOService<T> implements IAmDisposable {
 			// Stash the callbacks so we can call them later.
 			this.activeRequests[id.toString()] = [resolve, reject, method];
 
-			const req = {
-				id: id.toString(),
-				method,
-				params,
-			};
+			const req = this.buildRequest(id, method, params);
 			const json = this.messagesWrappedInBrackets
 				? "[" + JSON.stringify(req) + "]\r\n"
 				: JSON.stringify(req) + "\r\n";

--- a/src/uri_handlers/flutter_sample_handler.ts
+++ b/src/uri_handlers/flutter_sample_handler.ts
@@ -1,10 +1,6 @@
-import * as fs from "fs";
-import * as os from "os";
-import * as path from "path";
 import * as vs from "vscode";
-import { dartCodeExtensionIdentifier } from "../debug/utils";
 import { FlutterCapabilities } from "../flutter/capabilities";
-import * as util from "../utils";
+import { createFlutterSampleInTempFolder } from "../sdk/flutter_samples";
 
 export class FlutterSampleUriHandler {
 	constructor(private flutterCapabilities: FlutterCapabilities) { }
@@ -15,23 +11,7 @@ export class FlutterSampleUriHandler {
 			return;
 		}
 
-		// Ensure we're on at least Flutter v1 so we know creating samples works.
-		if (!this.flutterCapabilities.supportsCreatingSamples) {
-			vs.window.showErrorMessage("Opening sample projects requires Flutter v1.0 or later");
-			return;
-		}
-
-		// Create a temp folder for the sample.
-		const tempSamplePath = path.join(os.tmpdir(), dartCodeExtensionIdentifier, "flutter", "sample", sampleID, util.getRandomInt(0x1000, 0x10000).toString(16));
-
-		// Create the empty folder so we can open it.
-		util.mkDirRecursive(tempSamplePath);
-		// Create a temp dart file to force extension to load when we open this folder.
-		fs.writeFileSync(path.join(tempSamplePath, util.FLUTTER_CREATE_PROJECT_TRIGGER_FILE), sampleID);
-
-		const hasFoldersOpen = !!(vs.workspace.workspaceFolders && vs.workspace.workspaceFolders.length);
-		const openInNewWindow = hasFoldersOpen;
-		vs.commands.executeCommand("vscode.openFolder", vs.Uri.file(tempSamplePath), openInNewWindow);
+		createFlutterSampleInTempFolder(this.flutterCapabilities, sampleID);
 	}
 
 	private readonly validSampleIdentifierPattern = new RegExp("^[\\w\\.]+$");

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,9 @@
+export function sortBy<T>(items: T[], f: (item: T) => any): T[] {
+	return items.sort((item1, item2) => {
+		const r1 = f(item1);
+		const r2 = f(item2);
+		if (r1 < r2) return -1;
+		if (r1 > r2) return 1;
+		return 0;
+	});
+}

--- a/src/views/test_view.ts
+++ b/src/views/test_view.ts
@@ -4,6 +4,7 @@ import { getChannel } from "../commands/channels";
 import { flatMap, uniq } from "../debug/utils";
 import { extensionPath } from "../extension";
 import { fsPath } from "../utils";
+import { sortBy } from "../utils/array";
 import { getLaunchConfig } from "../utils/test";
 import { ErrorNotification, Group, GroupNotification, PrintNotification, Suite, SuiteNotification, Test, TestDoneNotification, TestStartNotification } from "./test_protocol";
 
@@ -737,14 +738,4 @@ function getTestSortOrder(status: TestStatus): TestSortOrder {
 	// if (status === TestStatus.Skipped)
 	// 	return TestSortOrder.Bottom;
 	return TestSortOrder.Middle;
-}
-
-function sortBy<T>(items: T[], f: (item: T) => number): T[] {
-	return items.sort((item1, item2) => {
-		const r1 = f(item1);
-		const r2 = f(item2);
-		if (r1 < r2) return -1;
-		if (r1 > r2) return 1;
-		return 0;
-	});
 }

--- a/test/not_activated/flutter_create/extension.test.ts
+++ b/test/not_activated/flutter_create/extension.test.ts
@@ -47,4 +47,8 @@ describe("command", () => {
 		assert.ok(openFolder.calledOnce);
 		assert.ok(fs.existsSync(path.join(tempFolder, "my_test_flutter_proj", FLUTTER_CREATE_PROJECT_TRIGGER_FILE)));
 	});
+
+	it.skip("Flutter: Create Sample Project can be invoked and creates trigger file", async () => {
+		// TODO
+	});
 });

--- a/test/not_activated/flutter_create/extension.test.ts
+++ b/test/not_activated/flutter_create/extension.test.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as sinon from "sinon";
 import * as vs from "vscode";
+import { FlutterSampleSnippet } from "../../../src/commands/sdk";
 import { FLUTTER_CREATE_PROJECT_TRIGGER_FILE, fsPath } from "../../../src/utils";
 import { ext, getRandomTempFolder, sb } from "../../helpers";
 
@@ -48,7 +49,24 @@ describe("command", () => {
 		assert.ok(fs.existsSync(path.join(tempFolder, "my_test_flutter_proj", FLUTTER_CREATE_PROJECT_TRIGGER_FILE)));
 	});
 
-	it.skip("Flutter: Create Sample Project can be invoked and creates trigger file", async () => {
-		// TODO
+	it("Flutter: Create Sample Project can be invoked and creates trigger file", async () => {
+		const sampleID = "material.IconButton";
+		const showQuickPick = sb.stub(vs.window, "showQuickPick");
+		type SnippetOption = vs.QuickPickItem & { snippet: FlutterSampleSnippet };
+		showQuickPick.callsFake((items: SnippetOption[]) => items.find((s) => s.snippet.id === sampleID));
+
+		// Intercept executeCommand for openFolder so we don't spawn a new instance of Code!
+		const executeCommand = sb.stub(vs.commands, "executeCommand");
+		const openFolder = executeCommand.withArgs("vscode.openFolder", sinon.match.any).resolves();
+		executeCommand.callThrough();
+
+		const sampleFolderUri: string = await vs.commands.executeCommand("flutter.createSampleProject");
+
+		assert.ok(showQuickPick.calledOnce);
+		assert.ok(openFolder.calledOnce);
+		const triggerFile = path.join(fsPath(sampleFolderUri), FLUTTER_CREATE_PROJECT_TRIGGER_FILE);
+		assert.ok(fs.existsSync(triggerFile));
+		const recordedSampleId = fs.readFileSync(triggerFile).toString().trim();
+		assert.equal(recordedSampleId, sampleID);
 	});
 });

--- a/test/test_projects/empty/.vscode/settings.json
+++ b/test/test_projects/empty/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+	// TODO: Remove this file once the snippets index file is live.
+	"dart.flutterDocsHost": "master-docs.flutter.io"
+}


### PR DESCRIPTION
Adds a `Flutter: Create Sample Project`:

![screenshot 2019-01-15 at 2 57 10 pm](https://user-images.githubusercontent.com/1078012/51188447-e0323c00-18d5-11e9-897b-7463f7198961.png)

![screenshot 2019-01-15 at 2 57 16 pm](https://user-images.githubusercontent.com/1078012/51188455-e7f1e080-18d5-11e9-8cb4-09f35a8a5657.png)

Selecting one will write the trigger file for a sample then open that folder (in a new window if you already have a project open, reusing the current window if not). It's written to a random temp folder to avoid prompting the user (though not sure whether we'd prefer the other?).

Outstanding:

- [x] Automated tests
- [x] Manual testing of hard-to-test failure cases (eg. missing Flutter SDK gives a good prompt, recovers if you point it at an SDK)
- ~~Switch to master docs path~~ https://github.com/Dart-Code/Dart-Code/issues/1392
- ~~Should we pre-fetch samples and hide this if we can't get them, or just fail at the time we fetch?~~ Failing at fetch time, to make it clearer when something is wrong