### PR TITLE
Sync states for Flutter VM service extensions

### DIFF
--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -10,10 +10,23 @@ import { handleDebugLogEvent } from "../utils/log";
 
 export const IS_INSPECTING_WIDGET_CONTEXT = "dart-code:flutter.isInspectingWidget";
 
+const keyTimeDilation = "timeDilation";
+const keyEnabled = "enabled";
+const extDebugAllowBanner = "ext.flutter.debugAllowBanner";
+const extDebugPaint = "ext.flutter.debugPaint";
+const extDebugPaintBaselinesEnabled = "ext.flutter.debugPaintBaselinesEnabled";
+const extInspectorShow = "ext.flutter.inspector.show";
+const extRepaintRainbow = "ext.flutter.repaintRainbow";
+const extShowPerformanceOverlay = "ext.flutter.showPerformanceOverlay";
+const extTimeDilation = "ext.flutter.timeDilation";
+
+const timeDilationNormal = 1.0;
+const timeDilationSlow = 5.0;
+
 let debugPaintingEnabled = false;
 let performanceOverlayEnabled = false;
 let repaintRainbowEnabled = false;
-let timeDilation = 1.0;
+let timeDilation = timeDilationNormal;
 let debugModeBannerEnabled = true;
 let paintBaselinesEnabled = false;
 let widgetInspectorEnabled = false;
@@ -147,21 +160,21 @@ export class DebugCommands {
 				this.disableAllServiceExtensions();
 		}));
 
