### PR TITLE
Prompt users (once) to install the Flutter extension when opening a Flutter project if they don't have it

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -388,7 +388,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 
 	// Prompt user for any special config we might want to set.
 	if (!isRestart)
-		showUserPrompts(context);
+		showUserPrompts(context, sdks);
 
 	// Turn on all the commands.
 	setCommandVisiblity(true, sdks.projectType);

--- a/src/user_prompts.ts
+++ b/src/user_prompts.ts
@@ -17,6 +17,9 @@ export function showUserPrompts(context: vs.ExtensionContext, sdks: Sdks) {
 		return context.globalState.get(stateKey) === true;
 	}
 
+	/// Shows a prompt and stores the return value. Prompt should return `true` to mark
+	/// this extension as seen-forever and it won't be shown again. Returning anything
+	/// else will allow the prompt to appear again next time.
 	function showPrompt(key: string, prompt: () => Thenable<boolean>): void {
 		const stateKey = `${promptPrefix}${key}`;
 		prompt().then((res) => context.globalState.update(stateKey, res), error);
@@ -50,7 +53,7 @@ function prompt(context: vs.ExtensionContext, key: string, prompt: () => Thenabl
 
 async function promptToInstallFlutterExtension(): Promise<boolean> {
 	const res = await vs.window.showInformationMessage(
-		"Working on a Flutter project? Install the Flutter extension for additional future functionality.",
+		"Working on a Flutter project? Install the Flutter extension for additional functionality.",
 		"Show Me",
 	);
 	if (res) {


### PR DESCRIPTION
![screenshot 2019-01-29 at 11 52 07 am](https://user-images.githubusercontent.com/1078012/51906583-534eae80-23bc-11e9-8ac3-006833133295.png)

The prompt will only appear if you don't have the Flutter extension and open a Flutter project. Once you either click **Show Me** or dismiss the notification, it will never be shown again (note: if you just ignore it so VS Code hides it into the notification area without it being dismissed, you will see it again the next time).