### PR TITLE
Fix up coverage after webpacking broke it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -170,5 +170,5 @@ after_script:
       dpl --provider=s3 --bucket="test-results.dartcode.org" --skip_cleanup=true --local-dir=".dart_code_test_logs" --upload-dir="logs/$TRAVIS_BRANCH/$TRAVIS_COMMIT/$TRAVIS_OS_NAME" --acl=public_read --default_text_charset=utf-8;
     fi
   - if [ $ONLY_RUN_CODE_VERSION == "STABLE" ] && [ $ONLY_RUN_DART_VERSION == "STABLE" ]; then
-      ./cc-test-reporter after-build --prefix ../../ --exit-code $TRAVIS_TEST_RESULT;
+      ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT;
     fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -413,12 +413,6 @@
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true
 		},
-		"abbrev": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-			"dev": true
-		},
 		"acorn": {
 			"version": "6.1.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
@@ -464,32 +458,16 @@
 			"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
 			"dev": true
 		},
-		"amdefine": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-			"dev": true,
-			"optional": true
-		},
-		"ansi-colors": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
-			"integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
-			"dev": true,
-			"requires": {
-				"ansi-wrap": "^0.1.0"
-			}
-		},
 		"ansi-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 			"dev": true
 		},
-		"ansi-wrap": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+		"ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
 			"dev": true
 		},
 		"anymatch": {
@@ -602,12 +580,6 @@
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
 			"dev": true
 		},
-		"async": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-			"dev": true
-		},
 		"async-each": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -623,6 +595,169 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
+			"requires": {
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
+			}
+		},
+		"babel-generator": {
+			"version": "6.26.1",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"dev": true,
+			"requires": {
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.17.4",
+				"source-map": "^0.5.7",
+				"trim-right": "^1.0.1"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+					"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"babel-messages": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.22.0"
+			}
+		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
+			"requires": {
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
+			}
+		},
+		"babel-template": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"lodash": "^4.17.4"
+			}
+		},
+		"babel-traverse": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "^6.26.0",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"debug": "^2.6.8",
+				"globals": "^9.18.0",
+				"invariant": "^2.2.2",
+				"lodash": "^4.17.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"globals": {
+					"version": "9.18.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+					"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+					"dev": true
+				}
+			}
+		},
+		"babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
+			},
+			"dependencies": {
+				"to-fast-properties": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+					"dev": true
+				}
+			}
+		},
+		"babylon": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
 			"dev": true
 		},
 		"balanced-match": {
@@ -1020,6 +1155,12 @@
 				"wrap-ansi": "^2.0.0"
 			}
 		},
+		"co": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+			"dev": true
+		},
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -1133,6 +1274,15 @@
 			"integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
 			"dev": true
 		},
+		"convert-source-map": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
+		},
 		"copy-concurrently": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -1151,6 +1301,12 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true
+		},
+		"core-js": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+			"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -1269,12 +1425,6 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
-		"deep-is": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-			"dev": true
-		},
 		"define-property": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -1331,6 +1481,15 @@
 			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
 			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
 			"dev": true
+		},
+		"detect-indent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
+			"requires": {
+				"repeating": "^2.0.0"
+			}
 		},
 		"diff": {
 			"version": "3.5.0",
@@ -1438,31 +1597,6 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true
 		},
-		"escodegen": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-			"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-			"dev": true,
-			"requires": {
-				"esprima": "^2.7.1",
-				"estraverse": "^1.9.1",
-				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.2.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"amdefine": ">=0.0.4"
-					}
-				}
-			}
-		},
 		"eslint-scope": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -1481,12 +1615,6 @@
 				}
 			}
 		},
-		"esprima": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-			"dev": true
-		},
 		"esrecurse": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
@@ -1503,12 +1631,6 @@
 					"dev": true
 				}
 			}
-		},
-		"estraverse": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-			"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
@@ -1696,12 +1818,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-			"dev": true
-		},
-		"fast-levenshtein": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
 		"figgy-pudding": {
@@ -2565,16 +2681,21 @@
 			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
 			"dev": true
 		},
-		"handlebars": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"neo-async": "^2.6.0",
-				"optimist": "^0.6.1",
-				"source-map": "^0.6.1",
-				"uglify-js": "^3.1.4"
+				"ansi-regex": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				}
 			}
 		},
 		"has-flag": {
@@ -2747,6 +2868,15 @@
 			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
 			"dev": true
 		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
+		},
 		"invert-kv": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
