### PR TITLE
Use "Service" instead of "_Service" for VM service protocol >= 3.22

### DIFF
--- a/src/extension/debug/dart_debug_impl.ts
+++ b/src/extension/debug/dart_debug_impl.ts
@@ -12,7 +12,7 @@ import { white } from "../../shared/utils/colors";
 import { config } from "../config";
 import { getLogHeader } from "../utils/log";
 import { safeSpawn } from "../utils/processes";
-import { DebuggerResult, ObservatoryConnection, SourceReportKind, Version, VM, VMClass, VMErrorRef, VMEvent, VMFrame, VMInstance, VMInstanceRef, VMIsolate, VMLibrary, VMMapEntry, VMObj, VMScript, VMScriptRef, VMSentinel, VMSourceReport, VMStack, VMTypeRef } from "./dart_debug_protocol";
+import { DebuggerResult, ObservatoryConnection, SourceReportKind, Version, VM, VMClass, VMClassRef, VMErrorRef, VMEvent, VMFrame, VMInstance, VMInstanceRef, VMIsolate, VMIsolateRef, VMLibrary, VMMapEntry, VMObj, VMScript, VMScriptRef, VMSentinel, VMSourceReport, VMStack, VMTypeRef } from "./dart_debug_protocol";
 import { DebugAdapterLogger } from "./logging";
 import { PackageMap } from "./package_map";
 import { ThreadInfo, ThreadManager } from "./threads";

--- a/src/extension/debug/dart_debug_protocol.ts
+++ b/src/extension/debug/dart_debug_protocol.ts
@@ -220,6 +220,16 @@ export interface VM extends VMResponse {
 	libraries: VMLibraryRef[];
 }
 
+export interface Version extends VMResponse {
+	// The major version number is incremented when the protocol is changed
+	// in a potentially incompatible way.
+	major: number;
+
+	// The minor version number is incremented when the protocol is changed
+	// in a backwards compatible way.
+	minor: number;
+}
+
 export interface VMMapEntry extends VMResponse {
 	keyId: string;
 	mapEvaluateName: string;

--- a/src/shared/capabilities/vm_service.ts
+++ b/src/shared/capabilities/vm_service.ts
@@ -1,0 +1,9 @@
+import { versionIsAtLeast } from "../utils";
+
+export class VmServiceCapabilities {
+	public static get empty() { return new VmServiceCapabilities("0.0.0"); }
+
+	constructor(public version: string) { }
+
+	get serviceStreamIsPublic() { return versionIsAtLeast(this.version, "3.22.0"); }
+}


### PR DESCRIPTION
@devoncarew would you mind scanning these changes? (Select **Hide whitespace changes** in the diff to avoid seeing loads of changes due to indent change!).

Fixes https://github.com/Dart-Code/Dart-Code/issues/1843.
Also see https://github.com/dart-lang/vm_service_drivers/pull/251.