### PR TITLE
Run downloads/setups of Dart/Flutter in parallel during CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,77 +32,78 @@ addons:
       - gcc-4.8
 
 before_install:
-  - mkdir with\ spaces
-  - cd with\ spaces
+  - |
+    mkdir with\ spaces
+    cd with\ spaces
 
 
-  - echo Setting variables...
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CXX="g++-4.8" CC="gcc-4.8" DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-      sleep 3;
-    fi
-  - export ELECTRON_NO_ATTACH_CONSOLE=1
-  - export TRAVIS_COMMIT_AUTHOR="$(git log -1 $TRAVIS_COMMIT --pretty="%aN")"
-  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-      export DART_OS=macos;
-    else
-      export DART_OS=linux;
-    fi
-  - if [[ $ONLY_RUN_DART_VERSION == "STABLE" ]]; then
-      export DART_CHANNEL=stable/release;
-      export FLUTTER_BRANCH=stable;
-    elif [[ $ONLY_RUN_DART_VERSION == "DEV" ]]; then
-      export DART_CHANNEL=dev/release;
-      export FLUTTER_BRANCH=dev;
-    else
-      export DART_CHANNEL=be/raw;
-      export FLUTTER_BRANCH=master;
-    fi
-  - export FLUTTER_PATH=`pwd`/flutter
-  - export DART_PATH=`pwd`/dart-sdk
-  - export DART_PATH_SYMLINK=`pwd`/fakedart:`pwd`/dartsymlinkbins
-  - export FLUTTER_PATH_SYMLINK=`pwd`/fluttersymlinkbins
+    echo Setting variables...
+    if [ $TRAVIS_OS_NAME == "linux" ]; then
+        export CXX="g++-4.8" CC="gcc-4.8" DISPLAY=:99.0;
+        sh -e /etc/init.d/xvfb start;
+        sleep 3;
+      fi
+    export ELECTRON_NO_ATTACH_CONSOLE=1
+    export TRAVIS_COMMIT_AUTHOR="$(git log -1 $TRAVIS_COMMIT --pretty="%aN")"
+    if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+        export DART_OS=macos;
+      else
+        export DART_OS=linux;
+      fi
+    if [[ $ONLY_RUN_DART_VERSION == "STABLE" ]]; then
+        export DART_CHANNEL=stable/release;
+        export FLUTTER_BRANCH=stable;
+      elif [[ $ONLY_RUN_DART_VERSION == "DEV" ]]; then
+        export DART_CHANNEL=dev/release;
+        export FLUTTER_BRANCH=dev;
+      else
+        export DART_CHANNEL=be/raw;
+        export FLUTTER_BRANCH=master;
+      fi
+    export FLUTTER_PATH=`pwd`/flutter
+    export DART_PATH=`pwd`/dart-sdk
+    export DART_PATH_SYMLINK=`pwd`/fakedart:`pwd`/dartsymlinkbins
+    export FLUTTER_PATH_SYMLINK=`pwd`/fluttersymlinkbins
 
 
-  - echo Installing Misc...
-  - gem install dpl
+    echo Installing Misc...
+    gem install dpl
 
 
-  - echo Installing Dart...
-  - curl https://storage.googleapis.com/dart-archive/channels/$DART_CHANNEL/latest/sdk/dartsdk-$DART_OS-x64-release.zip > dart-sdk.zip
-  - unzip dart-sdk.zip > /dev/null
-  - dart-sdk/bin/pub global activate --no-executables stagehand
-  - dart-sdk/bin/pub global activate --no-executables args 1.5.0
-  - dart-sdk/bin/pub global activate --no-executables meta 1.1.6
-  - dart-sdk/bin/pub global activate --no-executables devtools
+    echo Installing Dart...
+    curl https://storage.googleapis.com/dart-archive/channels/$DART_CHANNEL/latest/sdk/dartsdk-$DART_OS-x64-release.zip > dart-sdk.zip
+    unzip dart-sdk.zip > /dev/null
+    dart-sdk/bin/pub global activate --no-executables stagehand
+    dart-sdk/bin/pub global activate --no-executables args 1.5.0
+    dart-sdk/bin/pub global activate --no-executables meta 1.1.6
+    dart-sdk/bin/pub global activate --no-executables devtools
 
 
-  - echo Installing Flutter...
-  - git clone -b $FLUTTER_BRANCH https://github.com/flutter/flutter.git
-  - flutter/bin/flutter config --no-analytics
-  - flutter/bin/flutter update-packages
-  - flutter/bin/flutter doctor
+    echo Installing Flutter...
+    git clone -b $FLUTTER_BRANCH https://github.com/flutter/flutter.git
+    flutter/bin/flutter config --no-analytics
+    flutter/bin/flutter update-packages
+    flutter/bin/flutter doctor
 