@@ -2839,6 +2969,15 @@
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
 			"dev": true
 		},
+		"is-finite": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
+			"requires": {
+				"number-is-nan": "^1.0.0"
+			}
+		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -2927,55 +3066,77 @@
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
 		},
-		"istanbul": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
-			"integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+		"istanbul-instrumenter-loader": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/istanbul-instrumenter-loader/-/istanbul-instrumenter-loader-3.0.1.tgz",
+			"integrity": "sha512-a5SPObZgS0jB/ixaKSMdn6n/gXSrK2S6q/UfRJBT3e6gQmVjwZROTODQsYW5ZNwOu78hG62Y3fWlebaVOL0C+w==",
 			"dev": true,
 			"requires": {
-				"abbrev": "1.0.x",
-				"async": "1.x",
-				"escodegen": "1.8.x",
-				"esprima": "2.7.x",
-				"glob": "^5.0.15",
-				"handlebars": "^4.0.1",
-				"js-yaml": "3.x",
-				"mkdirp": "0.5.x",
-				"nopt": "3.x",
-				"once": "1.x",
-				"resolve": "1.1.x",
-				"supports-color": "^3.1.0",
-				"which": "^1.1.1",
-				"wordwrap": "^1.0.0"
+				"convert-source-map": "^1.5.0",
+				"istanbul-lib-instrument": "^1.7.3",
+				"loader-utils": "^1.1.0",
+				"schema-utils": "^0.3.0"
 			},
 			"dependencies": {
-				"glob": {
-					"version": "5.0.15",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+				"ajv": {
+					"version": "5.5.2",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 					"dev": true,
 					"requires": {
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "2 || 3",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"co": "^4.6.0",
+						"fast-deep-equal": "^1.0.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0"
 					}
 				},
-				"has-flag": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+				"fast-deep-equal": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
 					"dev": true
 				},
-				"supports-color": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+				"istanbul-lib-coverage": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
+					"integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
+					"dev": true
+				},
+				"istanbul-lib-instrument": {
+					"version": "1.10.2",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
+					"integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^1.0.0"
+						"babel-generator": "^6.18.0",
+						"babel-template": "^6.16.0",
+						"babel-traverse": "^6.18.0",
+						"babel-types": "^6.18.0",
+						"babylon": "^6.18.0",
+						"istanbul-lib-coverage": "^1.2.1",
+						"semver": "^5.3.0"
 					}
+				},
+				"json-schema-traverse": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+					"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+					"dev": true
+				},
+				"schema-utils": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
+					"integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+					"dev": true,
+					"requires": {
+						"ajv": "^5.0.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -3007,6 +3168,12 @@
 					"dev": true
 				}
 			}
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
 		},
 		"js-yaml": {
 			"version": "3.13.1",
@@ -3082,16 +3249,6 @@
 				"invert-kv": "^2.0.0"
 			}
 		},
-		"levn": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"dev": true,
-			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
-			}
-		},
 		"loader-runner": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -3136,6 +3293,15 @@
 			"resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
 			"integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
 			"dev": true
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
 		},
 		"lru-cache": {
 			"version": "5.1.1",
@@ -3563,15 +3729,6 @@
 						"safe-buffer": "~5.1.0"
 					}
 				}
-			}
-		},
-		"nopt": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-			"dev": true,
-			"requires": {
-				"abbrev": "1"
 			}
 		},
 		"normalize-path": {
@@ -4779,20 +4936,6 @@
 				}
 			}
 		},
-		"optionator": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-			"dev": true,
-			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
-			}
-		},
 		"os-browserify": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -5019,12 +5162,6 @@
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
 			"dev": true
 		},
-		"prelude-ls": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-			"dev": true
-		},
 		"process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -5158,6 +5295,12 @@
 				"readable-stream": "^2.0.2"
 			}
 		},
