### PR TITLE
Add ide=VSCode to DevTools querystring

### DIFF
--- a/src/extension/sdk/dev_tools.ts
+++ b/src/extension/sdk/dev_tools.ts
@@ -69,6 +69,7 @@ export class DevToolsManager implements vs.Disposable {
 								params: {
 									queryParams: {
 										hide: "debugger",
+										ide: "VSCode",
 										theme: config.useDevToolsDarkTheme ? "dark" : null,
 									},
 								},


### PR DESCRIPTION
@jacob314 @terrylucas any preference on the name/value of this? Although not technically an IDE, `ide` seemed shorter than `editor`. Using a real `name=value` rather than just `&vscode=` makes it easier to just write as-is to a custom dimension if the other editors did the same.