### PR TITLE
Keep track of whether a file supports pub-run-test in the file tracker

### DIFF
--- a/src/code_lens/test_code_lens_provider.ts
+++ b/src/code_lens/test_code_lens_provider.ts
@@ -2,8 +2,7 @@ import { CancellationToken, CodeLens, CodeLensProvider, commands, debug, Event, 
 import { Analyzer } from "../analysis/analyzer";
 import { OpenFileTracker } from "../analysis/open_file_tracker";
 import { flatMap, IAmDisposable } from "../debug/utils";
-import { locateBestProjectRoot } from "../project";
-import { fsPath, projectSupportsPubRunTest, toRange } from "../utils";
+import { toRange } from "../utils";
 import { TestOutlineInfo, TestOutlineVisitor } from "../utils/outline";
 import { getLaunchConfig } from "../utils/test";
 
@@ -41,8 +40,7 @@ export class TestCodeLensProvider implements CodeLensProvider, IAmDisposable {
 
 		// We should only show the Code Lens for projects we know can actually handle `pub run` (for ex. the
 		// SDK codebase cannot, and will therefore run all tests when you click them).
-		const projectRoot = locateBestProjectRoot(fsPath(document.uri));
-		if (!projectRoot || !projectSupportsPubRunTest(projectRoot))
+		if (!OpenFileTracker.supportsPubRunTest(document.uri))
 			return;
 
 		const visitor = new TestOutlineVisitor();

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,7 +1,5 @@
 import * as vs from "vscode";
 import { OpenFileTracker } from "../analysis/open_file_tracker";
-import { locateBestProjectRoot } from "../project";
-import { fsPath, projectSupportsPubRunTest } from "../utils";
 import { TestOutlineInfo, TestOutlineVisitor } from "../utils/outline";
 
 export const CURSOR_IS_IN_TEST = "dart-code:cursorIsInTest";
@@ -44,10 +42,9 @@ export class TestCommands implements vs.Disposable {
 		if (!outline || !outline.children || !outline.children.length)
 			return;
 
-		// We should only show the Code Lens for projects we know can actually handle `pub run` (for ex. the
-		// SDK codebase cannot, and will therefore run all tests when you click them).
-		const projectRoot = locateBestProjectRoot(fsPath(document.uri));
-		if (!projectRoot || !projectSupportsPubRunTest(projectRoot))
+		// We should only allow running for projects we know can actually handle `pub run` (for ex. the
+		// SDK codebase cannot, and will therefore run all tests).
+		if (!OpenFileTracker.supportsPubRunTest(document.uri))
 			return;
 
 		const visitor = new TestOutlineVisitor();

--- a/src/providers/debug_config_provider.ts
+++ b/src/providers/debug_config_provider.ts
@@ -17,7 +17,7 @@ import { FlutterCapabilities } from "../flutter/capabilities";
 import { FlutterDeviceManager } from "../flutter/device_manager";
 import { locateBestProjectRoot } from "../project";
 import { dartVMPath, flutterPath, pubPath, pubSnapshotPath } from "../sdk/utils";
-import { fsPath, isDartFile, isFlutterProjectFolder, isFlutterWorkspaceFolder, isInsideFolderNamed, isTestFile, isTestFileOrFolder, projectSupportsPubRunTest, ProjectType, Sdks } from "../utils";
+import { fsPath, isDartFile, isFlutterProjectFolder, isFlutterWorkspaceFolder, isInsideFolderNamed, isTestFile, isTestFileOrFolder, checkProjectSupportsPubRunTest, ProjectType, Sdks } from "../utils";
 import { log, logError, logWarn } from "../utils/log";
 import { TestResultsProvider } from "../views/test_view";
 
@@ -167,7 +167,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		const isTest = debugConfig.program && isTestFileOrFolder(debugConfig.program as string);
 		if (isTest)
 			log(`Detected launch project as a Test project`);
-		const canPubRunTest = isTest && debugConfig.cwd && projectSupportsPubRunTest(debugConfig.cwd as string);
+		const canPubRunTest = isTest && debugConfig.cwd && checkProjectSupportsPubRunTest(debugConfig.cwd as string);
 		if (isTest && !canPubRunTest)
 			log(`Project does not appear to support 'pub run test', will use VM directly`);
 		const debugType = isFlutter

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -177,7 +177,7 @@ export function isTestFolder(path: string): boolean {
 	return path && isInsideFolderNamed(path, "test") && fs.existsSync(path) && fs.statSync(path).isDirectory();
 }
 
-export function projectSupportsPubRunTest(folder: string): boolean {
+export function checkProjectSupportsPubRunTest(folder: string): boolean {
 	return hasPackagesFile(folder) && hasPubspec(folder);
 }
 


### PR DESCRIPTION
This avoids querying on every keypress now that we need to update the run-test-at-cursor context.

Fixes #1441.