### PR TITLE
Add custom tracking to UI Guides preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1228,6 +1228,12 @@
 					"description": "Whether to enable the Flutter UI Guides preview.",
 					"scope": "window"
 				},
+				"dart.previewFlutterUiGuidesCustomTracking": {
+					"type": "boolean",
+					"default": false,
+					"description": "Whether to enable custom tracking of Flutter UI guidelines (to hide some latency of waiting for the next Flutter Outline).",
+					"scope": "window"
+				},
 				"dart.previewToStringInDebugViews": {
 					"type": "boolean",
 					"default": false,

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,7 @@ class Config {
 	get openTestView(): Array<"testRunStart" | "testFailure"> { return this.getConfig<Array<"testRunStart" | "testFailure">>("openTestView", ["testRunStart"]); }
 	get previewBuildRunnerTasks(): boolean { return this.getConfig<boolean>("previewBuildRunnerTasks", false); }
 	get previewFlutterUiGuides(): boolean { return this.getConfig<boolean>("previewFlutterUiGuides", false); }
+	get previewFlutterUiGuidesCustomTracking(): boolean { return this.getConfig<boolean>("previewFlutterUiGuidesCustomTracking", false); }
 	get previewToStringInDebugViews(): boolean { return this.getConfig<boolean>("previewToStringInDebugViews", false); }
 	get promptToRunIfErrors(): boolean { return this.getConfig<boolean>("promptToRunIfErrors", true); }
 	get reportAnalyzerErrors(): boolean { return this.getConfig<boolean>("reportAnalyzerErrors", true); }

--- a/src/editing/trackers.ts
+++ b/src/editing/trackers.ts
@@ -1,0 +1,111 @@
+import * as vs from "vscode";
+
+export class DocumentPositionTracker implements vs.Disposable {
+	private readonly disposables: vs.Disposable[] = [];
+	private readonly tracker: DocumentOffsetTracker = new DocumentOffsetTracker();
+	private readonly positionMap: Map<vs.Position, number> = new Map<vs.Position, number>();
+
+	private onPositionsChangedEmitter = new vs.EventEmitter<[vs.TextDocument, Map<vs.Position, vs.Position>]>();
+	public readonly onPositionsChanged = this.onPositionsChangedEmitter.event;
+
+	constructor() {
+		this.disposables.push(this.tracker);
+
+		this.tracker.onOffsetsChanged(([doc, offsets]) => {
+			// Map all our original positions onto new positions based on their
+			// new offsets.
+			const newPositions = new Map<vs.Position, vs.Position>();
+			for (const position of this.positionMap.keys()) {
+				const currentOffset = this.positionMap.get(position);
+				const newOffset = offsets.get(currentOffset);
+				if (newOffset)
+					newPositions.set(position, doc.positionAt(newOffset));
+			}
+
+			this.onPositionsChangedEmitter.fire([doc, newPositions]);
+		});
+	}
+
+	public clear(): void {
+		this.positionMap.clear();
+		this.tracker.clear();
+	}
+
+	public trackDoc(document: vs.TextDocument, positions: vs.Position[]) {
+		// Stash all positions as offsets.
+		this.positionMap.clear();
+		for (const position of positions)
+			this.positionMap.set(position, document.offsetAt(position));
+
+		// Track via the offset tracker.
+		this.tracker.trackDoc(document, [...this.positionMap.values()]);
+	}
+
+	public dispose() {
+		this.disposables.forEach((s) => s.dispose());
+	}
+}
+
+export class DocumentOffsetTracker implements vs.Disposable {
+	private readonly disposables: vs.Disposable[] = [];
+	private document: vs.TextDocument | undefined;
+	private readonly offsetMap: Map<number, number> = new Map<number, number>();
+
+	private onOffsetsChangedEmitter = new vs.EventEmitter<[vs.TextDocument, Map<number, number>]>();
+	public readonly onOffsetsChanged = this.onOffsetsChangedEmitter.event;
+
+	constructor() {
+		this.disposables.push(vs.workspace.onDidChangeTextDocument((e) => this.handleUpdate(e)));
+	}
+
+	public trackDoc(document: vs.TextDocument, offsets: number[]) {
+		this.document = document;
+		// Set all offsets to just point to themeselves.
+		this.offsetMap.clear();
+		for (const offset of offsets)
+			this.offsetMap.set(offset, offset);
+	}
+
+	public clear(): void {
+		this.document = undefined;
+		this.offsetMap.clear();
+	}
+
+	private handleUpdate(e: vs.TextDocumentChangeEvent) {
+		if (e.document !== this.document)
+			return;
+
+		for (const offset of [...this.offsetMap.keys()]) {
+			// The key (offset) is the original offset, which we must use in the
+			// map to track the current offset.
+			// updateOffset takes the *value*, since we need to map the "current" (not
+			// original) value, and then updates the value in the map.
+			const currentOffset = this.offsetMap.get(offset);
+			const newOffset = this.updateOffset(currentOffset, e);
+			this.offsetMap.set(offset, newOffset);
+		}
+
+		this.onOffsetsChangedEmitter.fire([e.document, this.offsetMap]);
+	}
+
+	private updateOffset(offset: number, change: vs.TextDocumentChangeEvent): number | undefined {
+		// If any edit spans us, consider us deleted.
+		if (change.contentChanges.find((edit) => edit.rangeOffset < offset && edit.rangeOffset + edit.rangeLength > offset)) {
+			return undefined;
+		}
+
+		// Otherwise, shift us along to account for any edits before us.
+		const totalDiff = change.contentChanges
+			// Edits that end before us.
+			.filter((edit) => edit.rangeOffset + edit.rangeLength <= offset)
+			// Get the difference in lengths to know if we inserted or removed.
+			.map((edit) => edit.text.length - edit.rangeLength)
+			.reduce((total, n) => total + n, 0);
+
+		return offset + totalDiff;
+	}
+
+	public dispose() {
+		this.disposables.forEach((s) => s.dispose());
+	}
+}

--- a/test/dart_only/editing/position_trackers.test.ts
+++ b/test/dart_only/editing/position_trackers.test.ts
@@ -1,0 +1,241 @@
+import * as assert from "assert";
+import { Position, Range } from "vscode";
+import { DocumentOffsetTracker, DocumentPositionTracker } from "../../../src/editing/trackers";
+import { activate, currentDoc, currentEditor, positionOf, setTestContent } from "../../helpers";
+
+describe("offset tracker", () => {
+	beforeEach("activate emptyFile", () => activate());
+	const tracker = new DocumentOffsetTracker();
+
+	it("handles insertions before tracked position", async () => {
+		const editor = currentEditor();
+		const doc = currentDoc();
+		await setTestContent("0123456789");
+
+		const originalOffset = 5;
+		tracker.trackDoc(doc, [originalOffset]);
+
+		let updatedValues: Map<number, number> | undefined;
+		tracker.onOffsetsChanged(([_, offsetMap]) => updatedValues = offsetMap);
+
+		// Insert a character before our position.
+		await editor.edit((eb) => eb.insert(new Position(0, 0), "_"));
+
+		assert.ok(updatedValues);
+		assert.equal(updatedValues.get(originalOffset), 6);
+	});
+
+	it("handles deletes before tracked position", async () => {
+		const editor = currentEditor();
+		const doc = currentDoc();
+		await setTestContent("0123456789");
+
+		const originalOffset = 5;
+		tracker.trackDoc(doc, [originalOffset]);
+
+		let updatedValues: Map<number, number> | undefined;
+		tracker.onOffsetsChanged(([_, offsetMap]) => updatedValues = offsetMap);
+
+		// Delete a character before our position.
+		await editor.edit((eb) => eb.delete(new Range(new Position(0, 0), new Position(0, 1))));
+
+		assert.ok(updatedValues);
+		assert.equal(updatedValues.get(originalOffset), 4);
+	});
+
+	it("handles same-length edits before tracked position", async () => {
+		const editor = currentEditor();
+		const doc = currentDoc();
+		await setTestContent("0123456789");
+
+		const originalOffset = 5;
+		tracker.trackDoc(doc, [originalOffset]);
+
+		let updatedValues: Map<number, number> | undefined;
+		tracker.onOffsetsChanged(([_, offsetMap]) => updatedValues = offsetMap);
+
+		// Replace a character before our position.
+		await editor.edit((eb) => eb.replace(new Range(new Position(0, 0), new Position(0, 1)), "_"));
+
+		assert.ok(updatedValues);
+		assert.equal(updatedValues.get(originalOffset), originalOffset);
+	});
+
+	it("ignores edits after tracked position", async () => {
+		const editor = currentEditor();
+		const doc = currentDoc();
+		await setTestContent("0123456789");
+
+		const originalOffset = 5;
+		tracker.trackDoc(doc, [originalOffset]);
+
+		let updatedValues: Map<number, number> | undefined;
+		tracker.onOffsetsChanged(([_, offsetMap]) => updatedValues = offsetMap);
+
+		// Insert text after our position.
+		await editor.edit((eb) => eb.insert(new Position(0, 7), "NEW TEXT"));
+
+		assert.ok(updatedValues);
+		assert.equal(updatedValues.get(originalOffset), originalOffset);
+	});
+
+	it("returns undefined if position was swallowed by an edit", async () => {
+		const editor = currentEditor();
+		const doc = currentDoc();
+		await setTestContent("0123456789");
+
+		const originalOffset = 5;
+		tracker.trackDoc(doc, [originalOffset]);
+
+		let updatedValues: Map<number, number> | undefined;
+		tracker.onOffsetsChanged(([_, offsetMap]) => updatedValues = offsetMap);
+
+		// Insert text after our position.
+		await editor.edit((eb) => eb.replace(new Range(new Position(0, 2), new Position(0, 8)), "THIS IS NEW TEXT"));
+
+		assert.ok(updatedValues);
+		assert.equal(updatedValues.get(originalOffset), undefined);
+	});
+
+	it("handles multiple edits", async () => {
+		const editor = currentEditor();
+		const doc = currentDoc();
+		await setTestContent("0123456789");
+
+		const originalOffset = 5;
+		tracker.trackDoc(doc, [originalOffset]);
+
+		let updatedValues: Map<number, number> | undefined;
+		tracker.onOffsetsChanged(([_, offsetMap]) => updatedValues = offsetMap);
+
+		// Make multiple edits so that we still expect to key using the original
+		// offset but the value is updated based on its current value each time.
+		await editor.edit((eb) => eb.insert(new Position(0, 0), "_"));
+		await editor.edit((eb) => eb.insert(new Position(0, 0), "_"));
+		await editor.edit((eb) => eb.insert(new Position(0, 0), "_"));
+		await editor.edit((eb) => eb.insert(new Position(0, 0), "_"));
+		await editor.edit((eb) => eb.insert(new Position(0, 0), "_"));
+
+		assert.ok(updatedValues);
+		assert.equal(updatedValues.get(originalOffset), 10);
+	});
+});
+
+describe("position tracker", () => {
+	beforeEach("activate emptyFile", () => activate());
+
+	const tracker = new DocumentPositionTracker();
+
+	it("handles insertions before tracked position", async () => {
+		const editor = currentEditor();
+		const doc = currentDoc();
+		await setTestContent("0123456789");
+
+		const originalPosition = positionOf("4^5");
+		tracker.trackDoc(doc, [originalPosition]);
+
+		let updatedValues: Map<Position, Position> | undefined;
+		tracker.onPositionsChanged(([_, positionMap]) => updatedValues = positionMap);
+
+		// Insert a character before our position.
+		await editor.edit((eb) => eb.insert(new Position(0, 0), "_"));
+
+		assert.ok(updatedValues);
+		assert.ok(updatedValues.get(originalPosition).isEqual(positionOf("4^5")));
+	});
+
+	it("handles deletes before tracked position", async () => {
+		const editor = currentEditor();
+		const doc = currentDoc();
+		await setTestContent("0123456789");
+
+		const originalPosition = positionOf("4^5");
+		tracker.trackDoc(doc, [originalPosition]);
+
+		let updatedValues: Map<Position, Position> | undefined;
+		tracker.onPositionsChanged(([_, positionMap]) => updatedValues = positionMap);
+
+		// Delete a character before our position.
+		await editor.edit((eb) => eb.delete(new Range(new Position(0, 0), new Position(0, 1))));
+
+		assert.ok(updatedValues);
+		assert.ok(updatedValues.get(originalPosition).isEqual(positionOf("4^5")));
+	});
+
+	it("handles same-length edits before tracked position", async () => {
+		const editor = currentEditor();
+		const doc = currentDoc();
+		await setTestContent("0123456789");
+
+		const originalPosition = positionOf("4^5");
+		tracker.trackDoc(doc, [originalPosition]);
+
+		let updatedValues: Map<Position, Position> | undefined;
+		tracker.onPositionsChanged(([_, positionMap]) => updatedValues = positionMap);
+
+		// Replace a character before our position.
+		await editor.edit((eb) => eb.replace(new Range(new Position(0, 0), new Position(0, 1)), "_"));
+
+		assert.ok(updatedValues);
+		assert.ok(updatedValues.get(originalPosition).isEqual(positionOf("4^5")));
+	});
+
+	it("ignores edits after tracked position", async () => {
+		const editor = currentEditor();
+		const doc = currentDoc();
+		await setTestContent("0123456789");
+
+		const originalPosition = positionOf("4^5");
+		tracker.trackDoc(doc, [originalPosition]);
+
+		let updatedValues: Map<Position, Position> | undefined;
+		tracker.onPositionsChanged(([_, positionMap]) => updatedValues = positionMap);
+
+		// Insert text after our position.
+		await editor.edit((eb) => eb.insert(new Position(0, 7), "NEW TEXT"));
+
+		assert.ok(updatedValues);
+		assert.ok(updatedValues.get(originalPosition).isEqual(positionOf("4^5")));
+	});
+
+	it("returns undefined if position was swallowed by an edit", async () => {
+		const editor = currentEditor();
+		const doc = currentDoc();
+		await setTestContent("0123456789");
+
+		const originalPosition = positionOf("4^5");
+		tracker.trackDoc(doc, [originalPosition]);
+
+		let updatedValues: Map<Position, Position> | undefined;
+		tracker.onPositionsChanged(([_, positionMap]) => updatedValues = positionMap);
+
+		// Insert text after our position.
+		await editor.edit((eb) => eb.replace(new Range(new Position(0, 2), new Position(0, 8)), "THIS IS NEW TEXT"));
+
+		assert.ok(updatedValues);
+		assert.equal(updatedValues.get(originalPosition), undefined);
+	});
+
+	it("handles multiple edits", async () => {
+		const editor = currentEditor();
+		const doc = currentDoc();
+		await setTestContent("0123456789");
+
+		const originalPosition = positionOf("4^5");
+		tracker.trackDoc(doc, [originalPosition]);
+
+		let updatedValues: Map<Position, Position> | undefined;
+		tracker.onPositionsChanged(([_, positionMap]) => updatedValues = positionMap);
+
+		// Make multiple edits so that we still expect to key using the original
+		// offset but the value is updated based on its current value each time.
+		await editor.edit((eb) => eb.insert(new Position(0, 0), "_"));
+		await editor.edit((eb) => eb.insert(new Position(0, 0), "_"));
+		await editor.edit((eb) => eb.insert(new Position(0, 0), "_"));
+		await editor.edit((eb) => eb.insert(new Position(0, 0), "_"));
+		await editor.edit((eb) => eb.insert(new Position(0, 0), "_"));
+
+		assert.ok(updatedValues);
+		assert.ok(updatedValues.get(originalPosition).isEqual(positionOf("4^5")));
+	});
+});


### PR DESCRIPTION
Adds a `dart.previewFlutterUiGuidesCustomTracking` setting that enables custom tracking of edits to try and keep guides updated while waiting for a Flutter Outline update.

Guide are currently tinted pink when being rendered by this code. If it takes a while for pink guides to go back grey, then there's probably a real benefit to this. If the pink guides are rendered incorrectly, maybe not!