-  # To ensure we follow symlinks properly, put links
-  # in folders that we'll use in PATHs.
-  - mkdir dartsymlinkbins
-  - ln -s ../dart-sdk/bin/dart dartsymlinkbins/dart
-  - mkdir fluttersymlinkbins
-  - ln -s ../flutter/bin/flutter fluttersymlinkbins/flutter
+    # To ensure we follow symlinks properly, put links
+    # in folders that we'll use in PATHs.
+    mkdir dartsymlinkbins
+    ln -s ../dart-sdk/bin/dart dartsymlinkbins/dart
+    mkdir fluttersymlinkbins
+    ln -s ../flutter/bin/flutter fluttersymlinkbins/flutter
 
-  # To ensure we detectonly detect real SDKs and not non-Dartlang
-  # dart binaries, add a fake dart that is actually just echo
-  - mkdir fakedart
-  - ln -s /bin/echo fakedart/dart
+    # To ensure we detectonly detect real SDKs and not non-Dartlang
+    # dart binaries, add a fake dart that is actually just echo
+    mkdir fakedart
+    ln -s /bin/echo fakedart/dart
 
 
-  - dart-sdk/bin/dart --version
-  - flutter/bin/flutter --version
-  - dartsymlinkbins/dart --version
-  - fluttersymlinkbins/flutter --version
-  - node --version
-  - npm --version
+    dart-sdk/bin/dart --version
+    flutter/bin/flutter --version
+    dartsymlinkbins/dart --version
+    fluttersymlinkbins/flutter --version
+    node --version
+    npm --version
 
 
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,21 +32,23 @@ addons:
       - gcc-4.8
 
 before_install:
-  - echo Misc setup
-  - export ELECTRON_NO_ATTACH_CONSOLE=1
-  - export TRAVIS_COMMIT_AUTHOR="$(git log -1 $TRAVIS_COMMIT --pretty="%aN")"
-  - gem install dpl
+  - mkdir with\ spaces
+  - cd with\ spaces
+
+
+  - echo Setting variables...
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
       export CXX="g++-4.8" CC="gcc-4.8" DISPLAY=:99.0;
       sh -e /etc/init.d/xvfb start;
       sleep 3;
     fi
+  - export ELECTRON_NO_ATTACH_CONSOLE=1
+  - export TRAVIS_COMMIT_AUTHOR="$(git log -1 $TRAVIS_COMMIT --pretty="%aN")"
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
       export DART_OS=macos;
     else
       export DART_OS=linux;
     fi
-  - echo Setting variables...
   - if [[ $ONLY_RUN_DART_VERSION == "STABLE" ]]; then
       export DART_CHANNEL=stable/release;
       export FLUTTER_BRANCH=stable;
@@ -57,17 +59,30 @@ before_install:
       export DART_CHANNEL=be/raw;
       export FLUTTER_BRANCH=master;
     fi
-  - mkdir with\ spaces
-  - cd with\ spaces
-  - echo Downloading Dart and Flutter...
-  - curl https://storage.googleapis.com/dart-archive/channels/$DART_CHANNEL/latest/sdk/dartsdk-$DART_OS-x64-release.zip > dart-sdk.zip
-  - unzip dart-sdk.zip > /dev/null
-  - git clone -b $FLUTTER_BRANCH https://github.com/flutter/flutter.git
-  - echo Configuring Dart and Flutter...
-  - flutter/bin/flutter config --no-analytics
-  - flutter/bin/flutter update-packages
   - export FLUTTER_PATH=`pwd`/flutter
   - export DART_PATH=`pwd`/dart-sdk