-		this.registerBoolServiceCommand("ext.flutter.debugPaint", () => debugPaintingEnabled);
-		this.registerBoolServiceCommand("ext.flutter.showPerformanceOverlay", () => performanceOverlayEnabled);
-		this.registerBoolServiceCommand("ext.flutter.repaintRainbow", () => repaintRainbowEnabled);
-		this.registerServiceCommand("ext.flutter.timeDilation", () => ({ timeDilation }));
-		this.registerBoolServiceCommand("ext.flutter.debugAllowBanner", () => debugModeBannerEnabled);
-		this.registerBoolServiceCommand("ext.flutter.debugPaintBaselinesEnabled", () => paintBaselinesEnabled);
-		this.registerBoolServiceCommand("ext.flutter.inspector.show", () => widgetInspectorEnabled);
-		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleDebugPainting", () => { debugPaintingEnabled = !debugPaintingEnabled; this.sendServiceSetting("ext.flutter.debugPaint"); }));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePerformanceOverlay", () => { performanceOverlayEnabled = !performanceOverlayEnabled; this.sendServiceSetting("ext.flutter.showPerformanceOverlay"); }));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleRepaintRainbow", () => { repaintRainbowEnabled = !repaintRainbowEnabled; this.sendServiceSetting("ext.flutter.repaintRainbow"); }));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleSlowAnimations", () => { timeDilation = 6.0 - timeDilation; this.sendServiceSetting("ext.flutter.timeDilation"); }));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleDebugModeBanner", () => { debugModeBannerEnabled = !debugModeBannerEnabled; this.sendServiceSetting("ext.flutter.debugAllowBanner"); }));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePaintBaselines", () => { paintBaselinesEnabled = !paintBaselinesEnabled; this.sendServiceSetting("ext.flutter.debugPaintBaselinesEnabled"); }));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.inspectWidget", () => { widgetInspectorEnabled = true; this.sendServiceSetting("ext.flutter.inspector.show"); }));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.cancelInspectWidget", () => { widgetInspectorEnabled = false; this.sendServiceSetting("ext.flutter.inspector.show"); }));
+		this.registerBoolServiceCommand(extDebugPaint, () => debugPaintingEnabled);
+		this.registerBoolServiceCommand(extShowPerformanceOverlay, () => performanceOverlayEnabled);
+		this.registerBoolServiceCommand(extRepaintRainbow, () => repaintRainbowEnabled);
+		this.registerServiceCommand(extTimeDilation, () => ({ timeDilation }));
+		this.registerBoolServiceCommand(extDebugAllowBanner, () => debugModeBannerEnabled);
+		this.registerBoolServiceCommand(extDebugPaintBaselinesEnabled, () => paintBaselinesEnabled);
+		this.registerBoolServiceCommand(extInspectorShow, () => widgetInspectorEnabled);
+		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleDebugPainting", () => { debugPaintingEnabled = !debugPaintingEnabled; this.sendServiceSetting(extDebugPaint); }));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePerformanceOverlay", () => { performanceOverlayEnabled = !performanceOverlayEnabled; this.sendServiceSetting(extShowPerformanceOverlay); }));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleRepaintRainbow", () => { repaintRainbowEnabled = !repaintRainbowEnabled; this.sendServiceSetting(extRepaintRainbow); }));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleSlowAnimations", () => { timeDilation = timeDilationSlow - timeDilation; this.sendServiceSetting(extTimeDilation); }));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleDebugModeBanner", () => { debugModeBannerEnabled = !debugModeBannerEnabled; this.sendServiceSetting(extDebugAllowBanner); }));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePaintBaselines", () => { paintBaselinesEnabled = !paintBaselinesEnabled; this.sendServiceSetting(extDebugPaintBaselinesEnabled); }));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.inspectWidget", () => { widgetInspectorEnabled = true; this.sendServiceSetting(extInspectorShow); }));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.cancelInspectWidget", () => { widgetInspectorEnabled = false; this.sendServiceSetting(extInspectorShow); }));
 
 		// Open Observatory.
 		context.subscriptions.push(vs.commands.registerCommand("dart.openObservatory", async () => {
@@ -294,7 +307,7 @@ export class DebugCommands {
 		if (this.serviceSettings[id] && this.enabledServiceExtensions.indexOf(id) !== -1) {
 			this.serviceSettings[id]();
 
-			if (id === "ext.flutter.inspector.show")
+			if (id === extInspectorShow)
 				vs.commands.executeCommand("setContext", IS_INSPECTING_WIDGET_CONTEXT, widgetInspectorEnabled);
 		}
 	}
@@ -332,7 +345,7 @@ export class DebugCommands {
 		debugPaintingEnabled = false;
 		performanceOverlayEnabled = false;
 		repaintRainbowEnabled = false;
-		timeDilation = 1.0;
+		timeDilation = timeDilationNormal;
 		debugModeBannerEnabled = true;
 		paintBaselinesEnabled = false;
 		widgetInspectorEnabled = false;

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -180,15 +180,15 @@ export class DebugCommands {
 		this.registerServiceCommand(extDebugAllowBanner);
 		this.registerServiceCommand(extDebugPaintBaselinesEnabled);
 		this.registerServiceCommand(extInspectorShow);
-		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleDebugPainting", () => { currentExtensionState[extDebugPaint] = !currentExtensionState[extDebugPaint]; this.sendServiceSetting(extDebugPaint); }));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePerformanceOverlay", () => { currentExtensionState[extShowPerformanceOverlay] = !currentExtensionState[extShowPerformanceOverlay]; this.sendServiceSetting(extShowPerformanceOverlay); }));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleRepaintRainbow", () => { currentExtensionState[extRepaintRainbow] = !currentExtensionState[extRepaintRainbow]; this.sendServiceSetting(extRepaintRainbow); }));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleDebugPainting", () => this.toggleServiceSetting(extDebugPaint)));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePerformanceOverlay", () => this.toggleServiceSetting(extShowPerformanceOverlay)));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleRepaintRainbow", () => this.toggleServiceSetting(extRepaintRainbow)));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleSlowAnimations", () => {
 			currentExtensionState[extTimeDilation] = currentExtensionState[extTimeDilation] !== timeDilationNormal ? timeDilationNormal : timeDilationSlow;
 			this.sendServiceSetting(extTimeDilation);
 		}));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleDebugModeBanner", () => { currentExtensionState[extDebugAllowBanner] = !currentExtensionState[extDebugAllowBanner]; this.sendServiceSetting(extDebugAllowBanner); }));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePaintBaselines", () => { currentExtensionState[extDebugPaintBaselinesEnabled] = !currentExtensionState[extDebugPaintBaselinesEnabled]; this.sendServiceSetting(extDebugPaintBaselinesEnabled); }));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleDebugModeBanner", () => this.toggleServiceSetting(extDebugAllowBanner)));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePaintBaselines", () => this.toggleServiceSetting(extDebugPaintBaselinesEnabled)));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.inspectWidget", () => { currentExtensionState[extInspectorShow] = true; this.sendServiceSetting(extInspectorShow); }));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.cancelInspectWidget", () => { currentExtensionState[extInspectorShow] = false; this.sendServiceSetting(extInspectorShow); }));
 
