### PR TITLE
Avoid activation failures due to link file errors

### DIFF
--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -6,7 +6,7 @@ export function getChildFolders(parent: string): string[] {
 		return [];
 	return fs.readdirSync(parent)
 		.map((item) => path.join(parent, item))
-		.filter((item) => fs.statSync(item).isDirectory());
+		.filter((item) => fs.existsSync(item) && fs.statSync(item).isDirectory());
 }
 
 export function hasPackagesFile(folder: string): boolean {


### PR DESCRIPTION
![test](https://qzonestyle.gtimg.cn/aoi/sola/20190216161422_XlIL3pyzmi.png)

Reproduce step:
```
// In the project folder's primary directory
touch ln_origin.txt 
ln -s ln_origin.txt ln_linked.txt
rm ln_origin.txt
// open VSCode and activate Dart-Code(Flutter plugin)
```

If there is a soft link file, but the original file is deleted, `fs.statSync`will throw an error and cause the activation to fail. 