+		"regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true
+		},
 		"regex-not": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -5166,74 +5309,6 @@
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
-			}
-		},
-		"remap-istanbul": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.13.0.tgz",
-			"integrity": "sha512-rS5ZpVAx3fGtKZkiBe1esXg5mKYbgW9iz8kkADFt3p6lo3NsBBUX1q6SwdhwUtYCGnr7nK6gRlbYK3i8R0jbRA==",
-			"dev": true,
-			"requires": {
-				"istanbul": "0.4.5",
-				"minimatch": "^3.0.4",
-				"plugin-error": "^1.0.1",
-				"source-map": "0.6.1",
-				"through2": "3.0.0"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
-				},
-				"arr-union": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-					"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-					"dev": true
-				},
-				"extend-shallow": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-					"dev": true,
-					"requires": {
-						"assign-symbols": "^1.0.0",
-						"is-extendable": "^1.0.1"
-					}
-				},
-				"is-extendable": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
-					"requires": {
-						"is-plain-object": "^2.0.4"
-					}
-				},
-				"plugin-error": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
-					"integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
-					"dev": true,
-					"requires": {
-						"ansi-colors": "^1.0.1",
-						"arr-diff": "^4.0.0",
-						"arr-union": "^3.1.0",
-						"extend-shallow": "^3.0.2"
-					}
-				},
-				"through2": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.0.tgz",
-					"integrity": "sha512-8B+sevlqP4OiCjonI1Zw03Sf8PuV1eRsYQgLad5eonILOdyeRsY27A/2Ze8IlvlMvq31OH+3fz/styI7Ya62yQ==",
-					"dev": true,
-					"requires": {
-						"readable-stream": "2 || 3",
-						"xtend": "~4.0.1"
-					}
-				}
 			}
 		},
 		"remove-trailing-separator": {
@@ -5254,6 +5329,15 @@
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
 			"dev": true
 		},
+		"repeating": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
+			"requires": {
+				"is-finite": "^1.0.0"
+			}
+		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5264,12 +5348,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-			"dev": true
-		},
-		"resolve": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
 			"dev": true
 		},
 		"resolve-cwd": {
@@ -5326,24 +5404,6 @@
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
-			}
-		},
-		"run-for-every-file": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/run-for-every-file/-/run-for-every-file-1.1.0.tgz",
-			"integrity": "sha512-uA3vA06H644eBw8sQx1FpjP6HeG6Ob648TPYYs20pLrvnJLjIOYqCvI+g3pDYtcLa4YDbDJDiStPPF3heSVeaQ==",
-			"dev": true,
-			"requires": {
-				"glob": "^7.0.5",
-				"minimist": "^1.2.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
 			}
 		},
 		"run-queue": {
@@ -5802,6 +5862,12 @@
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
 		},
+		"supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
+		},
 		"tapable": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
@@ -6078,15 +6144,6 @@
 			"resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
 			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
 			"dev": true
-		},
-		"type-check": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"dev": true,
-			"requires": {
-				"prelude-ls": "~1.1.2"
-			}
 		},
 		"type-detect": {
 			"version": "4.0.8",
@@ -6429,12 +6486,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
-		},
-		"wordwrap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
 			"dev": true
 		},
 		"worker-farm": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -413,6 +413,12 @@
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true
 		},
+		"abbrev": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+			"integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+			"dev": true
+		},
 		"acorn": {
 			"version": "6.1.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
@@ -458,6 +464,22 @@
 			"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
 			"dev": true
 		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true,
+			"optional": true
+		},
+		"ansi-colors": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+			"integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+			"dev": true,
+			"requires": {
+				"ansi-wrap": "^0.1.0"
+			}
+		},
 		"ansi-regex": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -468,6 +490,12 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
 			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
+		},
+		"ansi-wrap": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
 			"dev": true
 		},
 		"anymatch": {
@@ -578,6 +606,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true
+		},
+		"async": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
 			"dev": true
 		},
 		"async-each": {
@@ -1425,6 +1459,12 @@
 			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 			"dev": true
 		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
 		"define-property": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -1597,6 +1637,31 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 			"dev": true
 		},
+		"escodegen": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+			"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+			"dev": true,
+			"requires": {
+				"esprima": "^2.7.1",
+				"estraverse": "^1.9.1",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.2.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"amdefine": ">=0.0.4"
+					}
+				}
+			}
+		},
 		"eslint-scope": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -1615,6 +1680,12 @@
 				}
 			}
 		},
+		"esprima": {
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+			"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+			"dev": true
+		},
 		"esrecurse": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
@@ -1631,6 +1702,12 @@
 					"dev": true
 				}
 			}
+		},
+		"estraverse": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+			"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.2",
@@ -1818,6 +1895,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"dev": true
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true
 		},
 		"figgy-pudding": {
@@ -2681,6 +2764,18 @@
 			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
 			"dev": true
 		},
+		"handlebars": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+			"dev": true,
+			"requires": {
+				"neo-async": "^2.6.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
+			}
+		},
 		"has-ansi": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -3066,6 +3161,58 @@
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
 		},