@@ -316,6 +316,11 @@ export class DebugCommands {
 		);
 
 		return selectedItem && selectedItem.session;
+	}
+
+	private toggleServiceSetting(id: string) {
+		currentExtensionState[id] = !currentExtensionState[id];
+		this.sendServiceSetting(id);
 	}
 
 	private serviceSettings: { [id: string]: () => void } = {};

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -130,6 +130,7 @@ export class DebugCommands {
 				this.flutterExtensions.markAllServiceExtensionsUnloaded();
 		}));
 
+		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePlatform", () => this.flutterExtensions.toggle(FlutterServiceExtension.PlatformOverride, "iOS", "android")));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleDebugPainting", () => this.flutterExtensions.toggle(FlutterServiceExtension.DebugPaint)));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePerformanceOverlay", () => this.flutterExtensions.toggle(FlutterServiceExtension.PerformanceOverlay)));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleRepaintRainbow", () => this.flutterExtensions.toggle(FlutterServiceExtension.RepaintRainbow)));
@@ -224,14 +225,6 @@ export class DebugCommands {
 		}));
 		context.subscriptions.push(vs.commands.registerCommand("dart.rerunLastDebugSession", () => {
 			vs.debug.startDebugging(LastDebugSession.workspaceFolder, LastDebugSession.debugConfig);
-		}));
-
-		// Flutter toggle platform.
-		// We can't just use the service extension directly here, as we need to call it twice (once to get, once to change) and
-		// currently it seems like the DA can't return responses to us here, so we'll have to do them both inside the DA.
-		// TODO: Find out if there's a better way to do this now we get updates to service extension values.
-		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePlatform", () => {
-			debugSessions.forEach((s) => s.session.customRequest("togglePlatform"));
 		}));
 
 		// Attach commands.

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -185,12 +185,9 @@ export class DebugCommands {
 		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleRepaintRainbow", () => this.toggleServiceSetting(extRepaintRainbow)));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleDebugModeBanner", () => this.toggleServiceSetting(extDebugAllowBanner)));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePaintBaselines", () => this.toggleServiceSetting(extDebugPaintBaselinesEnabled)));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleSlowAnimations", () => {
-			currentExtensionState[extTimeDilation] = currentExtensionState[extTimeDilation] !== timeDilationNormal ? timeDilationNormal : timeDilationSlow;
-			this.sendServiceSetting(extTimeDilation);
-		}));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.inspectWidget", () => { currentExtensionState[extInspectorShow] = true; this.sendServiceSetting(extInspectorShow); }));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.cancelInspectWidget", () => { currentExtensionState[extInspectorShow] = false; this.sendServiceSetting(extInspectorShow); }));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleSlowAnimations", () => this.toggleServiceSetting(extTimeDilation, timeDilationNormal, timeDilationSlow)));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.inspectWidget", () => this.toggleServiceSetting(extInspectorShow, true, true)));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.cancelInspectWidget", () => this.toggleServiceSetting(extInspectorShow, false, false)));
 
 		// Open Observatory.
 		context.subscriptions.push(vs.commands.registerCommand("dart.openObservatory", async () => {
@@ -318,8 +315,10 @@ export class DebugCommands {
 		return selectedItem && selectedItem.session;
 	}
 
-	private toggleServiceSetting(id: string) {
-		currentExtensionState[id] = !currentExtensionState[id];
+	/// Toggles between two values. Always picks the value1 if the current value
+	// is not already value1 (eg. if it's neither of those, it'll pick val1).
+	private toggleServiceSetting(id: string, val1: any = true, val2: any = false) {
+		currentExtensionState[id] = currentExtensionState[id] !== val1 ? val1 : val2;
 		this.sendServiceSetting(id);
 	}
 

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -183,12 +183,12 @@ export class DebugCommands {
 		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleDebugPainting", () => this.toggleServiceSetting(extDebugPaint)));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePerformanceOverlay", () => this.toggleServiceSetting(extShowPerformanceOverlay)));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleRepaintRainbow", () => this.toggleServiceSetting(extRepaintRainbow)));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleDebugModeBanner", () => this.toggleServiceSetting(extDebugAllowBanner)));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePaintBaselines", () => this.toggleServiceSetting(extDebugPaintBaselinesEnabled)));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleSlowAnimations", () => {
 			currentExtensionState[extTimeDilation] = currentExtensionState[extTimeDilation] !== timeDilationNormal ? timeDilationNormal : timeDilationSlow;
 			this.sendServiceSetting(extTimeDilation);
 		}));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleDebugModeBanner", () => this.toggleServiceSetting(extDebugAllowBanner)));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePaintBaselines", () => this.toggleServiceSetting(extDebugPaintBaselinesEnabled)));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.inspectWidget", () => { currentExtensionState[extInspectorShow] = true; this.sendServiceSetting(extInspectorShow); }));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.cancelInspectWidget", () => { currentExtensionState[extInspectorShow] = false; this.sendServiceSetting(extInspectorShow); }));
 

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -173,13 +173,6 @@ export class DebugCommands {
 				this.disableAllServiceExtensions();
 		}));
 
