### PR TITLE
Add support for target-platform to Flutter launch config.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1277,6 +1277,17 @@
 								],
 								"default": "debug"
 							},
+							"flutterPlatform": {
+								"description": "Passes the --target-platform option to the flutter run command. Ignored on iOS.",
+								"enum": [
+									"default",
+									"android-arm",
+									"android-arm64",
+									"android-x86",
+									"android-x64"
+								],
+								"default": "default"
+							},
 							"args": {
 								"type": "array",
 								"description": "Command line arguments to the application.",

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -162,6 +162,10 @@ export class FlutterDebugSession extends DartDebugSession {
 				}
 			}
 
+			if (args.flutterPlatform) {
+				appArgs.push(`--target-platform=${args.flutterPlatform}`)
+			}
+
 			if (this.shouldConnectDebugger) {
 				appArgs.push("--start-paused");
 

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -163,7 +163,7 @@ export class FlutterDebugSession extends DartDebugSession {
 			}
 
 			if (args.flutterPlatform) {
-				appArgs.push(`--target-platform=${args.flutterPlatform}`)
+				appArgs.push(`--target-platform=${args.flutterPlatform}`);
 			}
 
 			if (this.shouldConnectDebugger) {

--- a/src/debug/utils.ts
+++ b/src/debug/utils.ts
@@ -198,6 +198,7 @@ export interface FlutterLaunchRequestArguments extends DartLaunchRequestArgument
 	flutterAttachSupportsUris: boolean;
 	flutterPath?: string;
 	flutterMode?: "debug" | "profile" | "release";
+	flutterPlatform?: "default" | "android-arm" | "android-arm64" | "android-x86" | "android-x64";
 	flutterRunLogFile?: string;
 	flutterTestLogFile?: string;
 }

--- a/src/providers/debug_config_provider.ts
+++ b/src/providers/debug_config_provider.ts
@@ -468,6 +468,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 					// Otherwise use the config.
 					conf.flutterTrackWidgetCreation;
 			debugConfig.flutterMode = debugConfig.flutterMode || "debug";
+			debugConfig.flutterPlatform = debugConfig.flutterPlatform || "default";
 			debugConfig.flutterPath = debugConfig.flutterPath || (this.sdks.flutter ? path.join(this.sdks.flutter, flutterPath) : undefined);
 			debugConfig.flutterRunLogFile = debugConfig.flutterRunLogFile || conf.flutterRunLogFile;
 			debugConfig.flutterTestLogFile = debugConfig.flutterTestLogFile || conf.flutterTestLogFile;


### PR DESCRIPTION
`flutter --target-platform` allows developers to choose the target architecture.

It's auto-selected but sometimes there is a definitive need to specify the field sometimes, e.g. App testing for different phones / architectures.