+		"istanbul": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
+			"integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
+			"dev": true,
+			"requires": {
+				"abbrev": "1.0.x",
+				"async": "1.x",
+				"escodegen": "1.8.x",
+				"esprima": "2.7.x",
+				"glob": "^5.0.15",
+				"handlebars": "^4.0.1",
+				"js-yaml": "3.x",
+				"mkdirp": "0.5.x",
+				"nopt": "3.x",
+				"once": "1.x",
+				"resolve": "1.1.x",
+				"supports-color": "^3.1.0",
+				"which": "^1.1.1",
+				"wordwrap": "^1.0.0"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"dev": true,
+					"requires": {
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
+					"requires": {
+						"has-flag": "^1.0.0"
+					}
+				}
+			}
+		},
 		"istanbul-instrumenter-loader": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/istanbul-instrumenter-loader/-/istanbul-instrumenter-loader-3.0.1.tgz",
@@ -3247,6 +3394,16 @@
 			"dev": true,
 			"requires": {
 				"invert-kv": "^2.0.0"
+			}
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"loader-runner": {
@@ -3729,6 +3886,15 @@
 						"safe-buffer": "~5.1.0"
 					}
 				}
+			}
+		},
+		"nopt": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+			"dev": true,
+			"requires": {
+				"abbrev": "1"
 			}
 		},
 		"normalize-path": {
@@ -4936,6 +5102,20 @@
 				}
 			}
 		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
+			"requires": {
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
+			}
+		},
 		"os-browserify": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -5156,10 +5336,28 @@
 				"find-up": "^3.0.0"
 			}
 		},
+		"plugin-error": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+			"integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "^1.0.1",
+				"arr-diff": "^4.0.0",
+				"arr-union": "^3.1.0",
+				"extend-shallow": "^3.0.2"
+			}
+		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"dev": true
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 			"dev": true
 		},
 		"process": {
@@ -5311,6 +5509,31 @@
 				"safe-regex": "^1.1.0"
 			}
 		},
+		"remap-istanbul": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.13.0.tgz",
+			"integrity": "sha512-rS5ZpVAx3fGtKZkiBe1esXg5mKYbgW9iz8kkADFt3p6lo3NsBBUX1q6SwdhwUtYCGnr7nK6gRlbYK3i8R0jbRA==",
+			"dev": true,
+			"requires": {
+				"istanbul": "0.4.5",
+				"minimatch": "^3.0.4",
+				"plugin-error": "^1.0.1",
+				"source-map": "0.6.1",
+				"through2": "3.0.0"
+			},
+			"dependencies": {
+				"through2": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.0.tgz",
+					"integrity": "sha512-8B+sevlqP4OiCjonI1Zw03Sf8PuV1eRsYQgLad5eonILOdyeRsY27A/2Ze8IlvlMvq31OH+3fz/styI7Ya62yQ==",
+					"dev": true,
+					"requires": {
+						"readable-stream": "2 || 3",
+						"xtend": "~4.0.1"
+					}
+				}
+			}
+		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -5348,6 +5571,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
+		},
+		"resolve": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+			"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
 			"dev": true
 		},
 		"resolve-cwd": {
@@ -5404,6 +5633,24 @@
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
+			}
+		},
+		"run-for-every-file": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/run-for-every-file/-/run-for-every-file-1.1.0.tgz",
+			"integrity": "sha512-uA3vA06H644eBw8sQx1FpjP6HeG6Ob648TPYYs20pLrvnJLjIOYqCvI+g3pDYtcLa4YDbDJDiStPPF3heSVeaQ==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.0.5",
+				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
 			}
 		},
 		"run-queue": {
@@ -6145,6 +6392,15 @@
 			"integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
 			"dev": true
 		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "~1.1.2"
+			}
+		},
 		"type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -6486,6 +6742,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