+  - export DART_PATH_SYMLINK=`pwd`/fakedart:`pwd`/dartsymlinkbins
+  - export FLUTTER_PATH_SYMLINK=`pwd`/fluttersymlinkbins
+
+
+  - echo Installing Misc...
+  - gem install dpl
+
+
+  - echo Installing Dart...
+  - curl https://storage.googleapis.com/dart-archive/channels/$DART_CHANNEL/latest/sdk/dartsdk-$DART_OS-x64-release.zip > dart-sdk.zip
+  - unzip dart-sdk.zip > /dev/null
+  - dart-sdk/bin/pub global activate --no-executables stagehand
+  - dart-sdk/bin/pub global activate --no-executables args 1.5.0
+  - dart-sdk/bin/pub global activate --no-executables meta 1.1.6
+  - dart-sdk/bin/pub global activate --no-executables devtools
+
+
+  - echo Installing Flutter...
+  - git clone -b $FLUTTER_BRANCH https://github.com/flutter/flutter.git
+  - flutter/bin/flutter config --no-analytics
+  - flutter/bin/flutter update-packages
+  - flutter/bin/flutter doctor
 
   # To ensure we follow symlinks properly, put links
   # in folders that we'll use in PATHs.
@@ -81,19 +96,15 @@ before_install:
   - mkdir fakedart
   - ln -s /bin/echo fakedart/dart
 
-  - export DART_PATH_SYMLINK=`pwd`/fakedart:`pwd`/dartsymlinkbins
-  - export FLUTTER_PATH_SYMLINK=`pwd`/fluttersymlinkbins
+
   - dart-sdk/bin/dart --version
   - flutter/bin/flutter --version
   - dartsymlinkbins/dart --version
   - fluttersymlinkbins/flutter --version
   - node --version
   - npm --version
-  - flutter/bin/flutter doctor
-  - dart-sdk/bin/pub global activate stagehand
-  - dart-sdk/bin/pub global activate args 1.5.0
-  - dart-sdk/bin/pub global activate meta 1.1.6
-  - dart-sdk/bin/pub global activate devtools
+
+
   - cd ..
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,8 +93,6 @@ before_install:
           echo Installing Flutter...
           git clone -b $FLUTTER_BRANCH https://github.com/flutter/flutter.git
           flutter/bin/flutter config --no-analytics
-          flutter/bin/flutter update-packages
-          flutter/bin/flutter doctor
         )
       ) &
 
@@ -102,6 +100,14 @@ before_install:
       echo
       echo Total time for parallel tasks...
     )
+
+    (
+      echo Running update-packages and doctor in background...
+      echo If these don't complete before tests get to Flutter tests,
+      echo things may fail, but if they do, it will have saved many minutes!
+      flutter/bin/flutter update-packages
+      flutter/bin/flutter doctor
+    ) &
 
     # To ensure we follow symlinks properly, put links
     # in folders that we'll use in PATHs.

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,7 @@ before_install:
       echo "things may fail, but if they do, it will have saved many minutes"
       flutter/bin/flutter update-packages
       flutter/bin/flutter doctor
+      fluttersymlinkbins/flutter --version
     ) &
 
     # To ensure we follow symlinks properly, put links
@@ -125,7 +126,7 @@ before_install:
     dart-sdk/bin/dart --version
     flutter/bin/flutter --version
     dartsymlinkbins/dart --version
-    fluttersymlinkbins/flutter --version
+    # Flutter version is run above in the background job, to avoid it hanging here on startup lock.
     node --version
     npm --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ before_install:
     (
       echo Running update-packages and doctor in background...
       echo If these don't complete before tests get to Flutter tests,
-      echo things may fail, but if they do, it will have saved many minutes!
+      echo things may fail, but if they do, it will have saved many minutes
       flutter/bin/flutter update-packages
       flutter/bin/flutter doctor
     ) &

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,10 +101,10 @@ before_install:
       echo Total time for parallel tasks...
     )
 
-    (
-      echo Running update-packages and doctor in background...
-      echo If these don't complete before tests get to Flutter tests,
-      echo things may fail, but if they do, it will have saved many minutes
+    time (
+      echo "Running update-packages and doctor in background..."
+      echo "If these don't complete before tests get to Flutter tests,"
+      echo "things may fail, but if they do, it will have saved many minutes"
       flutter/bin/flutter update-packages
       flutter/bin/flutter doctor
     ) &

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,8 @@ before_install:
       fluttersymlinkbins/flutter --version
     ) &
 
+    wait
+
     # To ensure we follow symlinks properly, put links
     # in folders that we'll use in PATHs.
     mkdir dartsymlinkbins

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,32 +66,42 @@ before_install:
     export FLUTTER_PATH_SYMLINK=`pwd`/fluttersymlinkbins
 
 
