### PR TITLE
Stop "pub get on save" being super-aggro

### DIFF
--- a/test/dart_only/commands/pub_get.test.ts
+++ b/test/dart_only/commands/pub_get.test.ts
@@ -3,7 +3,7 @@ import * as sinon from "sinon";
 import * as vs from "vscode";
 import { activate, delay, helloWorldPubspec, openFile, sb, setConfigForTest, setTestContent } from "../../helpers";
 
-describe.only("pub get", () => {
+describe("pub get", () => {
 
 	beforeEach("activate", () => activate());
 

--- a/test/dart_only/commands/pub_get.test.ts
+++ b/test/dart_only/commands/pub_get.test.ts
@@ -1,0 +1,62 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as vs from "vscode";
+import { activate, delay, helloWorldPubspec, openFile, sb, setConfigForTest, setTestContent } from "../../helpers";
+
+describe.only("pub get", () => {
+
+	beforeEach("activate", () => activate());
+
+	it("runs automatically when pubspec is saved", async () => {
+		const executeCommand = sb.stub(vs.commands, "executeCommand").callThrough();
+		const getPackagesCommand = executeCommand.withArgs("dart.getPackages", sinon.match.any).resolves();
+
+		const editor = await openFile(helloWorldPubspec);
+		const doc = editor.document;
+		await setTestContent(doc.getText() + " ");
+		await doc.save();
+
+		assert.ok(getPackagesCommand.calledOnce);
+	});
+
+	it("does not run automatically if disabled", async () => {
+		await setConfigForTest("dart", "runPubGetOnPubspecChanges", false);
+
+		const executeCommand = sb.stub(vs.commands, "executeCommand").callThrough();
+		const getPackagesCommand = executeCommand.withArgs("dart.getPackages", sinon.match.any).resolves();
+
+		const editor = await openFile(helloWorldPubspec);
+		const doc = editor.document;
+		await setTestContent(doc.getText() + " ");
+		await doc.save();
+
+		assert.ok(!getPackagesCommand.calledOnce);
+	});
+
+	it("runs delayed when pubspec is auto-saved", async () => {
+		await setConfigForTest("files", "autoSave", "afterDelay");
+
+		const executeCommand = sb.stub(vs.commands, "executeCommand").callThrough();
+		const getPackagesCommand = executeCommand.withArgs("dart.getPackages", sinon.match.any).resolves();
+
+		const editor = await openFile(helloWorldPubspec);
+		const doc = editor.document;
+		await setTestContent(doc.getText() + " ");
+
+		// Wait for 1sec and ensure it wasn't called.
+		await delay(1000);
+		assert.ok(!getPackagesCommand.called);
+
+		// Wait for 7sec and make another change to test debouncing.
+		await delay(7000);
+		await setTestContent(doc.getText() + " ");
+
+		// Wait for 5sec and ensure it still wasn't called (because it was pushed back to 10sec again).
+		await delay(5000);
+		assert.ok(!getPackagesCommand.called);
+
+		// Wait enough time that it definitely should've been called.
+		await delay(10000);
+		assert.ok(getPackagesCommand.called);
+	});
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -30,6 +30,7 @@ if (!ext) {
 
 export const helloWorldFolder = vs.Uri.file(path.join(ext.extensionPath, "test/test_projects/hello_world"));
 export const helloWorldMainFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "bin/main.dart"));
+export const helloWorldPubspec = vs.Uri.file(path.join(fsPath(helloWorldFolder), "pubspec.yaml"));
 export const helloWorldGettersFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "bin/getters.dart"));
 export const helloWorldBrokenFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "bin/broken.dart"));
 export const helloWorldGoodbyeFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "bin/goodbye.dart"));
@@ -664,4 +665,11 @@ export function watchPromise<T>(name: string, promise: Promise<T>): Promise<T> {
 	setTimeout(checkResult, 3000); // First log is after 3s, rest are 10s.
 
 	return promise;
+}
+
+export async function setConfigForTest(section: string, key: string, value: any): Promise<void> {
+	const conf = vs.workspace.getConfiguration(section);
+	const oldValue = conf.inspect(key).globalValue;
+	await conf.update(key, value, vs.ConfigurationTarget.Global);
+	defer(() => conf.update(key, oldValue, vs.ConfigurationTarget.Global));
 }


### PR DESCRIPTION
Fixes #1427.

@paulcbetts how does this seem to you?

I've uploaded a build here if you want to try it out:

https://github.com/Dart-Code/Dart-Code/releases/tag/v2.23.0-alpha.1.delay-pub-get

Download the vsix and install with `Extensions: Install from VSIX`. It'll auto-update you back to stable once we publish the next release (which will include this if the feedback is good).