+		},
+		"wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
 			"dev": true
 		},
 		"worker-farm": {

--- a/package.json
+++ b/package.json
@@ -1459,7 +1459,9 @@
 		"build-tests": "tsc -p ./",
 		"watch-tests": "tsc -p ./ --watch",
 		"lint": "tslint 'src/**/*.ts' -t verbose",
-		"test": "npm run build-with-instrumentation && npm run build-tests && npm run test-only && npm run report_lcov && npm run report_screen",
+		"test": "npm run build && npm run build-tests && npm run instrument && npm run test-only && npm run remap_coverage && npm run report_lcov && npm run report_screen",
+		"instrument": "cd out/src && nyc instrument --compact false . . && cd ../..",
+		"remap_coverage": "cd out/src && node ../../out/src/test/remap_coverage.js && cd ../..",
 		"test-only": "node ./out/src/test/test_all.js",
 		"report_lcov": "nyc report -r lcovonly",
 		"report_screen": "nyc report"
@@ -1484,6 +1486,7 @@
 		"istanbul-instrumenter-loader": "^3.0.1",
 		"mocha": "^5.2.0",
 		"nyc": "^13.1.0",
+		"remap-istanbul": "^0.13.0",
 		"signal-exit": "^3.0.2",
 		"sinon": "^7.1.1",
 		"source-map-support": "^0.5.12",

--- a/package.json
+++ b/package.json
@@ -1459,7 +1459,7 @@
 		"build-tests": "tsc -p ./",
 		"watch-tests": "tsc -p ./ --watch",
 		"lint": "tslint 'src/**/*.ts' -t verbose",
-		"test": "npm run build && npm run build-tests && npm run instrument && npm run test-only && npm run remap_coverage && npm run report_lcov && npm run report_screen",
+		"test": "npm run build-with-instrumentation && npm run build-tests && npm run instrument && npm run test-only && npm run remap_coverage && npm run report_lcov && npm run report_screen",
 		"instrument": "cd out/src && nyc instrument --compact false . . && cd ../..",
 		"remap_coverage": "cd out/src && node ../../out/src/test/remap_coverage.js && cd ../..",
 		"test-only": "node ./out/src/test/test_all.js",

--- a/package.json
+++ b/package.json
@@ -1454,14 +1454,12 @@
 	"scripts": {
 		"vscode:prepublish": "webpack --mode production",
 		"build": "webpack --mode development",
+		"build-with-instrumentation": "webpack --env.instrumentation --mode development",
 		"watch": "webpack --mode development --watch --info-verbosity verbose",
 		"build-tests": "tsc -p ./",
 		"watch-tests": "tsc -p ./ --watch",
 		"lint": "tslint 'src/**/*.ts' -t verbose",
-		"test": "npm run build && npm run build-tests && npm run write_empty_coverage && npm run remap_empty_coverage && npm run instrument && npm run test-only && npm run report_lcov && npm run report_screen",
-		"instrument": "cd out/src/extension && nyc instrument . . && cd ../../..",
-		"write_empty_coverage": "cd out/src/extension && nyc --all --reporter=none --include out/src/extension echo && cd ../../..",
-		"remap_empty_coverage": "cd out/src/extension && run-for-every-file --src \"../../../.nyc_output/*.json\" --run \"remap-istanbul -i {{src-file}} -o {{src-file}}\" && cd ../../..",
+		"test": "npm run build-with-instrumentation && npm run build-tests && npm run test-only && npm run report_lcov && npm run report_screen",
 		"test-only": "node ./out/src/test/test_all.js",
 		"report_lcov": "nyc report -r lcovonly",
 		"report_screen": "nyc report"
@@ -1483,10 +1481,9 @@
 		"@types/sinon": "^5.0.5",
 		"@types/vscode": "^1.33.0",
 		"@types/ws": "^6.0.1",
+		"istanbul-instrumenter-loader": "^3.0.1",
 		"mocha": "^5.2.0",
 		"nyc": "^13.1.0",
-		"remap-istanbul": "^0.13.0",
-		"run-for-every-file": "^1.1.0",
 		"signal-exit": "^3.0.2",
 		"sinon": "^7.1.1",
 		"source-map-support": "^0.5.12",
@@ -1495,7 +1492,7 @@
 		"typescript": "^3.5.1",
 		"vscode-debugadapter-testsupport": "^1.34.0",
 		"vscode-test": "^0.4.3",
-		"webpack-cli": "^3.3.2",
-		"webpack": "^4.33.0"
+		"webpack": "^4.33.0",
+		"webpack-cli": "^3.3.2"
 	}
 }

--- a/src/test/remap_coverage.ts
+++ b/src/test/remap_coverage.ts
@@ -1,0 +1,17 @@
+import * as fs from "fs";
+import * as path from "path";
+const loadCoverage = require("remap-istanbul/lib/loadCoverage");
+const remap = require("remap-istanbul/lib/remap");
+const writeReport = require("remap-istanbul/lib/writeReport");
+
+const files = fs.readdirSync("../../.nyc_output")
+	.filter((item) => item.endsWith(".json"));
+
+for (const filename of files) {
+	const fullPath = `../../.nyc_output/${filename}`;
+	const coverage = loadCoverage(fullPath);
+	const collector = remap(coverage, {
+		mapFileName: path.resolve,
+	});
+	writeReport(collector, "json", {}, fullPath);
+}

