### PR TITLE
Make many tests compatible with running against LSP server

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -500,7 +500,6 @@ export function activate(context: vs.ExtensionContext, isRestart: boolean = fals
 			packagesTreeProvider: dartPackagesProvider,
 			pubGlobal,
 			reanalyze,
-			referenceProvider,
 			renameProvider,
 			safeSpawn,
 			testTreeProvider,

--- a/src/shared/vscode/interfaces.ts
+++ b/src/shared/vscode/interfaces.ts
@@ -1,5 +1,5 @@
 import * as child_process from "child_process";
-import { CompletionItem, CompletionItemProvider, DebugConfigurationProvider, DebugSession, DebugSessionCustomEvent, DefinitionProvider, MarkdownString, ReferenceProvider, RenameProvider, TextDocument, TreeDataProvider, TreeItem, Uri } from "vscode";
+import { CompletionItem, CompletionItemProvider, DebugConfigurationProvider, DebugSession, DebugSessionCustomEvent, MarkdownString, RenameProvider, TextDocument, TreeDataProvider, TreeItem, Uri } from "vscode";
 import { AvailableSuggestion, Outline } from "../analysis_server_types";
 import { TestStatus, VersionStatus } from "../enums";
 import { DebugCommandHandler } from "../interfaces";
@@ -54,7 +54,6 @@ export interface InternalExtensionApi {
 		uninstall(packageID: string): Promise<void>;
 	};
 	reanalyze: () => void;
-	referenceProvider: ReferenceProvider & DefinitionProvider;
 	renameProvider: RenameProvider;
 	safeSpawn: (workingDirectory: string | undefined, binPath: string, args: string[], envOverrides?: any) => child_process.ChildProcess;
 	testTreeProvider: TestResultsProvider;

--- a/src/test/dart_only/providers/dart_formatting_edit_provider.test.ts
+++ b/src/test/dart_only/providers/dart_formatting_edit_provider.test.ts
@@ -45,6 +45,9 @@ describe("dart_formatting_edit_provider", () => {
 	});
 
 	it("does not format the document if disabled", async () => {
+		// TODO: How can we handle this in LSP?
+		// https://github.com/microsoft/vscode/issues/70314#issuecomment-502699605
+
 		await setConfigForTest("editor", "formatOnSave", true);
 		await setConfigForTest("dart", "enableSdkFormatter", false);
 		await setTestContent(unformattedContent);

--- a/src/test/dart_only/providers/dart_hover_provider.test.ts
+++ b/src/test/dart_only/providers/dart_hover_provider.test.ts
@@ -22,9 +22,13 @@ describe("dart_hover_provider", () => {
 			// TODO: Once VS Code updates (and we require that version), we may be able to simplify this.
 			// For the existing VS Code impl we get an array here, but for LSP we return '---' as a separator since
 			// we only get a single item. To treat them the same, join with `---` then split on `---`.
-			const sections = h.contents.map((c) => ((c as any).value as string).trim()).join("\n---\n").split("\n---\n");
+			const sections = h.contents.map((c) => ((c as any).value as string).trim())
+				.join("\n---\n")
+				.replace("\n```\n", "\n```\n---\n")
+				.replace("\n---\n---\n", "\n---\n") // Hacks just to make both LSP and non-LSP end up formatted the same.
+				.split("\n---\n");
 			const displayText = sections[0];
-			const docs = sections[1];
+			const docs = sections.slice(1).join("\n");
 			assert.equal(displayText.substr(0, 7), "```dart");
 			assert.equal(displayText.substr(-3), "```");
 			return {
@@ -49,7 +53,7 @@ describe("dart_hover_provider", () => {
 	}
 
 	function getExpectedDoc(packagePath: string, doc: string): string {
-		return extApi.analyzerCapabilities.hasNewHoverLibraryFormat && packagePath
+		return (extApi.analyzerCapabilities.hasNewHoverLibraryFormat) && packagePath
 			? `*${packagePath}*\n\n${doc}`
 			: doc;
 	}

--- a/src/test/dart_only/providers/ignore_lint_code_action_provider.test.ts
+++ b/src/test/dart_only/providers/ignore_lint_code_action_provider.test.ts
@@ -14,7 +14,10 @@ describe("ignore_lint_code_action_provider", () => {
 		assert.ok(fixResults);
 		assert.ok(fixResults.length);
 
-		const ignoreLintAction = fixResults.find((r) => r.title.indexOf("Ignore hint 'unused_local_variable' for this line") !== -1);
+		const ignoreLintAction = fixResults.find((r) => {
+			return r.title.indexOf("Ignore hint 'unused_local_variable' for this line") !== -1
+				|| r.title.indexOf("Ignore 'unused_local_variable' for this line") !== -1;
+		});
 		assert.ok(ignoreLintAction);
 	});
 
@@ -29,7 +32,10 @@ describe("ignore_lint_code_action_provider", () => {
 
 		const filteredResults = fixResults.filter((f) => !vs.CodeActionKind.Source.contains(f.kind));
 
-		const index = filteredResults.findIndex((r) => r.title.indexOf("Ignore hint 'unused_local_variable' for this line") !== -1);
+		const index = filteredResults.findIndex((r) => {
+			return r.title.indexOf("Ignore hint 'unused_local_variable' for this line") !== -1
+				|| r.title.indexOf("Ignore 'unused_local_variable' for this line") !== -1;
+		});
 		assert.equal(index, filteredResults.length - 1);
 	});
 
@@ -39,7 +45,10 @@ describe("ignore_lint_code_action_provider", () => {
   var a = 1;
 }`);
 		const fixResults = await (vs.commands.executeCommand("vscode.executeCodeActionProvider", currentDoc().uri, rangeOf("|a| = 1")) as Thenable<vs.CodeAction[]>);
-		const ignoreLintAction = fixResults.find((r) => r.title.indexOf("Ignore hint 'unused_local_variable' for this line") !== -1);
+		const ignoreLintAction = fixResults.find((r) => {
+			return r.title.indexOf("Ignore hint 'unused_local_variable' for this line") !== -1
+				|| r.title.indexOf("Ignore 'unused_local_variable' for this line") !== -1;
+		});
 
 		await vs.workspace.applyEdit(ignoreLintAction!.edit);
 

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -534,7 +534,7 @@ export async function getSnippetCompletionsAt(searchText: string, triggerCharact
 export function ensureCompletion(items: vs.CompletionItem[], kind: vs.CompletionItemKind, label: string, filterText?: string, documentation?: string): vs.CompletionItem {
 	let completion = items.find((item) =>
 		item.label === label
-		&& item.filterText === filterText
+		&& (item.filterText === filterText || (item.filterText === undefined && filterText === label))
 		&& item.kind === kind,
 	);
 	assert.ok(


### PR DESCRIPTION
Does doesn't enable LSP, but is some fixes back-ported (and then tweaked to ensure they didn't break non-LSP).