### PR TITLE
Only select ephemeral devices

### DIFF
--- a/src/extension/flutter/device_manager.ts
+++ b/src/extension/flutter/device_manager.ts
@@ -31,6 +31,7 @@ export class FlutterDeviceManager implements vs.Disposable {
 	}
 
 	public deviceAdded(dev: f.Device) {
+		dev = { ...dev, type: "device" };
 		this.devices.push(dev);
 		// undefined is treated as true for backwards compatibility.
 		const canAutoSelectDevice = dev.ephemeral !== false;
@@ -97,12 +98,15 @@ export class FlutterDeviceManager implements vs.Disposable {
 		}
 	}
 
-	private async getEmulators(): Promise<Array<{ id: string, name: string }>> {
+	private async getEmulators(): Promise<f.Emulator[]> {
 		try {
 			const emus = await this.daemon.getEmulators();
 			return emus.map((e) => ({
+				category: e.category,
 				id: e.id,
 				name: e.name || e.id,
+				platformType: e.platformType,
+				type: "emulator",
 			}));
 		} catch (e) {
 			this.logger.error({ message: e });

--- a/src/extension/flutter/device_manager.ts
+++ b/src/extension/flutter/device_manager.ts
@@ -32,17 +32,20 @@ export class FlutterDeviceManager implements vs.Disposable {
 
 	public deviceAdded(dev: f.Device) {
 		this.devices.push(dev);
-		if (!this.currentDevice || config.flutterSelectDeviceWhenConnected) {
+		// undefined is treated as true for backwards compatibility.
+		const canAutoSelectDevice = dev.ephemeral !== false;
+		if (!this.currentDevice || (config.flutterSelectDeviceWhenConnected && canAutoSelectDevice)) {
 			this.currentDevice = dev;
+			this.updateStatusBar();
 		}
-		this.updateStatusBar();
 	}
 
 	public deviceRemoved(dev: f.Device) {
 		this.devices = this.devices.filter((d) => d.id !== dev.id);
-		if (this.currentDevice && this.currentDevice.id === dev.id)
+		if (this.currentDevice && this.currentDevice.id === dev.id) {
 			this.currentDevice = this.devices.length === 0 ? undefined : this.devices[this.devices.length - 1];
-		this.updateStatusBar();
+			this.updateStatusBar();
+		}
 	}
 
 	public async showDevicePicker(): Promise<void> {

--- a/src/extension/flutter/flutter_daemon.ts
+++ b/src/extension/flutter/flutter_daemon.ts
@@ -24,6 +24,7 @@ export class DaemonCapabilities {
 
 	get canCreateEmulators() { return versionIsAtLeast(this.version, "0.4.0"); }
 	get canFlutterAttach() { return versionIsAtLeast(this.version, "0.4.1"); }
+	get providesPlatformTypes() { return versionIsAtLeast(this.version, "0.5.2"); }
 }
 
 export class FlutterDaemon extends StdIOService<UnknownNotification> {
@@ -164,7 +165,7 @@ export class FlutterDaemon extends StdIOService<UnknownNotification> {
 		return this.sendRequest("device.enable");
 	}
 
-	public getEmulators(): Thenable<Array<{ id: string, name: string }>> {
+	public getEmulators(): Thenable<f.Emulator[]> {
 		return this.sendRequest("emulator.getEmulators");
 	}
 
@@ -174,6 +175,10 @@ export class FlutterDaemon extends StdIOService<UnknownNotification> {
 
 	public createEmulator(name?: string): Thenable<{ success: boolean, emulatorName: string, error: string }> {
 		return this.sendRequest("emulator.create", { name });
+	}
+
+	public getSupportedPlatforms(projectRoot: string): Thenable<f.SupportedPlatformsResponse> {
+		return this.sendRequest("daemon.getSupportedPlatforms", { projectRoot });
 	}
 
 	// Subscription methods.

--- a/src/extension/flutter/flutter_types.ts
+++ b/src/extension/flutter/flutter_types.ts
@@ -1,8 +1,27 @@
+export type PlatformType = "android" | "ios" | "linux" | "macos" | "fuchsia" | "windows" | "web" | string;
+export type Category = "mobile" | "web" | "desktop" | string;
+
 export interface Device {
+	category: Category | undefined | null;
+	emulator: boolean;
+	ephemeral: boolean | undefined;
 	id: string;
 	name: string;
 	platform: string;
-	emulator: boolean;
+	platformType: PlatformType | undefined | null;
+	type: "device";
+}
+
+export interface Emulator {
+	id: string;
+	name: string;
+	category: Category | undefined | null;
+	platformType: PlatformType | undefined | null;
+	type: "emulator";
+}
+
+export interface EmulatorCreator {
+	type: "emulator-creator";
 }
 
 export interface DaemonConnected {
@@ -52,4 +71,8 @@ export interface ShowMessage {
 	level: "info" | "warning" | "error";
 	title: string;
 	message: string;
+}
+
+export interface SupportedPlatformsResponse {
+	platforms: PlatformType[];
 }


### PR DESCRIPTION
For older versions we just treat every device as auto-selectable, but when Flutter tells us a device is not ephemeral (Desktop/Web) we don't auto-select it unless there are no other devices.

This can be improved further (only auto-select if it's valid for an open project), but this will at least avoid the issue where a desktop device is selected upon opening a project if the mobile is already connected (the devices come through with mobile first, desktop second).