--- a/src/test/remap_coverage.ts
+++ b/src/test/remap_coverage.ts
@@ -1,3 +1,4 @@
+// tslint:disable: no-var-requires
 import * as fs from "fs";
 import * as path from "path";
 const loadCoverage = require("remap-istanbul/lib/loadCoverage");

--- a/src/test/test_all.ts
+++ b/src/test/test_all.ts
@@ -95,7 +95,7 @@ async function runTests(testFolder: string, workspaceFolder: string, sdkPaths: s
 	if (!fs.existsSync(testEnv.DC_TEST_LOGS))
 		fs.mkdirSync(testEnv.DC_TEST_LOGS);
 
-	let res = await vstest.runTests({
+	const res = await vstest.runTests({
 		extensionPath: cwd,
 		testRunnerEnv: testEnv,
 		testRunnerPath: path.join(cwd, "out", "src", "test", testFolder),
@@ -105,23 +105,6 @@ async function runTests(testFolder: string, workspaceFolder: string, sdkPaths: s
 		version: codeVersion,
 	});
 	exitCode = exitCode || res;
-
-	// Remap coverage output.
-	if (fs.existsSync(testEnv.COVERAGE_OUTPUT)) {
-		// Note: Path wonkiness - only seems to work from out/src/extension even if supplying -b!
-		res = await runNode(
-			path.join(cwd, "out", "src", "extension"),
-			[
-				"../../../node_modules/remap-istanbul/bin/remap-istanbul",
-				"-i",
-				testEnv.COVERAGE_OUTPUT,
-				"-o",
-				testEnv.COVERAGE_OUTPUT,
-			],
-			testEnv,
-		);
-		exitCode = exitCode || res;
-	}
 
 	console.log(yellow("############################################################"));
 	console.log("\n\n");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,35 +19,44 @@
 
 const path = require("path");
 
-/**
- * @type {import("webpack").Configuration}
- */
-const config = {
-	devtool: "source-map",
-	entry: "./src/extension/extension.ts",
-	// https://webpack.js.org/configuration/externals/
-	externals: {
-		vscode: "commonjs vscode",
-	},
-	module: {
-		rules: [{
-			exclude: /node_modules/,
-			test: /\.ts$/,
-			use: [{
+module.exports = env => {
+	/**
+	 * @type {import("webpack").Configuration}
+	 */
+	const config = {
+		devtool: "source-map",
+		entry: "./src/extension/extension.ts",
+		// https://webpack.js.org/configuration/externals/
+		externals: {
+			vscode: "commonjs vscode",
+		},
+		module: {
+			rules: [{
+				exclude: /node_modules/,
+				test: /\.ts$/,
 				loader: "ts-loader",
 			}],
-		}],
-	},
-	output: {
-		devtoolModuleFilenameTemplate: "../../[resource-path]",
-		filename: "extension.js",
-		libraryTarget: "commonjs2",
-		path: path.resolve(__dirname, "out/dist"),
-	},
-	resolve: {
-		extensions: [".ts", ".js"],
-	},
-	target: "node",
-};
+		},
+		output: {
+			devtoolModuleFilenameTemplate: "../../[resource-path]",
+			filename: "extension.js",
+			libraryTarget: "commonjs2",
+			path: path.resolve(__dirname, "out/dist"),
+		},
+		resolve: {
+			extensions: [".ts", ".js"],
+		},
+		target: "node",
+	};
 
-module.exports = config;
+	if (env && env.instrumentation) {
+		config.module.rules.push({
+			enforce: "post",
+			exclude: /node_modules/,
+			test: /\.ts$/,
+			loader: "istanbul-instrumenter-loader",
+		});
+	}
+
+	return config;
+};


### PR DESCRIPTION
This gets the report mostly working locally, however there are two issues to resolve:

- [x] ~~The paths are based are relative to `src` instead of the root, which might mess up Code Climate~~ fixed because coverage has full path (though this may break again when second point is fixed)
- [x] This is now only doing the packed extension - the things loaded directly in tests (for ex. unit tests that test against code in shared) are almost certainly excluded