-		this.registerServiceCommand(extDebugPaint);
-		this.registerServiceCommand(extShowPerformanceOverlay);
-		this.registerServiceCommand(extRepaintRainbow);
-		this.registerServiceCommand(extTimeDilation);
-		this.registerServiceCommand(extDebugAllowBanner);
-		this.registerServiceCommand(extDebugPaintBaselinesEnabled);
-		this.registerServiceCommand(extInspectorShow);
 		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleDebugPainting", () => this.toggleServiceSetting(extDebugPaint)));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.togglePerformanceOverlay", () => this.toggleServiceSetting(extShowPerformanceOverlay)));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.toggleRepaintRainbow", () => this.toggleServiceSetting(extRepaintRainbow)));
@@ -322,10 +315,9 @@ export class DebugCommands {
 		this.sendServiceSetting(id);
 	}
 
-	private serviceSettings: { [id: string]: () => void } = {};
 	private sendServiceSetting(id: string) {
-		if (this.serviceSettings[id] && this.enabledServiceExtensions.indexOf(id) !== -1) {
-			this.serviceSettings[id]();
+		if (currentExtensionState[id] !== undefined && this.enabledServiceExtensions.indexOf(id) !== -1) {
+			debugSessions.forEach((s) => this.runServiceCommand(s, id));
 
 			this.updateInspectingWidgetContextIfRequired(id);
 		}
@@ -337,14 +329,8 @@ export class DebugCommands {
 	}
 
 	private sendAllServiceSettings() {
-		for (const id in this.serviceSettings)
+		for (const id in currentExtensionState)
 			this.sendServiceSetting(id);
-	}
-
-	private registerServiceCommand(id: string): void {
-		this.serviceSettings[id] = () => {
-			debugSessions.forEach((s) => this.runServiceCommand(s, id));
-		};
 	}
 
 	private runServiceCommand(session: DartDebugSessionInformation, method: string) {

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -119,6 +119,8 @@ export class DebugCommands {
 				this.onFirstFrameEmitter.fire();
 			} else if (e.event === "dart.flutter.updateIsWidgetCreationTracked") {
 				vs.commands.executeCommand("setContext", TRACK_WIDGET_CREATION_ENABLED, e.body.isWidgetCreationTracked);
+			} else if (e.event === "dart.flutter.serviceExtensionStateChanged") {
+				this.updateServiceExtensionState(e.body.extension, e.body.value);
 			} else if (e.event === "dart.debugMetrics") {
 				const memory = e.body.memory;
 				const message = `${Math.ceil(memory.current / 1024 / 1024)}MB of ${Math.ceil(memory.total / 1024 / 1024)}MB`;
@@ -358,6 +360,21 @@ export class DebugCommands {
 		}
 		this.enabledServiceExtensions.length = 0;
 		vs.commands.executeCommand("setContext", TRACK_WIDGET_CREATION_ENABLED, false);
+	}
+
+	private updateServiceExtensionState(id: string, value: any) {
+		// Don't try to process service extension we don't know about.
+		if (currentExtensionState[id] === undefined) {
+			return;
+		}
+
+		// HACK: This is because the values we get are currently all strings.
+		if (typeof value === "string") {
+			value = JSON.parse(value);
+		}
+
+		currentExtensionState[id] = value;
+		this.updateInspectingWidgetContextIfRequired(id);
 	}
 }
 

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -328,9 +328,13 @@ export class DebugCommands {
 		if (this.serviceSettings[id] && this.enabledServiceExtensions.indexOf(id) !== -1) {
 			this.serviceSettings[id]();
 
-			if (id === extInspectorShow)
-				vs.commands.executeCommand("setContext", IS_INSPECTING_WIDGET_CONTEXT, currentExtensionState[id]);
+			this.updateInspectingWidgetContextIfRequired(id);
 		}
+	}
+
+	private updateInspectingWidgetContextIfRequired(id: string) {
+		if (id === extInspectorShow)
+			vs.commands.executeCommand("setContext", IS_INSPECTING_WIDGET_CONTEXT, currentExtensionState[id]);
 	}
 
 	private sendAllServiceSettings() {

--- a/src/debug/dart_debug_protocol.ts
+++ b/src/debug/dart_debug_protocol.ts
@@ -19,6 +19,7 @@ export interface VMEvent {
 	atAsyncSuspension?: boolean;
 	extensionRPC?: string;
 	extensionKind?: string;
+	extensionData?: any;
 }
 
 export interface VMBreakpoint extends VMObj {
@@ -538,4 +539,9 @@ export class ObservatoryConnection {
 	public close() {
 		this.socket.close();
 	}
+}
+
+export interface FlutterServiceExtensionStateChangedData {
+	extension: string;
+	value: any;
 }

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -308,6 +308,8 @@ export class FlutterDebugSession extends DartDebugSession {
 			this.sendEvent(new Event("dart.flutter.firstFrame", {}));
 		} else if (event.kind === "Extension" && event.extensionKind === "Flutter.Frame") {
 			this.requestCoverageUpdate("frame");
+		} else if (event.kind === "Extension" && event.extensionKind === "Flutter.ServiceExtensionStateChanged") {
+			this.sendEvent(new Event("dart.flutter.serviceExtensionStateChanged", event.extensionData));
 		} else {
 			super.handleExtensionEvent(event);
 		}

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -219,10 +219,10 @@ export class FlutterDebugSession extends DartDebugSession {
 					this.sendResponse(response);
 					break;
 
-				case "togglePlatform":
+				case "checkPlatformOverride":
 					if (this.currentRunningAppId) {
 						const result = await this.flutter.callServiceExtension(this.currentRunningAppId, "ext.flutter.platformOverride", null);
-						await this.flutter.callServiceExtension(this.currentRunningAppId, "ext.flutter.platformOverride", { value: result.value === "android" ? "iOS" : "android" });
+						this.sendEvent(new Event("dart.flutter.updatePlatformOverride", { platform: result.value }));
 					}
 					this.sendResponse(response);
 					break;

--- a/src/flutter/vm_service_extensions.ts
+++ b/src/flutter/vm_service_extensions.ts
@@ -1,0 +1,146 @@
+import * as vs from "vscode";
+import { SERVICE_EXTENSION_CONTEXT_PREFIX } from "../extension";
+import { TRACK_WIDGET_CREATION_ENABLED } from "../providers/debug_config_provider";
+
+export const IS_INSPECTING_WIDGET_CONTEXT = "dart-code:flutter.isInspectingWidget";
+
+/// The service extensions we know about and allow toggling via commands.
+export enum FlutterServiceExtension {
+	DebugBanner = "ext.flutter.debugAllowBanner",
+	DebugPaint = "ext.flutter.debugPaint",
+	PaintBaselines = "ext.flutter.debugPaintBaselinesEnabled",
+	InspectorSelectMode = "ext.flutter.inspector.show",
+	RepaintRainbow = "ext.flutter.repaintRainbow",
+	PerformanceOverlay = "ext.flutter.showPerformanceOverlay",
+	SlowAnimations = "ext.flutter.timeDilation",
+}
+
+const keyTimeDilation = "timeDilation";
+const keyEnabled = "enabled";
+
+/// Service extension values must be wrapped in objects when sent to the VM, eg:
+///
+///     { timeDilation: x.x }
+///     { enabled: true }
+///
+/// This map tracks the name of the key for a fivengiven extension.
+const extensionStateKeys: { [key: string]: string } = {
+	[FlutterServiceExtension.DebugBanner]: keyEnabled,
+	[FlutterServiceExtension.DebugPaint]: keyEnabled,
+	[FlutterServiceExtension.PaintBaselines]: keyEnabled,
+	[FlutterServiceExtension.InspectorSelectMode]: keyEnabled,
+	[FlutterServiceExtension.RepaintRainbow]: keyEnabled,
+	[FlutterServiceExtension.PerformanceOverlay]: keyEnabled,
+	[FlutterServiceExtension.SlowAnimations]: keyTimeDilation,
+};
+
+export const timeDilationNormal = 1.0;
+export const timeDilationSlow = 5.0;
+
+/// Default values for each service extension.
+const defaultExtensionState: { [key: string]: any } = {
+	[FlutterServiceExtension.DebugBanner]: true,
+	[FlutterServiceExtension.DebugPaint]: false,
+	[FlutterServiceExtension.PaintBaselines]: false,
+	[FlutterServiceExtension.InspectorSelectMode]: false,
+	[FlutterServiceExtension.RepaintRainbow]: false,
+	[FlutterServiceExtension.PerformanceOverlay]: false,
+	[FlutterServiceExtension.SlowAnimations]: timeDilationNormal,
+};
+
+export interface FlutterServiceExtensionArgs { type: FlutterServiceExtension; params: any; }
+
+/// Manages state for Flutter VM service extensions.
+export class FlutterVmServiceExtensions {
+	private loadedServiceExtensions: FlutterServiceExtension[] = [];
+	private currentExtensionState = Object.assign({}, defaultExtensionState);
+	private sendValueToVM: (extension: FlutterServiceExtension) => void;
+
+	constructor(sendRequest: (extension: FlutterServiceExtension, args: FlutterServiceExtensionArgs) => void) {
+		// To avoid any code in this class accidentally calling sendRequestToFlutter directly, we wrap it here and don't
+		// keep a reference to it.
+		this.sendValueToVM = (extension: FlutterServiceExtension) => {
+			// Only ever send values for enabled and known extensions.
+			if (this.loadedServiceExtensions.indexOf(extension) !== -1 && extensionStateKeys[extension] !== undefined) {
+				// Build the args in the required format using the correct key and value.
+				const params = { [extensionStateKeys[extension]]: this.currentExtensionState[extension] };
+				const args = { type: extension, params };
+
+				sendRequest(extension, args);
+
+				this.syncInspectingWidgetContext(extension);
+			}
+		};
+	}
+
+	/// Handles an event from the Debugger, such as extension services being loaded and values updated.
+	public handleDebugEvent(e: vs.DebugSessionCustomEvent): void {
+		if (e.event === "dart.serviceExtensionAdded") {
+			this.handleServiceExtensionLoaded(e.body.id);
+
+			// If the isWidgetCreationTracked extension loads, send a command to the debug adapter
+			// asking it to query whether it's enabled (it'll send us an event back with the answer).
+			if (e.body.id === "ext.flutter.inspector.isWidgetCreationTracked") {
+				e.session.customRequest("checkIsWidgetCreationTracked");
+			}
+
+		} else if (e.event === "dart.flutter.firstFrame") {
+			// Send all values back to the VM on the first frame so that they persist across restarts.
+			for (const extension in FlutterServiceExtension)
+				this.sendValueToVM(extension as FlutterServiceExtension);
+		} else if (e.event === "dart.flutter.updateIsWidgetCreationTracked") {
+			vs.commands.executeCommand("setContext", TRACK_WIDGET_CREATION_ENABLED, e.body.isWidgetCreationTracked);
+		} else if (e.event === "dart.flutter.serviceExtensionStateChanged") {
+			this.handleRemoteValueUpdate(e.body.extension, e.body.value);
+		}
+	}
+
+	/// Toggles between two values. Always picks the value1 if the current value
+	// is not already value1 (eg. if it's neither of those, it'll pick val1).
+	public toggle(id: FlutterServiceExtension, val1: any = true, val2: any = false) {
+		this.currentExtensionState[id] = this.currentExtensionState[id] !== val1 ? val1 : val2;
+		this.sendValueToVM(id);
+	}
+
+	/// Keep the context in sync so that the "Cancel Inspect Widget" command is enabled/disabled.
+	private syncInspectingWidgetContext(id: string) {
+		vs.commands.executeCommand("setContext", IS_INSPECTING_WIDGET_CONTEXT, this.currentExtensionState[FlutterServiceExtension.InspectorSelectMode]);
+	}
+
+	/// Handles updates that come from the VM (eg. were updated by another tool).
+	private handleRemoteValueUpdate(id: string, value: any) {
+		// Don't try to process service extension we don't know about.
+		if (this.currentExtensionState[id] === undefined) {
+			return;
+		}
+
+		// HACK: This is because the values we get are currently all strings.
+		if (typeof value === "string") {
+			value = JSON.parse(value);
+		}
+
+		this.currentExtensionState[id] = value;
+		this.syncInspectingWidgetContext(id);
+	}
+
+	/// Resets all local state to defaults - used when terminating the last debug session (or
+	// starting the first) to ensure debug toggles don't "persist" across sessions.
+	public resetToDefaults() {
+		this.currentExtensionState = Object.assign({}, defaultExtensionState);
+	}
+
+	/// Tracks loaded service extensions and updates contexts to enable VS Code commands.
+	private handleServiceExtensionLoaded(id: FlutterServiceExtension) {
+		this.loadedServiceExtensions.push(id);
+		vs.commands.executeCommand("setContext", `${SERVICE_EXTENSION_CONTEXT_PREFIX}${id}`, true);
+	}
+
+	/// Marks all service extensions as not-loaded in the context to disable VS Code Commands.
+	public markAllServiceExtensionsUnloaded() {
+		for (const id of this.loadedServiceExtensions) {
+			vs.commands.executeCommand("setContext", `${SERVICE_EXTENSION_CONTEXT_PREFIX}${id}`, undefined);
+		}
+		this.loadedServiceExtensions.length = 0;
+		vs.commands.executeCommand("setContext", TRACK_WIDGET_CREATION_ENABLED, false);
+	}
+}


### PR DESCRIPTION
This listens for `Flutter.ServiceExtensionStateChanged` events and updates the local state for those service extension values.

As part of it, I tidied up a lot of this code so there was less duplication and string IDs all over the place, and extracted the extension state tracking from `debug.ts` into a new file `flutter/vm_service_extensions.ts`.

Also changed the platform override to work more like the others, being a standard toggle (between Android/iOS), and with a request sent when the extension loads to get the default value (since it'll vary by device (it's possible this isn't needed in newer versions of Flutter that transmit them all at the start, but this makes old Flutter work correctly too).