-    (
-      echo Installing Misc...
-      gem install dpl
-    ) &
+    time (
+      (
+        time (
+          echo Installing Misc...
+          gem install dpl
+        )
+      ) &
 
 
-    (
-      echo Installing Dart...
-      curl https://storage.googleapis.com/dart-archive/channels/$DART_CHANNEL/latest/sdk/dartsdk-$DART_OS-x64-release.zip > dart-sdk.zip
-      unzip dart-sdk.zip > /dev/null
-      dart-sdk/bin/pub global activate --no-executables stagehand
-      dart-sdk/bin/pub global activate --no-executables args 1.5.0
-      dart-sdk/bin/pub global activate --no-executables meta 1.1.6
-      dart-sdk/bin/pub global activate --no-executables devtools
-    ) &
+      (
+        time (
+          echo Installing Dart...
+          curl https://storage.googleapis.com/dart-archive/channels/$DART_CHANNEL/latest/sdk/dartsdk-$DART_OS-x64-release.zip > dart-sdk.zip
+          unzip dart-sdk.zip > /dev/null
+          dart-sdk/bin/pub global activate --no-executables stagehand
+          dart-sdk/bin/pub global activate --no-executables args 1.5.0
+          dart-sdk/bin/pub global activate --no-executables meta 1.1.6
+          dart-sdk/bin/pub global activate --no-executables devtools
+        )
+      ) &
 
 
-    (
-      echo Installing Flutter...
-      git clone -b $FLUTTER_BRANCH https://github.com/flutter/flutter.git
-      flutter/bin/flutter config --no-analytics
-      flutter/bin/flutter update-packages
-      flutter/bin/flutter doctor
-    ) &
+      (
+        time (
+          echo Installing Flutter...
+          git clone -b $FLUTTER_BRANCH https://github.com/flutter/flutter.git
+          flutter/bin/flutter config --no-analytics
+          flutter/bin/flutter update-packages
+          flutter/bin/flutter doctor
+        )
+      ) &
 
-    wait
+      wait
+      echo
+      echo Total time for parallel tasks...
+    )
 
     # To ensure we follow symlinks properly, put links
     # in folders that we'll use in PATHs.

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,24 +66,32 @@ before_install:
     export FLUTTER_PATH_SYMLINK=`pwd`/fluttersymlinkbins
 
 
-    echo Installing Misc...
-    gem install dpl
+    (
+      echo Installing Misc...
+      gem install dpl
+    ) &
 
 
-    echo Installing Dart...
-    curl https://storage.googleapis.com/dart-archive/channels/$DART_CHANNEL/latest/sdk/dartsdk-$DART_OS-x64-release.zip > dart-sdk.zip
-    unzip dart-sdk.zip > /dev/null
-    dart-sdk/bin/pub global activate --no-executables stagehand
-    dart-sdk/bin/pub global activate --no-executables args 1.5.0
-    dart-sdk/bin/pub global activate --no-executables meta 1.1.6
-    dart-sdk/bin/pub global activate --no-executables devtools
+    (
+      echo Installing Dart...
+      curl https://storage.googleapis.com/dart-archive/channels/$DART_CHANNEL/latest/sdk/dartsdk-$DART_OS-x64-release.zip > dart-sdk.zip
+      unzip dart-sdk.zip > /dev/null
+      dart-sdk/bin/pub global activate --no-executables stagehand
+      dart-sdk/bin/pub global activate --no-executables args 1.5.0
+      dart-sdk/bin/pub global activate --no-executables meta 1.1.6
+      dart-sdk/bin/pub global activate --no-executables devtools
+    ) &
 
 
-    echo Installing Flutter...
-    git clone -b $FLUTTER_BRANCH https://github.com/flutter/flutter.git
-    flutter/bin/flutter config --no-analytics
-    flutter/bin/flutter update-packages
-    flutter/bin/flutter doctor
+    (
+      echo Installing Flutter...
+      git clone -b $FLUTTER_BRANCH https://github.com/flutter/flutter.git
+      flutter/bin/flutter config --no-analytics
+      flutter/bin/flutter update-packages
+      flutter/bin/flutter doctor
+    ) &
+
+    wait
 
     # To ensure we follow symlinks properly, put links
     # in folders that we'll use in PATHs.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,7 @@ install:
 
       Start-Job {
         Set-Location $using:PWD
-        echo Installing Misc...
+        echo "Installing Misc..."
         Install-Product node ''
         gem install dpl
       }
