### PR TITLE
Speed up CI by running less build combinations for branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ matrix:
 # Don't build tags.
 if: tag IS blank
 
+# Don't build Stable/Dev or Dev/Stable unless master as the changes of
+# a failure showing up in those and not in either Stable/Stable or Dev/Dev
+# are pretty slim so this will half the time for branch builds.
+if: branch = master OR (env(ONLY_RUN_DART_VERSION) = env(ONLY_RUN_CODE_VERSION))
+
 cache:
   directories:
     - $HOME/.pub-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ if: tag IS blank
 # Don't build Stable/Dev or Dev/Stable unless master as the changes of
 # a failure showing up in those and not in either Stable/Stable or Dev/Dev
 # are pretty slim so this will half the time for branch builds.
-if: branch = master OR (env(ONLY_RUN_DART_VERSION) = env(ONLY_RUN_CODE_VERSION))
+if: branch = run-less-builds OR (env(ONLY_RUN_DART_VERSION) = env(ONLY_RUN_CODE_VERSION))
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
     - env: ONLY_RUN_CODE_VERSION=STABLE ONLY_RUN_DART_VERSION=DEV
     - env: ONLY_RUN_CODE_VERSION=DEV    ONLY_RUN_DART_VERSION=DEV
 
+# Don't build tags.
+if: tag IS blank
+
 cache:
   directories:
     - $HOME/.pub-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ if: tag IS blank
 # Don't build Stable/Dev or Dev/Stable unless master as the changes of
 # a failure showing up in those and not in either Stable/Stable or Dev/Dev
 # are pretty slim so this will half the time for branch builds.
-if: branch = run-less-builds OR (env(ONLY_RUN_DART_VERSION) = env(ONLY_RUN_CODE_VERSION))
+if: branch = master OR (env(ONLY_RUN_DART_VERSION) = env(ONLY_RUN_CODE_VERSION))
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,10 @@ matrix:
 # Don't build tags.
 if: tag IS blank
 
-# Don't build Stable/Dev or Dev/Stable unless master as the changes of
-# a failure showing up in those and not in either Stable/Stable or Dev/Dev
-# are pretty slim so this will half the time for branch builds.
-if: branch = master OR (env(ONLY_RUN_DART_VERSION) = env(ONLY_RUN_CODE_VERSION))
+# Don't build Stable/Dev or Dev/Stable unless master (and not a PR->master merge build)
+# as the changes of a failure showing up in those and not in either Stable/Stable or
+# Dev/Dev are pretty slim so this will half the time for branch builds.
+if: (branch = master and type = push) OR (env(ONLY_RUN_DART_VERSION) = env(ONLY_RUN_CODE_VERSION))
 
 cache:
   directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ for:
   -
     branches:
       only:
-        - master
+        - run-less-builds
     environment:
       matrix:
         - ONLY_RUN_CODE_VERSION: DEV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,14 +24,16 @@ matrix:
 # Don't build tags.
 skip_tags: true
 
-# Don't build Stable/Dev or Dev/Stable unless master as the changes of
-# a failure showing up in those and not in either Stable/Stable or Dev/Dev
-# are pretty slim so this will half the time for branch builds.
+# Don't build Stable/Dev or Dev/Stable unless master (and not a PR->master merge build)
+# as the changes of a failure showing up in those and not in either Stable/Stable or
+# Dev/Dev are pretty slim so this will half the time for branch builds.
 for:
   -
     branches:
       only:
         - master
+    # TODO: Skip master builds that are PR-merges
+    # https://help.appveyor.com/discussions/questions/35664-how-to-conditionally-skip-some-matrix-builds-for-the-prs-merge-into-branch-builds
     environment:
       matrix:
         - ONLY_RUN_CODE_VERSION: DEV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,6 @@ environment:
     - ONLY_RUN_CODE_VERSION: STABLE
       ONLY_RUN_DART_VERSION: STABLE
     - ONLY_RUN_CODE_VERSION: DEV
-      ONLY_RUN_DART_VERSION: STABLE
-    - ONLY_RUN_CODE_VERSION: STABLE
-      ONLY_RUN_DART_VERSION: DEV
-    - ONLY_RUN_CODE_VERSION: DEV
       ONLY_RUN_DART_VERSION: DEV
 
 matrix:
@@ -27,6 +23,21 @@ matrix:
 
 # Don't build tags.
 skip_tags: true
+
+# Don't build Stable/Dev or Dev/Stable unless master as the changes of
+# a failure showing up in those and not in either Stable/Stable or Dev/Dev
+# are pretty slim so this will half the time for branch builds.
+for:
+  -
+    branches:
+      only:
+        - master
+    environment:
+      matrix:
+        - ONLY_RUN_CODE_VERSION: DEV
+          ONLY_RUN_DART_VERSION: STABLE
+        - ONLY_RUN_CODE_VERSION: STABLE
+          ONLY_RUN_DART_VERSION: DEV
 
 cache:
   - "%APPDATA%\\Pub\\Cache"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ for:
   -
     branches:
       only:
-        - run-less-builds
+        - master
     environment:
       matrix:
         - ONLY_RUN_CODE_VERSION: DEV

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,9 @@ matrix:
     - ONLY_RUN_CODE_VERSION: DEV
       ONLY_RUN_DART_VERSION: DEV
 
+# Don't build tags.
+skip_tags: true
+
 cache:
   - "%APPDATA%\\Pub\\Cache"
   - "with spaces\\flutter"


### PR DESCRIPTION
We normally run combinations of Stable/Stable, Stable/Dev, Dev/Stable, Dev/Dev for (Dart/Flutter) and (VS Code) builds. The Dev/Stable and Stable/Dev don't add massive value, they just make it easier to spot whether it's Dev Dart/Flutter or Dev VS Code that's caused a fail (that also shows up in Dev/Dev).

So, this change skips those combinations for branches, but still runs on master.