### PR TITLE
Remove assumptions about there being only one type of project in a workspace

### DIFF
--- a/src/analysis/analyzer_status_reporter.ts
+++ b/src/analysis/analyzer_status_reporter.ts
@@ -5,7 +5,7 @@ import { env, ProgressLocation, version as codeVersion, window, workspace } from
 import { Analytics } from "../analytics";
 import { config } from "../config";
 import { LogCategory, PromiseCompleter } from "../debug/utils";
-import { extensionVersion, getRandomInt, getSdkVersion, isStableSdk, ProjectType, Sdks } from "../utils";
+import { extensionVersion, getRandomInt, getSdkVersion, isStableSdk, Sdks } from "../utils";
 import { logError } from "../utils/log";
 import { RequestError, ServerErrorNotification, ServerStatusNotification } from "./analysis_server_types";
 import { Analyzer } from "./analyzer";
@@ -98,10 +98,7 @@ export class AnalyzerStatusReporter {
 	}
 
 	private shouldReportErrors(): boolean {
-		if (this.sdks.projectType === ProjectType.Flutter && this.sdks.flutter)
-			return !isStableSdk(getSdkVersion(this.sdks.flutter));
-		else
-			return !isStableSdk(getSdkVersion(this.sdks.dart));
+		return !isStableSdk(getSdkVersion(this.sdks.flutter || this.sdks.dart));
 	}
 
 	private reportError(error: ServerErrorNotification, method?: string) {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -2,7 +2,7 @@ import * as https from "https";
 import * as querystring from "querystring";
 import { env, Uri, version as codeVersion } from "vscode";
 import { config } from "./config";
-import { extensionVersion, hasFlutterExtension, isDevExtension, ProjectType, Sdks } from "./utils";
+import { extensionVersion, hasFlutterExtension, isDevExtension, ProjectType, WorkspaceContext } from "./utils";
 import { logError, logInfo, logWarn } from "./utils/log";
 
 // Set to true for analytics to be sent to the debug endpoint (non-logging) for validation.
@@ -43,13 +43,11 @@ enum TimingVariable {
 }
 
 export class Analytics {
-	public sdks: Sdks;
 	public sdkVersion?: string;
 	public flutterSdkVersion?: string;
 	public analysisServerVersion?: string;
 
-	constructor(sdks: Sdks) {
-		this.sdks = sdks;
+	constructor(public workspaceContext: WorkspaceContext) {
 	}
 
 	public logExtensionStartup(timeInMS: number) {
@@ -140,9 +138,9 @@ export class Analytics {
 			cd4: this.analysisServerVersion,
 			cd5: codeVersion,
 			cd6: resourceUri ? this.getDebuggerPreference(resourceUri) : null,
-			cd7: ProjectType[this.sdks.projectType],
+			cd7: ProjectType[this.workspaceContext.sdks.projectType],
 			cd8: config.closingLabels ? "On" : "Off",
-			cd9: this.sdks.projectType === ProjectType.Flutter ? (config.flutterHotReloadOnSave ? "On" : "Off") : null,
+			cd9: this.workspaceContext.hasAnyFlutterProjects ? (config.flutterHotReloadOnSave ? "On" : "Off") : null,
 			cid: machineId,
 			tid: "UA-2201586-19",
 			ul: env.language,

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -2,7 +2,7 @@ import * as https from "https";
 import * as querystring from "querystring";
 import { env, Uri, version as codeVersion } from "vscode";
 import { config } from "./config";
-import { extensionVersion, hasFlutterExtension, isDevExtension, ProjectType, WorkspaceContext } from "./utils";
+import { extensionVersion, hasFlutterExtension, isDevExtension, WorkspaceContext } from "./utils";
 import { logError, logInfo, logWarn } from "./utils/log";
 
 // Set to true for analytics to be sent to the debug endpoint (non-logging) for validation.
@@ -47,8 +47,7 @@ export class Analytics {
 	public flutterSdkVersion?: string;
 	public analysisServerVersion?: string;
 
-	constructor(public workspaceContext: WorkspaceContext) {
-	}
+	constructor(public workspaceContext: WorkspaceContext) { }
 
 	public logExtensionStartup(timeInMS: number) {
 		this.event(Category.Extension, EventAction.Activated);
@@ -138,7 +137,7 @@ export class Analytics {
 			cd4: this.analysisServerVersion,
 			cd5: codeVersion,
 			cd6: resourceUri ? this.getDebuggerPreference(resourceUri) : null,
-			cd7: ProjectType[this.workspaceContext.sdks.projectType],
+			cd7: this.workspaceContext.workspaceTypeDescription,
 			cd8: config.closingLabels ? "On" : "Off",
 			cd9: this.workspaceContext.hasAnyFlutterProjects ? (config.flutterHotReloadOnSave ? "On" : "Off") : null,
 			cid: machineId,

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -8,7 +8,7 @@ import { FlutterServiceExtension, FlutterServiceExtensionArgs, FlutterVmServiceE
 import { PubGlobal } from "../pub/global";
 import { DevTools } from "../sdk/dev_tools";
 import { showDevToolsNotificationIfAppropriate } from "../user_prompts";
-import { fsPath, getDartWorkspaceFolders, openInBrowser, ProjectType, Sdks } from "../utils";
+import { fsPath, getDartWorkspaceFolders, openInBrowser, WorkspaceContext } from "../utils";
 import { handleDebugLogEvent, logWarn } from "../utils/log";
 import { DartDebugSessionInformation } from "../utils/vscode/debug";
 
@@ -33,9 +33,9 @@ export class DebugCommands {
 	private readonly flutterExtensions: FlutterVmServiceExtensions;
 	private readonly devTools: DevTools;
 
-	constructor(context: Context, sdks: Sdks, analytics: Analytics, pubGlobal: PubGlobal) {
+	constructor(context: Context, workspaceContext: WorkspaceContext, analytics: Analytics, pubGlobal: PubGlobal) {
 		this.flutterExtensions = new FlutterVmServiceExtensions(this.sendServiceSetting);
-		this.devTools = new DevTools(sdks, analytics, pubGlobal);
+		this.devTools = new DevTools(workspaceContext.sdks, analytics, pubGlobal);
 		context.subscriptions.push(this.devTools);
 		context.subscriptions.push(this.debugMetrics);
 		context.subscriptions.push(vs.debug.onDidReceiveDebugSessionCustomEvent((e) => {
@@ -89,7 +89,7 @@ export class DebugCommands {
 			} else if (e.event === "dart.debuggerUris") {
 				session.observatoryUri = e.body.observatoryUri;
 				session.vmServiceUri = e.body.vmServiceUri;
-				if (sdks.projectType === ProjectType.Flutter)
+				if (workspaceContext.hasAnyFlutterProjects)
 					showDevToolsNotificationIfAppropriate(context);
 				// if (e.body.isProbablyReconnectable) {
 				// 	mostRecentAttachedProbablyReusableObservatoryUri = session.observatoryUri;

--- a/src/commands/sdk.ts
+++ b/src/commands/sdk.ts
@@ -212,6 +212,7 @@ export class SdkCommands {
 
 			// If we're in Fuchsia, we don't want to `pub get` by default but we do want to allow
 			// it to be overridden, so only read the setting if it's been declared explicitly.
+			// TODO: This should be handled per-project for a multi-root workspace.
 			if (workspace.isInFuchsiaTree && !conf.runPubGetOnPubspecChangesIsConfiguredExplicitly)
 				return;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -124,7 +124,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 	const sdks = workspaceContext.sdks;
 	buildLogHeaders(sdks);
 	util.logTime("findSdks");
-	analytics = new Analytics(sdks);
+	analytics = new Analytics(workspaceContext);
 	if (!sdks.dart || (workspaceContext.hasAnyFlutterMobileProjects && !sdks.flutter)) {
 		// Don't set anything else up; we can't work like this!
 		return handleMissingSdks(context, analytics, sdks);
@@ -328,7 +328,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 	const analyzerCommands = new AnalyzerCommands(context, analyzer);
 	const pubGlobal = new PubGlobal(extContext, sdks);
 	const sdkCommands = new SdkCommands(context, sdks, pubGlobal, flutterCapabilities, flutterDaemon && flutterDaemon.deviceManager);
-	const debug = new DebugCommands(extContext, sdks, analytics, pubGlobal);
+	const debug = new DebugCommands(extContext, workspaceContext, analytics, pubGlobal);
 
 	// Register URI handler.
 	context.subscriptions.push(vs.window.registerUriHandler(new DartUriHandler(flutterCapabilities)));
@@ -453,8 +453,8 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 			reanalyze,
 			referenceProvider,
 			renameProvider,
-			sdks,
 			testTreeProvider,
+			workspaceContext,
 		} as InternalExtensionApi,
 	};
 }
@@ -606,6 +606,6 @@ export interface InternalExtensionApi {
 	reanalyze: () => void;
 	referenceProvider: DartReferenceProvider;
 	renameProvider: DartRenameProvider;
-	sdks: util.Sdks;
 	testTreeProvider: TestResultsProvider;
+	workspaceContext: util.WorkspaceContext;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,7 +127,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 	analytics = new Analytics(workspaceContext);
 	if (!sdks.dart || (workspaceContext.hasAnyFlutterMobileProjects && !sdks.flutter)) {
 		// Don't set anything else up; we can't work like this!
-		return handleMissingSdks(context, analytics, sdks);
+		return handleMissingSdks(context, analytics, workspaceContext);
 	}
 
 	if (sdks.flutterVersion)
@@ -327,7 +327,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 	// Register additional commands.
 	const analyzerCommands = new AnalyzerCommands(context, analyzer);
 	const pubGlobal = new PubGlobal(extContext, sdks);
-	const sdkCommands = new SdkCommands(context, sdks, pubGlobal, flutterCapabilities, flutterDaemon && flutterDaemon.deviceManager);
+	const sdkCommands = new SdkCommands(context, workspaceContext, pubGlobal, flutterCapabilities, flutterDaemon && flutterDaemon.deviceManager);
 	const debug = new DebugCommands(extContext, workspaceContext, analytics, pubGlobal);
 
 	// Register URI handler.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -244,7 +244,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 	context.subscriptions.push(vs.languages.registerCompletionItemProvider(DART_MODE, new SnippetCompletionItemProvider("snippets/flutter.json", (uri) => util.isFlutterWorkspaceFolder(vs.workspace.getWorkspaceFolder(uri)))));
 
 	context.subscriptions.push(vs.languages.setLanguageConfiguration(DART_MODE.language, new DartLanguageConfiguration()));
-	const statusReporter = new AnalyzerStatusReporter(analyzer, sdks, analytics);
+	const statusReporter = new AnalyzerStatusReporter(analyzer, workspaceContext, analytics);
 
 	// Set up diagnostics.
 	const diagnostics = vs.languages.createDiagnosticCollection("dart");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,7 +122,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 	util.logTime();
 	const workspaceContext = initWorkspace();
 	const sdks = workspaceContext.sdks;
-	buildLogHeaders(sdks);
+	buildLogHeaders(workspaceContext);
 	util.logTime("findSdks");
 	analytics = new Analytics(workspaceContext);
 	if (!sdks.dart || (workspaceContext.hasAnyFlutterProjects && !sdks.flutter)) {
@@ -399,7 +399,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 
 	// Prompt user for any special config we might want to set.
 	if (!isRestart)
-		showUserPrompts(extContext, sdks);
+		showUserPrompts(extContext, workspaceContext);
 
 	// Turn on all the commands.
 	setCommandVisiblity(true, workspaceContext);
@@ -459,7 +459,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 	};
 }
 
-function buildLogHeaders(sdks: util.Sdks) {
+function buildLogHeaders(workspaceContext: util.WorkspaceContext) {
 	clearLogHeader();
 	addToLogHeader(() => `!! PLEASE REVIEW THIS LOG FOR SENSITIVE INFORMATION BEFORE SHARING !!`);
 	addToLogHeader(() => ``);
@@ -470,8 +470,9 @@ function buildLogHeaders(sdks: util.Sdks) {
 	});
 	addToLogHeader(() => `VS Code: ${vs.version}`);
 	addToLogHeader(() => `Platform: ${platformName}`);
-	addToLogHeader(() => `Workspace type: ${util.ProjectType[sdks.projectType]}`);
+	addToLogHeader(() => `Workspace type: ${workspaceContext.workspaceTypeDescription}`);
 	addToLogHeader(() => `Multi-root?: ${vs.workspace.workspaceFolders && vs.workspace.workspaceFolders.length > 1}`);
+	const sdks = workspaceContext.sdks;
 	addToLogHeader(() => `Dart SDK:\n    Loc: ${sdks.dart}\n    Ver: ${util.getSdkVersion(sdks.dart)}`);
 	addToLogHeader(() => `Flutter SDK:\n    Loc: ${sdks.flutter}\n    Ver: ${util.getSdkVersion(sdks.flutter)}`);
 	addToLogHeader(() => `HTTP_PROXY: ${process.env.HTTP_PROXY}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ import { PubGlobal } from "./pub/global";
 import { isPubGetProbablyRequired, promptToRunPubGet } from "./pub/pub";
 import { DartCapabilities } from "./sdk/capabilities";
 import { StatusBarVersionTracker } from "./sdk/status_bar_version_tracker";
-import { checkForSdkUpdates } from "./sdk/update_check";
+import { checkForStandardDartSdkUpdates } from "./sdk/update_check";
 import { analyzerSnapshotPath, dartVMPath, flutterPath, handleMissingSdks, initWorkspace } from "./sdk/utils";
 import { DartUriHandler } from "./uri_handlers/uri_handler";
 import { showUserPrompts } from "./user_prompts";
@@ -137,7 +137,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 	if (sdks.dartVersion) {
 		dartCapabilities.version = sdks.dartVersion;
 		analytics.sdkVersion = sdks.dartVersion;
-		checkForSdkUpdates(sdks, sdks.dartVersion);
+		checkForStandardDartSdkUpdates(workspaceContext);
 		context.subscriptions.push(new StatusBarVersionTracker(sdks.projectType, sdks.dartVersion, sdks.flutterVersion, sdks.dartSdkIsFromFlutter));
 	}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,7 +125,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 	buildLogHeaders(sdks);
 	util.logTime("findSdks");
 	analytics = new Analytics(workspaceContext);
-	if (!sdks.dart || (workspaceContext.hasAnyFlutterMobileProjects && !sdks.flutter)) {
+	if (!sdks.dart || (workspaceContext.hasAnyFlutterProjects && !sdks.flutter)) {
 		// Don't set anything else up; we can't work like this!
 		return handleMissingSdks(context, analytics, workspaceContext);
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -423,7 +423,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 	if (workspaceContext.shouldLoadFlutterExtension) {
 		const flutterExtension = vs.extensions.getExtension(flutterExtensionIdentifier);
 		if (flutterExtension) {
-			log(`Activating Flutter extension for ${util.ProjectType[sdks.projectType]} project...`);
+			log(`Activating Flutter extension for ${workspaceContext.workspaceTypeDescription} project...`);
 			flutterExtension.activate();
 		}
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -408,7 +408,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 	// Prompt for pub get if required
 	function checkForPackages() {
 		// Don't prompt for package updates in the Fuchsia tree.
-		if (workspaceContext.isInFuchsiaTree)
+		if (workspaceContext.isInFuchsiaTree) // TODO: This should be tested per-project.
 			return;
 		const folders = util.getDartWorkspaceFolders();
 		const foldersRequiringPackageGet = folders.filter((ws: WorkspaceFolder) => config.for(ws.uri).promptToGetPackages).filter(isPubGetProbablyRequired);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -138,7 +138,7 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 		dartCapabilities.version = sdks.dartVersion;
 		analytics.sdkVersion = sdks.dartVersion;
 		checkForStandardDartSdkUpdates(workspaceContext);
-		context.subscriptions.push(new StatusBarVersionTracker(sdks.projectType, sdks.dartVersion, sdks.flutterVersion, sdks.dartSdkIsFromFlutter));
+		context.subscriptions.push(new StatusBarVersionTracker(workspaceContext));
 	}
 
 	// Fire up the analyzer process.

--- a/src/providers/debug_config_provider.ts
+++ b/src/providers/debug_config_provider.ts
@@ -18,7 +18,7 @@ import { FlutterDeviceManager } from "../flutter/device_manager";
 import { Device } from "../flutter/flutter_types";
 import { locateBestProjectRoot } from "../project";
 import { dartVMPath, flutterPath, pubPath, pubSnapshotPath } from "../sdk/utils";
-import { checkProjectSupportsPubRunTest, fsPath, isDartFile, isFlutterProjectFolder, isFlutterWorkspaceFolder, isInsideFolderNamed, isTestFile, isTestFileOrFolder, ProjectType, Sdks } from "../utils";
+import { checkProjectSupportsPubRunTest, fsPath, isDartFile, isFlutterProjectFolder, isFlutterWorkspaceFolder, isInsideFolderNamed, isTestFile, isTestFileOrFolder, Sdks } from "../utils";
 import { log, logError, logWarn } from "../utils/log";
 import { TestResultsProvider } from "../views/test_view";
 
@@ -155,8 +155,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		if (debugConfig.program && debugConfig.cwd && !path.isAbsolute(debugConfig.program))
 			debugConfig.program = path.join(debugConfig.cwd, debugConfig.program);
 
-		const isFlutter = this.sdks.projectType !== ProjectType.Dart
-			&& debugConfig.cwd && isFlutterProjectFolder(debugConfig.cwd as string)
+		const isFlutter = debugConfig.cwd && isFlutterProjectFolder(debugConfig.cwd as string)
 			&& !isInsideFolderNamed(debugConfig.program, "bin") && !isInsideFolderNamed(debugConfig.program, "tool");
 		log(`Detected launch project as ${isFlutter ? "Flutter" : "Dart"}`);
 		const isTest = debugConfig.program && isTestFileOrFolder(debugConfig.program as string);

--- a/src/sdk/status_bar_version_tracker.ts
+++ b/src/sdk/status_bar_version_tracker.ts
@@ -1,24 +1,26 @@
 import * as vs from "vscode";
 import { config } from "../config";
-import { isAnalyzable, ProjectType } from "../utils";
+import { isAnalyzable, WorkspaceContext } from "../utils";
 
 export class StatusBarVersionTracker implements vs.Disposable {
 	private subscriptions: vs.Disposable[] = [];
 
-	constructor(projectType: ProjectType, dartSdkVersion: string, flutterSdkVersion: string, isDartSdkFromFlutter: boolean) {
+	constructor(workspaceContext: WorkspaceContext) {
+		const dartIsFromFlutter = workspaceContext.sdks.dartSdkIsFromFlutter;
+
 		// Which switcher we show is based on whether we're in a Flutter project or not.
-		const switchSdkCommand = projectType === ProjectType.Flutter
+		const switchSdkCommand = workspaceContext.hasAnyFlutterProjects
 			? (config.flutterSdkPaths && config.flutterSdkPaths.length > 0 ? "dart.changeFlutterSdk" : null)
 			: (config.sdkPaths && config.sdkPaths.length > 0 ? "dart.changeSdk" : null);
 
 		// Render an approprite label for what we're calling this SDK.
-		const label = projectType === ProjectType.Flutter
+		const label = workspaceContext.hasAnyFlutterProjects
 			? "Flutter"
-			: (isDartSdkFromFlutter ? "Dart from Flutter" : "Dart");
+			: (dartIsFromFlutter ? "Dart from Flutter" : "Dart");
 
-		const versionLabel = (projectType === ProjectType.Flutter || isDartSdkFromFlutter)
-			? flutterSdkVersion
-			: dartSdkVersion;
+		const versionLabel = (workspaceContext.hasAnyFlutterProjects || dartIsFromFlutter)
+			? workspaceContext.sdks.flutterVersion
+			: workspaceContext.sdks.dartVersion;
 
 		if (versionLabel) {
 			this.addStatusBarItem(

--- a/src/sdk/update_check.ts
+++ b/src/sdk/update_check.ts
@@ -1,19 +1,20 @@
 import { window } from "vscode";
 import { config } from "../config";
-import { getLatestSdkVersion, openInBrowser, ProjectType, Sdks, versionIsAtLeast } from "../utils";
+import { getLatestSdkVersion, openInBrowser, versionIsAtLeast, WorkspaceContext } from "../utils";
 import { logError } from "../utils/log";
 import { DART_DOWNLOAD_URL } from "./utils";
 
-export async function checkForSdkUpdates(sdks: Sdks, dartSdkVersion: string): Promise<void> {
-	if (!config.checkForSdkUpdates || sdks.projectType !== ProjectType.Dart)
+export async function checkForStandardDartSdkUpdates(workspaceContext: WorkspaceContext): Promise<void> {
+	if (!config.checkForSdkUpdates || !workspaceContext.hasOnlyDartProjects)
 		return;
 
 	// Someties people use the Dart SDK inside Flutter for non-Flutter projects. Since we'll never want
 	// to do SDK update checks in that situation (esp. as it's VERSION file is bad!) we should skip in
 	// that case.
-	if (sdks.dartSdkIsFromFlutter)
+	if (workspaceContext.sdks.dartSdkIsFromFlutter)
 		return;
 
+	const dartSdkVersion = workspaceContext.sdks.dartVersion;
 	try {
 		const version = await getLatestSdkVersion();
 		if (versionIsAtLeast(dartSdkVersion, version))

--- a/src/sdk/utils.ts
+++ b/src/sdk/utils.ts
@@ -28,6 +28,11 @@ export function handleMissingSdks(context: ExtensionContext, analytics: Analytic
 	// This can be reverted and improved if Code adds support for providing activation context:
 	//     https://github.com/Microsoft/vscode/issues/44711
 	let commandToReRun: string;
+	// Note: This code only runs if we fail to find the Dart SDK, or fail to find the Flutter SDK
+	// and are in a Flutter project. In the case where we fail to find the Flutter SDK but are not
+	// in a Flutter project (eg. we ran Flutter Doctor without the extension activated) then
+	// this code will not be run as the extension will activate normally, and then the command-handling
+	// code for each command will detect the missing Flutter SDK and respond appropriately.
 	context.subscriptions.push(commands.registerCommand("flutter.createProject", (_) => {
 		workspaceContext.attemptedToUseFlutter = true;
 		commandToReRun = "flutter.createProject";

--- a/src/sdk/utils.ts
+++ b/src/sdk/utils.ts
@@ -5,7 +5,7 @@ import { Analytics } from "../analytics";
 import { config } from "../config";
 import { PackageMap } from "../debug/package_map";
 import { flatMap, isWin, platformName } from "../debug/utils";
-import { FLUTTER_CREATE_PROJECT_TRIGGER_FILE, fsPath, getDartWorkspaceFolders, getSdkVersion, openExtensionLogFile, openInBrowser, ProjectType, reloadExtension, resolvePaths, Sdks, showLogAction } from "../utils";
+import { FLUTTER_CREATE_PROJECT_TRIGGER_FILE, fsPath, getDartWorkspaceFolders, getSdkVersion, openExtensionLogFile, openInBrowser, ProjectType, reloadExtension, resolvePaths, Sdks, showLogAction, WorkspaceContext } from "../utils";
 import { getChildFolders, hasPubspec } from "../utils/fs";
 import { log } from "../utils/log";
 
@@ -135,7 +135,7 @@ export async function showSdkActivationFailure(
 	}
 }
 
-export function findSdks(): Sdks {
+export function initWorkspace(): WorkspaceContext {
 	log("Searching for SDKs...");
 	const folders = getDartWorkspaceFolders()
 		.map((w) => fsPath(w.uri));
@@ -151,13 +151,13 @@ export function findSdks(): Sdks {
 	// of the other SDKs will work remotely. Also, there is no need to validate the sdk path,
 	// since that file will exist on a remote machine.
 	if (config.analyzerSshHost) {
-		return {
+		return new WorkspaceContext({
 			dart: config.sdkPath,
 			dartSdkIsFromFlutter: false,
 			flutter: null,
 			fuchsia: null,
 			projectType: ProjectType.Dart,
-		};
+		});
 	}
 
 	let fuchsiaRoot: string | undefined;
@@ -214,7 +214,7 @@ export function findSdks(): Sdks {
 
 	const dartSdkPath = findDartSdk(dartSdkSearchPaths);
 
-	return {
+	return new WorkspaceContext({
 		dart: dartSdkPath,
 		dartSdkIsFromFlutter: dartSdkPath && isDartSdkFromFlutter(dartSdkPath),
 		dartVersion: getSdkVersion(dartSdkPath),
@@ -224,7 +224,7 @@ export function findSdks(): Sdks {
 		projectType: fuchsiaRoot && hasFuchsiaProjectThatIsNotVanillaFlutter
 			? ProjectType.Fuchsia
 			: (flutterProject ? ProjectType.Flutter : ProjectType.Dart),
-	};
+	});
 }
 
 export function referencesFlutterSdk(folder?: string): boolean {

--- a/src/sdk/utils.ts
+++ b/src/sdk/utils.ts
@@ -28,33 +28,34 @@ export function handleMissingSdks(context: ExtensionContext, analytics: Analytic
 	// This can be reverted and improved if Code adds support for providing activation context:
 	//     https://github.com/Microsoft/vscode/issues/44711
 	let commandToReRun: string;
+	let attemptedToUseFlutter: boolean = false;
 	// Note: This code only runs if we fail to find the Dart SDK, or fail to find the Flutter SDK
 	// and are in a Flutter project. In the case where we fail to find the Flutter SDK but are not
 	// in a Flutter project (eg. we ran Flutter Doctor without the extension activated) then
 	// this code will not be run as the extension will activate normally, and then the command-handling
 	// code for each command will detect the missing Flutter SDK and respond appropriately.
 	context.subscriptions.push(commands.registerCommand("flutter.createProject", (_) => {
-		workspaceContext.attemptedToUseFlutter = true;
+		attemptedToUseFlutter = true;
 		commandToReRun = "flutter.createProject";
 	}));
 	context.subscriptions.push(commands.registerCommand("dart.createProject", (_) => {
 		commandToReRun = "dart.createProject";
 	}));
 	context.subscriptions.push(commands.registerCommand("_dart.flutter.createSampleProject", (_) => {
-		workspaceContext.attemptedToUseFlutter = true;
+		attemptedToUseFlutter = true;
 		commandToReRun = "_dart.flutter.createSampleProject";
 	}));
 	context.subscriptions.push(commands.registerCommand("flutter.doctor", (_) => {
-		workspaceContext.attemptedToUseFlutter = true;
+		attemptedToUseFlutter = true;
 		commandToReRun = "flutter.doctor";
 	}));
 	context.subscriptions.push(commands.registerCommand("flutter.upgrade", (_) => {
-		workspaceContext.attemptedToUseFlutter = true;
+		attemptedToUseFlutter = true;
 		commandToReRun = "flutter.upgrade";
 	}));
 	// Wait a while before showing the error to allow the code above to have run.
 	setTimeout(() => {
-		if (workspaceContext.attemptedToUseFlutter) {
+		if (attemptedToUseFlutter) {
 			if (workspaceContext.sdks.flutter && !workspaceContext.sdks.dart) {
 				showFluttersDartSdkActivationFailure();
 			} else {

--- a/src/user_prompts.ts
+++ b/src/user_prompts.ts
@@ -4,12 +4,12 @@ import * as vs from "vscode";
 import { doNotAskAgainAction, noRepeatPromptThreshold, noThanksAction, openDevToolsAction, wantToTryDevToolsPrompt } from "./constants";
 import { Context } from "./context";
 import { StagehandTemplate } from "./pub/stagehand";
-import { DART_STAGEHAND_PROJECT_TRIGGER_FILE, extensionVersion, FLUTTER_CREATE_PROJECT_TRIGGER_FILE, fsPath, getDartWorkspaceFolders, hasFlutterExtension, isDevExtension, openInBrowser, ProjectType, Sdks } from "./utils";
+import { DART_STAGEHAND_PROJECT_TRIGGER_FILE, extensionVersion, FLUTTER_CREATE_PROJECT_TRIGGER_FILE, fsPath, getDartWorkspaceFolders, hasFlutterExtension, isDevExtension, openInBrowser, WorkspaceContext } from "./utils";
 
 const promptPrefix = "hasPrompted.";
 const installFlutterExtensionPromptKey = "install_flutter_extension";
 
-export function showUserPrompts(context: Context, sdks: Sdks): void {
+export function showUserPrompts(context: Context, workspaceContext: WorkspaceContext): void {
 	handleNewProjects(context);
 
 	function hasPrompted(key: string): boolean {
@@ -28,7 +28,7 @@ export function showUserPrompts(context: Context, sdks: Sdks): void {
 	const versionLink = extensionVersion.split(".").slice(0, 2).join(".").replace(".", "-");
 	const releaseNotesKeyForThisVersion = `release_notes_${extensionVersion}`;
 
-	if (sdks.projectType === ProjectType.Flutter && !hasFlutterExtension && !hasPrompted(installFlutterExtensionPromptKey))
+	if (workspaceContext.hasAnyFlutterProjects && !hasFlutterExtension && !hasPrompted(installFlutterExtensionPromptKey))
 		return showPrompt(installFlutterExtensionPromptKey, promptToInstallFlutterExtension);
 
 	if (!isDevExtension && !hasPrompted(releaseNotesKeyForThisVersion))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -282,6 +282,12 @@ export class WorkspaceContext {
 	// TODO: Move things from Sdks to this class that aren't related to the SDKs.
 	constructor(public readonly sdks: Sdks) { }
 
+	// Whether or not something in the workspace attempted to use Flutter but failed to
+	// find the SDK. Used to provide better messages when commands like flutter.create fail
+	// due to missing SDKs, since they can't check for SDKs prior to appearing in the
+	// command palette since they're visible when the extension is not loaded.
+	public attemptedToUseFlutter: boolean = false;
+
 	get hasOnlyDartProjects() { return this.sdks.projectType === ProjectType.Dart; }
 	get hasAnyFlutterMobileProjects() { return this.sdks.projectType === ProjectType.Flutter; }
 	get hasAnyFlutterProjects() { return this.sdks.projectType !== ProjectType.Dart; }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -278,6 +278,21 @@ export function openInBrowser(url: string) {
 	commands.executeCommand("vscode.open", Uri.parse(url));
 }
 
+export class WorkspaceContext {
+	// TODO: Move things from Sdks to this class that aren't related to the SDKs.
+	constructor(
+		public readonly sdks: Sdks,
+	) { }
+
+	get hasAnyFlutterMobileProjects() { return this.sdks.projectType === ProjectType.Flutter; }
+	get hasAnyFlutterProjects() { return this.sdks.projectType !== ProjectType.Dart; }
+	get shouldLoadFlutterExtension() { return this.sdks.projectType === ProjectType.Flutter || this.sdks.projectType === ProjectType.Fuchsia; }
+	get isInFuchsiaTree() { return this.sdks.projectType === ProjectType.Fuchsia; }
+
+	// TODO: Since this class is passed around, we may need to make it update itself
+	// (eg. if the last Flutter project is removed from the multi-root workspace)?
+}
+
 export class Sdks {
 	public dart?: string;
 	public dartVersion?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -284,6 +284,7 @@ export class WorkspaceContext {
 		public readonly sdks: Sdks,
 	) { }
 
+	get hasOnlyDartProjects() { return this.sdks.projectType === ProjectType.Dart; }
 	get hasAnyFlutterMobileProjects() { return this.sdks.projectType === ProjectType.Flutter; }
 	get hasAnyFlutterProjects() { return this.sdks.projectType !== ProjectType.Dart; }
 	get shouldLoadFlutterExtension() { return this.sdks.projectType === ProjectType.Flutter || this.sdks.projectType === ProjectType.Fuchsia; }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -282,16 +282,11 @@ export class WorkspaceContext {
 	// TODO: Move things from Sdks to this class that aren't related to the SDKs.
 	constructor(public readonly sdks: Sdks) { }
 
-	// Whether or not something in the workspace attempted to use Flutter but failed to
-	// find the SDK. Used to provide better messages when commands like flutter.create fail
-	// due to missing SDKs, since they can't check for SDKs prior to appearing in the
-	// command palette since they're visible when the extension is not loaded.
-	public attemptedToUseFlutter: boolean = false;
-
 	get hasOnlyDartProjects() { return this.sdks.projectType === ProjectType.Dart; }
 	get hasAnyFlutterMobileProjects() { return this.sdks.projectType === ProjectType.Flutter; }
 	get hasAnyFlutterProjects() { return this.sdks.projectType !== ProjectType.Dart; }
 	get shouldLoadFlutterExtension() { return this.sdks.projectType === ProjectType.Flutter || this.sdks.projectType === ProjectType.Fuchsia; }
+	// TODO: Remove this flag - it's possible to have multiple projects open, only some of which are in the Fuchsia tree.
 	get isInFuchsiaTree() { return this.sdks.projectType === ProjectType.Fuchsia; }
 
 	/// Used only for display (for ex stats), not behaviour.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -280,15 +280,23 @@ export function openInBrowser(url: string) {
 
 export class WorkspaceContext {
 	// TODO: Move things from Sdks to this class that aren't related to the SDKs.
-	constructor(
-		public readonly sdks: Sdks,
-	) { }
+	constructor(public readonly sdks: Sdks) { }
 
 	get hasOnlyDartProjects() { return this.sdks.projectType === ProjectType.Dart; }
 	get hasAnyFlutterMobileProjects() { return this.sdks.projectType === ProjectType.Flutter; }
 	get hasAnyFlutterProjects() { return this.sdks.projectType !== ProjectType.Dart; }
 	get shouldLoadFlutterExtension() { return this.sdks.projectType === ProjectType.Flutter || this.sdks.projectType === ProjectType.Fuchsia; }
 	get isInFuchsiaTree() { return this.sdks.projectType === ProjectType.Fuchsia; }
+
+	/// Used only for display (for ex stats), not behaviour.
+	get workspaceTypeDescription(): string {
+		if (this.isInFuchsiaTree)
+			return "Fuchsia";
+		else if (this.hasAnyFlutterProjects)
+			return "Flutter";
+		else
+			return "Dart";
+	}
 
 	// TODO: Since this class is passed around, we may need to make it update itself
 	// (eg. if the last Flutter project is removed from the multi-root workspace)?

--- a/test/dart_only/extension.test.ts
+++ b/test/dart_only/extension.test.ts
@@ -28,7 +28,7 @@ describe("extension", () => {
 	it("found the Dart SDK", async () => {
 		await activateWithoutAnalysis();
 		assert.ok(extApi);
-		const sdks: Sdks = extApi.sdks;
+		const sdks: Sdks = extApi.workspaceContext.sdks;
 		assert.ok(sdks);
 		assert.ok(sdks.dart);
 		logInfo("        " + JSON.stringify(sdks, undefined, 8).trim().slice(1, -1).trim());
@@ -37,7 +37,7 @@ describe("extension", () => {
 	it("did not try to use Flutter's version of the Dart SDK", async () => {
 		await activateWithoutAnalysis();
 		assert.ok(extApi);
-		const sdks: Sdks = extApi.sdks;
+		const sdks: Sdks = extApi.workspaceContext.sdks;
 		assert.ok(sdks);
 		assert.ok(sdks.dart);
 		assert.equal(sdks.dartSdkIsFromFlutter, false);

--- a/test/flutter_only/extension.test.ts
+++ b/test/flutter_only/extension.test.ts
@@ -24,7 +24,7 @@ describe("extension", () => {
 	it("found the Dart and Flutter SDK", async () => {
 		await activateWithoutAnalysis();
 		assert.ok(extApi);
-		const sdks: Sdks = extApi.sdks;
+		const sdks: Sdks = extApi.workspaceContext.sdks;
 		assert.ok(sdks);
 		assert.ok(sdks.dart);
 		assert.ok(sdks.flutter);
@@ -34,7 +34,7 @@ describe("extension", () => {
 	it("used Flutter's version of the Dart SDK", async () => {
 		await activateWithoutAnalysis();
 		assert.ok(extApi);
-		const sdks: Sdks = extApi.sdks;
+		const sdks: Sdks = extApi.workspaceContext.sdks;
 		assert.ok(sdks);
 		assert.ok(sdks.dart);
 		assert.equal(sdks.dartSdkIsFromFlutter, true);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -9,7 +9,7 @@ import { Context } from "../src/context";
 import { dartCodeExtensionIdentifier, flatMap, LogCategory, LogSeverity } from "../src/debug/utils";
 import { InternalExtensionApi } from "../src/extension";
 import { internalApiSymbol } from "../src/symbols";
-import { fsPath, isAnalyzable, ProjectType, vsCodeVersionConstraint } from "../src/utils";
+import { fsPath, isAnalyzable, vsCodeVersionConstraint } from "../src/utils";
 import { tryDeleteFile } from "../src/utils/fs";
 import { log, logError, logTo, logWarn } from "../src/utils/log";
 import { waitFor } from "../src/utils/promises";
@@ -82,10 +82,11 @@ export function currentDoc(): vs.TextDocument {
 export let documentEol: string;
 
 function getDefaultFile(): vs.Uri {
-	if (extApi.sdks.projectType === ProjectType.Dart)
-		return emptyFile;
-	else
+	// TODO: Web?
+	if (extApi.workspaceContext.hasAnyFlutterProjects)
 		return flutterEmptyFile;
+	else
+		return emptyFile;
 }
 
 export async function activateWithoutAnalysis(): Promise<void> {

--- a/test/multi_root/extension.test.ts
+++ b/test/multi_root/extension.test.ts
@@ -27,7 +27,8 @@ describe("extension", () => {
 	it("found the Dart and Flutter SDK", async () => {
 		await activateWithoutAnalysis();
 		assert.ok(extApi);
-		const sdks: Sdks = extApi.sdks;
+		// TODO: Add tests for the workspaceContext flags (here and elsewhere).
+		const sdks: Sdks = extApi.workspaceContext.sdks;
 		assert.ok(sdks);
 		assert.ok(sdks.dart);
 		assert.ok(sdks.flutter);
@@ -35,7 +36,7 @@ describe("extension", () => {
 	it("used Flutter's version of the Dart SDK", async () => {
 		await activateWithoutAnalysis();
 		assert.ok(extApi);
-		const sdks: Sdks = extApi.sdks;
+		const sdks: Sdks = extApi.workspaceContext.sdks;
 		assert.ok(sdks);
 		assert.ok(sdks.dart);
 		assert.notEqual(sdks.dart!.indexOf("flutter"), -1);


### PR DESCRIPTION
ProjectType worked ok when there was only Dart vs Flutter, but now it's becoming more common to have multiple project types (in future you could easily have Dart, Web, Flutter, Flutter Web, Fuchsia workspace folders).

This moves all code that used ProjectTypes directly to instead use flags on a new WorkspaceContext which are not mutually exclusive. This makes it easier to answer questions like "do we need to show the device manager?" which really means "are any projects Flutter mobile?".