@@ -60,7 +60,7 @@ install:
 
       Start-Job {
         Set-Location $using:PWD
-        echo Installing Dart...
+        echo "Installing Dart..."
         Invoke-WebRequest "https://storage.googleapis.com/dart-archive/channels/${env:DART_CHANNEL}/latest/sdk/dartsdk-windows-x64-release.zip" -OutFile "dart.zip"
         7z.exe x dart.zip | out-null
         dart-sdk\bin\pub global activate --no-executables stagehand
@@ -72,7 +72,7 @@ install:
 
       Start-Job {
         Set-Location $using:PWD
-        echo Installing Flutter
+        echo "Installing Flutter"
         git clone -q -b $env:FLUTTER_BRANCH https://github.com/flutter/flutter.git
         flutter\bin\flutter config --no-analytics
       }
@@ -83,9 +83,9 @@ install:
 
       Start-Job {
         Set-Location $using:PWD
-        echo Running update-packages and doctor in background...
-        echo If these don't complete before tests get to Flutter tests,
-        echo things may fail, but if they do, it will have saved many minutes!
+        echo "Running update-packages and doctor in background..."
+        echo "If these don't complete before tests get to Flutter tests,"
+        echo "things may fail, but if they do, it will have saved many minutes!"
         flutter\bin\flutter update-packages
         flutter\bin\flutter doctor
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,7 +85,7 @@ install:
         Set-Location $using:PWD
         echo "Running update-packages and doctor in background..."
         echo "If these don't complete before tests get to Flutter tests,"
-        echo "things may fail, but if they do, it will have saved many minutes!"
+        echo "things may fail, but if they do, it will have saved many minutes"
         flutter\bin\flutter update-packages
         flutter\bin\flutter doctor
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,12 +75,20 @@ install:
         echo Installing Flutter
         git clone -q -b $env:FLUTTER_BRANCH https://github.com/flutter/flutter.git
         flutter\bin\flutter config --no-analytics
-        flutter\bin\flutter update-packages
-        flutter\bin\flutter doctor
       }
 
 
       Get-Job | Wait-Job | Receive-Job
+
+
+      Start-Job {
+        Set-Location $using:PWD
+        echo Running update-packages and doctor in background...
+        echo If these don't complete before tests get to Flutter tests,
+        echo things may fail, but if they do, it will have saved many minutes!
+        flutter\bin\flutter update-packages
+        flutter\bin\flutter doctor
+      }
 
 
       dart-sdk\bin\dart --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,26 +50,34 @@ install:
       $env:DART_PATH = "$pwd\dart-sdk"
 
 
-      echo Installing misc...
-      Install-Product node ''
-      gem install dpl
+      Start-Job {
+        echo Installing misc...
+        Install-Product node ''
+        gem install dpl
+      }
 
 
-      echo Installing Dart...
-      Invoke-WebRequest "https://storage.googleapis.com/dart-archive/channels/${env:DART_CHANNEL}/latest/sdk/dartsdk-windows-x64-release.zip" -OutFile "dart.zip"
-      7z.exe x dart.zip | out-null
-      dart-sdk\bin\pub global activate --no-executables stagehand
-      dart-sdk\bin\pub global activate --no-executables args 1.5.0
-      dart-sdk\bin\pub global activate --no-executables meta 1.1.6
-      dart-sdk\bin\pub global activate --no-executables devtools
+      Start-Job {
+        echo Installing Dart...
+        Invoke-WebRequest "https://storage.googleapis.com/dart-archive/channels/${env:DART_CHANNEL}/latest/sdk/dartsdk-windows-x64-release.zip" -OutFile "dart.zip"
+        7z.exe x dart.zip | out-null
+        dart-sdk\bin\pub global activate --no-executables stagehand
+        dart-sdk\bin\pub global activate --no-executables args 1.5.0
+        dart-sdk\bin\pub global activate --no-executables meta 1.1.6
+        dart-sdk\bin\pub global activate --no-executables devtools
+      }
 
 
+      Start-Job {
+        echo Installing Flutter
+        git clone -q -b $env:FLUTTER_BRANCH https://github.com/flutter/flutter.git
+        flutter\bin\flutter config --no-analytics
+        flutter\bin\flutter update-packages
+        flutter\bin\flutter doctor
+      }
 
-      echo Installing Flutter
-      git clone -q -b $env:FLUTTER_BRANCH https://github.com/flutter/flutter.git
-      flutter\bin\flutter config --no-analytics
-      flutter\bin\flutter update-packages
-      flutter\bin\flutter doctor
+
+      Get-Job | Wait-Job | Receive-Job
 
 
       dart-sdk\bin\dart --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,7 @@ install:
 
 
       Start-Job {
+        Set-Location $using:PWD
         echo Installing misc...
         Install-Product node ''
         gem install dpl
@@ -58,6 +59,7 @@ install:
 
 
       Start-Job {
+        Set-Location $using:PWD
         echo Installing Dart...
         Invoke-WebRequest "https://storage.googleapis.com/dart-archive/channels/${env:DART_CHANNEL}/latest/sdk/dartsdk-windows-x64-release.zip" -OutFile "dart.zip"
         7z.exe x dart.zip | out-null
@@ -69,6 +71,7 @@ install:
 
 
       Start-Job {
+        Set-Location $using:PWD
         echo Installing Flutter
         git clone -q -b $env:FLUTTER_BRANCH https://github.com/flutter/flutter.git
         flutter\bin\flutter config --no-analytics

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,44 +26,52 @@ matrix:
       ONLY_RUN_DART_VERSION: DEV
 
 install:
-  - echo Misc setup
-  - ps: $env:PATH="C:\Ruby25-x64\bin;$env:PATH"
-  - ps: Install-Product node ''
-  - ps: $env:ELECTRON_NO_ATTACH_CONSOLE = 1
-  - ps: gem install dpl
-  - echo Setting variables...
-  - ps: >-
-       if ($env:ONLY_RUN_DART_VERSION -eq "STABLE") {
-         $env:DART_CHANNEL="stable/release"
-         $env:FLUTTER_BRANCH="stable"
-       } elseif ($env:ONLY_RUN_DART_VERSION -eq "DEV") {
-         $env:DART_CHANNEL="dev/release"
-         $env:FLUTTER_BRANCH="dev"
-       } else {
-         $env:DART_CHANNEL="be/raw"
-         $env:FLUTTER_BRANCH="master"
-       }
-  - ps: mkdir "with spaces"
-  - ps: cd "with spaces"
-  - echo Downloading Dart and Flutter...
-  - ps: Invoke-WebRequest "https://storage.googleapis.com/dart-archive/channels/${env:DART_CHANNEL}/latest/sdk/dartsdk-windows-x64-release.zip" -OutFile "dart.zip"
-  - ps: 7z.exe x dart.zip | out-null
-  - git clone -b %FLUTTER_BRANCH% https://github.com/flutter/flutter.git
-  - echo Configuring Dart and Flutter...
-  - flutter\bin\flutter config --no-analytics
-  - flutter\bin\flutter update-packages
-  - ps: $env:FLUTTER_PATH = "$pwd\flutter"
-  - ps: $env:DART_PATH = "$pwd\dart-sdk"
-  - dart-sdk\bin\dart --version
-  - flutter\bin\flutter --version
-  - node --version
-  - npm --version
-  - flutter\bin\flutter doctor
-  - dart-sdk\bin\pub global activate stagehand
-  - dart-sdk\bin\pub global activate args 1.5.0
-  - dart-sdk\bin\pub global activate meta 1.1.6
-  - dart-sdk\bin\pub global activate devtools
-  - cd ..
+  - ps: |
+      echo Misc setup
+      $env:PATH="C:\Ruby25-x64\bin;$env:PATH"
+      Install-Product node ''
+      $env:ELECTRON_NO_ATTACH_CONSOLE = 1
+      gem install dpl
+
+      echo Setting variables...
+      if ($env:ONLY_RUN_DART_VERSION -eq "STABLE") {
+        $env:DART_CHANNEL="stable/release"
+        $env:FLUTTER_BRANCH="stable"
+      } elseif ($env:ONLY_RUN_DART_VERSION -eq "DEV") {
+        $env:DART_CHANNEL="dev/release"
+        $env:FLUTTER_BRANCH="dev"
+      } else {
+        $env:DART_CHANNEL="be/raw"
+        $env:FLUTTER_BRANCH="master"
+      }
+
+      mkdir "with spaces"
+      cd "with spaces"
+
+      echo Downloading Dart and Flutter...
+      Invoke-WebRequest "https://storage.googleapis.com/dart-archive/channels/${env:DART_CHANNEL}/latest/sdk/dartsdk-windows-x64-release.zip" -OutFile "dart.zip"
+      7z.exe x dart.zip | out-null
+      git clone -b %FLUTTER_BRANCH% https://github.com/flutter/flutter.git
+
+      echo Configuring Dart and Flutter...
+      flutter\bin\flutter config --no-analytics
+      flutter\bin\flutter update-packages
+      $env:FLUTTER_PATH = "$pwd\flutter"
+      $env:DART_PATH = "$pwd\dart-sdk"
+
+      dart-sdk\bin\dart --version
+      flutter\bin\flutter --version
+      node --version
+      npm --version
+
+      flutter\bin\flutter doctor
+
+      dart-sdk\bin\pub global activate stagehand
+      dart-sdk\bin\pub global activate args 1.5.0
+      dart-sdk\bin\pub global activate meta 1.1.6
+      dart-sdk\bin\pub global activate devtools
+
+      cd ..
 
 build_script:
   - npm install --depth 0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,13 +27,14 @@ matrix:
 
 install:
   - ps: |
-      echo Misc setup
-      $env:PATH="C:\Ruby25-x64\bin;$env:PATH"
-      Install-Product node ''
-      $env:ELECTRON_NO_ATTACH_CONSOLE = 1
-      gem install dpl
+      mkdir "with spaces"
+      cd "with spaces"
 
       echo Setting variables...
+
+      $env:PATH="C:\Ruby25-x64\bin;$env:PATH"
+      $env:ELECTRON_NO_ATTACH_CONSOLE = 1
+
       if ($env:ONLY_RUN_DART_VERSION -eq "STABLE") {
         $env:DART_CHANNEL="stable/release"
         $env:FLUTTER_BRANCH="stable"
@@ -45,31 +46,37 @@ install:
         $env:FLUTTER_BRANCH="master"
       }
 
-      mkdir "with spaces"
-      cd "with spaces"
-
-      echo Downloading Dart and Flutter...
-      Invoke-WebRequest "https://storage.googleapis.com/dart-archive/channels/${env:DART_CHANNEL}/latest/sdk/dartsdk-windows-x64-release.zip" -OutFile "dart.zip"
-      7z.exe x dart.zip | out-null
-      git clone -b $env:FLUTTER_BRANCH https://github.com/flutter/flutter.git
-
-      echo Configuring Dart and Flutter...
-      flutter\bin\flutter config --no-analytics
-      flutter\bin\flutter update-packages
       $env:FLUTTER_PATH = "$pwd\flutter"
       $env:DART_PATH = "$pwd\dart-sdk"
+
+
+      echo Installing misc...
+      Install-Product node ''
+      gem install dpl
+
+
+      echo Installing Dart...
+      Invoke-WebRequest "https://storage.googleapis.com/dart-archive/channels/${env:DART_CHANNEL}/latest/sdk/dartsdk-windows-x64-release.zip" -OutFile "dart.zip"
+      7z.exe x dart.zip | out-null
+      dart-sdk\bin\pub global activate stagehand
+      dart-sdk\bin\pub global activate args 1.5.0
+      dart-sdk\bin\pub global activate meta 1.1.6
+      dart-sdk\bin\pub global activate devtools
+
+
+
+      echo Installing Flutter
+      git clone -b $env:FLUTTER_BRANCH https://github.com/flutter/flutter.git
+      flutter\bin\flutter config --no-analytics
+      flutter\bin\flutter update-packages
+      flutter\bin\flutter doctor
+
 
       dart-sdk\bin\dart --version
       flutter\bin\flutter --version
       node --version
       npm --version
 
-      flutter\bin\flutter doctor
-
-      dart-sdk\bin\pub global activate stagehand
-      dart-sdk\bin\pub global activate args 1.5.0
-      dart-sdk\bin\pub global activate meta 1.1.6
-      dart-sdk\bin\pub global activate devtools
 
       cd ..
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,7 +52,7 @@ install:
 
       Start-Job {
         Set-Location $using:PWD
-        echo Installing misc...
+        echo Installing Misc...
         Install-Product node ''
         gem install dpl
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,15 +58,15 @@ install:
       echo Installing Dart...
       Invoke-WebRequest "https://storage.googleapis.com/dart-archive/channels/${env:DART_CHANNEL}/latest/sdk/dartsdk-windows-x64-release.zip" -OutFile "dart.zip"
       7z.exe x dart.zip | out-null
-      dart-sdk\bin\pub global activate stagehand
-      dart-sdk\bin\pub global activate args 1.5.0
-      dart-sdk\bin\pub global activate meta 1.1.6
-      dart-sdk\bin\pub global activate devtools
+      dart-sdk\bin\pub global activate --no-executables stagehand
+      dart-sdk\bin\pub global activate --no-executables args 1.5.0
+      dart-sdk\bin\pub global activate --no-executables meta 1.1.6
+      dart-sdk\bin\pub global activate --no-executables devtools
 
 
 
       echo Installing Flutter
-      git clone -b $env:FLUTTER_BRANCH https://github.com/flutter/flutter.git
+      git clone -q -b $env:FLUTTER_BRANCH https://github.com/flutter/flutter.git
       flutter\bin\flutter config --no-analytics
       flutter\bin\flutter update-packages
       flutter\bin\flutter doctor

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,7 @@ install:
       echo Downloading Dart and Flutter...
       Invoke-WebRequest "https://storage.googleapis.com/dart-archive/channels/${env:DART_CHANNEL}/latest/sdk/dartsdk-windows-x64-release.zip" -OutFile "dart.zip"
       7z.exe x dart.zip | out-null
-      git clone -b %FLUTTER_BRANCH% https://github.com/flutter/flutter.git
+      git clone -b $env:FLUTTER_BRANCH https://github.com/flutter/flutter.git
 
       echo Configuring Dart and Flutter...
       flutter\bin\flutter config --no-analytics

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -551,13 +551,13 @@ export function getRandomTempFolder(): string {
 	return tmpPath;
 }
 
-export async function waitForResult(action: () => boolean, message?: string, milliseconds: number = 2000, throwOnFailure = true): Promise<void> {
+export async function waitForResult(action: () => boolean, message?: string, milliseconds: number = 3000, throwOnFailure = true): Promise<void> {
 	const res = await waitFor(action, undefined, milliseconds);
 	if (throwOnFailure && !res)
 		throw new Error(`Action didn't return true within ${milliseconds}ms (${message})`);
 }
 
-export async function tryFor(action: () => Promise<void> | void, milliseconds: number = 2000): Promise<void> {
+export async function tryFor(action: () => Promise<void> | void, milliseconds: number = 3000): Promise<void> {
 	let timeRemaining = milliseconds;
 	while (timeRemaining > 0) {
 		try {

--- a/test/test_all.ts
+++ b/test/test_all.ts
@@ -149,14 +149,19 @@ async function runAllTests(): Promise<void> {
 	const totalRuns = 9;
 	let runNumber = 1;
 	try {
+		// Run all non-Flutter tests first, as `flutter update-packages` runs in the background for better performance...
+		// TODO: Move the installation into scripts, so we can handle that better...
+		await runTests("dart_only", "hello_world", dartSdkPath, codeVersion, `${runNumber++} of ${totalRuns}`);
+		await runTests("dart_create_tests", "dart_create_tests.code-workspace", dartSdkPath, codeVersion, `${runNumber++} of ${totalRuns}`);
+		await runTests("not_activated/dart_create", "empty", dartSdkPath, codeVersion, `${runNumber++} of ${totalRuns}`);
+
+		await runTests("flutter_only", "flutter_hello_world", flutterSdkPath, codeVersion, `${runNumber++} of ${totalRuns}`);
+		await runTests("flutter_create_tests", "flutter_create_tests.code-workspace", flutterSdkPath, codeVersion, `${runNumber++} of ${totalRuns}`);
+		await runTests("not_activated/flutter_create", "empty", flutterSdkPath, codeVersion, `${runNumber++} of ${totalRuns}`);
+
 		await runTests("multi_root", "projects.code-workspace", flutterSdkPath, codeVersion, `${runNumber++} of ${totalRuns}`);
 		await runTests("multi_project_folder", "", flutterSdkPath, codeVersion, `${runNumber++} of ${totalRuns}`);
-		await runTests("not_activated/dart_create", "empty", dartSdkPath, codeVersion, `${runNumber++} of ${totalRuns}`);
-		await runTests("not_activated/flutter_create", "empty", flutterSdkPath, codeVersion, `${runNumber++} of ${totalRuns}`);
-		await runTests("dart_create_tests", "dart_create_tests.code-workspace", dartSdkPath, codeVersion, `${runNumber++} of ${totalRuns}`);
-		await runTests("flutter_create_tests", "flutter_create_tests.code-workspace", flutterSdkPath, codeVersion, `${runNumber++} of ${totalRuns}`);
-		await runTests("dart_only", "hello_world", dartSdkPath, codeVersion, `${runNumber++} of ${totalRuns}`);
-		await runTests("flutter_only", "flutter_hello_world", flutterSdkPath, codeVersion, `${runNumber++} of ${totalRuns}`);
+
 		if (flutterRoot) {
 			await runTests("flutter_repository", flutterRoot, flutterSdkPath, codeVersion, `${runNumber++} of ${totalRuns}`);
 		} else {


### PR DESCRIPTION
A lot of time is spent setting things up, so running this in parallel may speed things up (this will need to be compared with some builds).