### PR TITLE
Show log events from dart:developer log() in the debug console (if enabled)

### DIFF
--- a/package.json
+++ b/package.json
@@ -795,6 +795,12 @@
 					"description": "Whether to mark external pub package libraries as debuggable, enabling stepping into them while debugging.",
 					"scope": "resource"
 				},
+				"dart.showDartDeveloperLogs": {
+					"type": "boolean",
+					"default": false,
+					"description": "Whether to show logs from dart:developer's log() function in the debug console.",
+					"scope": "resource"
+				},
 				"dart.enableCompletionCommitCharacters": {
 					"type": "boolean",
 					"default": false,

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -124,6 +124,7 @@ class ResourceConfig {
 	get pubAdditionalArgs(): string[] { return this.getConfig<string[]>("pubAdditionalArgs", []); }
 	get pubTestLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("pubTestLogFile", null))); }
 	get runPubGetOnPubspecChanges(): boolean { return this.getConfig<boolean>("runPubGetOnPubspecChanges", true); }
+	get showDartDeveloperLogs(): boolean { return this.getConfig<boolean>("showDartDeveloperLogs", false); }
 	get vmAdditionalArgs(): string[] { return this.getConfig<string[]>("vmAdditionalArgs", []); }
 	get webDaemonLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("webDaemonLogFile", null))); }
 

--- a/src/extension/debug/dart_debug_impl.ts
+++ b/src/extension/debug/dart_debug_impl.ts
@@ -54,6 +54,7 @@ export class DartDebugSession extends DebugSession {
 	private logStream?: fs.WriteStream;
 	public debugSdkLibraries: boolean;
 	public debugExternalLibraries: boolean;
+	public showDartDeveloperLogs: boolean;
 	public evaluateGettersInDebugViews: boolean;
 	protected threadManager: ThreadManager;
 	public packageMap?: PackageMap;
@@ -119,6 +120,7 @@ export class DartDebugSession extends DebugSession {
 		this.packageMap = new PackageMap(PackageMap.findPackagesFile(args.program || args.cwd));
 		this.debugSdkLibraries = args.debugSdkLibraries;
 		this.debugExternalLibraries = args.debugExternalLibraries;
+		this.showDartDeveloperLogs = args.showDartDeveloperLogs;
 		this.evaluateGettersInDebugViews = args.evaluateGettersInDebugViews;
 		this.logFile = args.observatoryLogFile;
 		this.maxLogLineLength = args.maxLogLineLength;
@@ -403,7 +405,7 @@ export class DartDebugSession extends DebugSession {
 		const serviceStreamName = this.capabilities.serviceStreamIsPublic ? "Service" : "_Service";
 		this.observatory.on(serviceStreamName, (event: VMEvent) => this.handleServiceEvent(event));
 
-		if (this.capabilities.hasLoggingStream)
+		if (this.capabilities.hasLoggingStream && this.showDartDeveloperLogs)
 			this.observatory.on("Logging", (event: VMEvent) => this.handleLoggingEvent(event));
 	}
 
@@ -1156,7 +1158,7 @@ export class DartDebugSession extends DebugSession {
 			if (record && record.message && record.message.valueAsString) {
 				this.logToUser(event.logRecord.message.valueAsString);
 				if (record.message.valueAsStringIsTruncated)
-				this.logToUser("…");
+					this.logToUser("…");
 				this.logToUser("\n");
 			}
 		}

--- a/src/extension/debug/dart_debug_protocol.ts
+++ b/src/extension/debug/dart_debug_protocol.ts
@@ -22,6 +22,7 @@ export interface VMEvent {
 	extensionData?: any;
 	service?: string;
 	method?: string;
+	logRecord?: VMLogRecord;
 }
 
 export interface VMBreakpoint extends VMObj {
@@ -271,6 +272,35 @@ export interface VMFunctionRef extends VMObjectRef {
 	_kind: string;
 	static: boolean;
 	const: boolean;
+}
+
+export interface VMLogRecord extends VMResponse {
+	// The log message.
+	message: VMInstanceRef;
+
+	// The timestamp.
+	time: number;
+
+	// The severity level (a value between 0 and 2000).
+	//
+	// See the package:logging `Level` class for an overview of the possible
+	// values.
+	level: number;
+
+	// A monotonically increasing sequence number.
+	sequenceNumber: number;
+
+	// The name of the source of the log message.
+	loggerName: VMInstanceRef;
+
+	// The zone where the log was emitted.
+	zone: VMInstanceRef;
+
+	// An error object associated with this log event.
+	error: VMInstanceRef;
+
+	// A stack trace associated with this log event.
+	stackTrace: VMInstanceRef;
 }
 
 export interface VMSourceReport extends VMResponse {

--- a/src/extension/debug/utils.ts
+++ b/src/extension/debug/utils.ts
@@ -30,6 +30,7 @@ export interface DartLaunchRequestArguments extends DebugProtocol.LaunchRequestA
 	dartPath: string;
 	debugSdkLibraries: boolean;
 	debugExternalLibraries: boolean;
+	showDartDeveloperLogs: boolean;
 	evaluateGettersInDebugViews: boolean;
 	env: any;
 	program: string;

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -458,6 +458,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		debugConfig.debugExternalLibraries = debugConfig.debugExternalLibraries !== undefined && debugConfig.debugExternalLibraries !== null
 			? debugConfig.debugExternalLibraries
 			: conf.debugExternalLibraries;
+		debugConfig.showDartDeveloperLogs = conf.showDartDeveloperLogs;
 		debugConfig.evaluateGettersInDebugViews = debugConfig.evaluateGettersInDebugViews || conf.evaluateGettersInDebugViews;
 		if (isFlutter) {
 			debugConfig.forceFlutterVerboseMode = isLogging || isCI;

--- a/src/shared/capabilities/vm_service.ts
+++ b/src/shared/capabilities/vm_service.ts
@@ -5,5 +5,6 @@ export class VmServiceCapabilities {
 
 	constructor(public version: string) { }
 
+	get hasLoggingStream() { return versionIsAtLeast(this.version, "3.17.0"); }
 	get serviceStreamIsPublic() { return versionIsAtLeast(this.version, "3.22.0"); }
 }

--- a/src/test/dart_only/debug/dart_cli.test.ts
+++ b/src/test/dart_only/debug/dart_cli.test.ts
@@ -131,6 +131,7 @@ describe("dart cli debugger", () => {
 		await Promise.all([
 			dc.configurationSequence(),
 			dc.assertOutput("stdout", "Hello, world!"),
+			dc.assertOutput("console", "Logging from dart:developer!"),
 			dc.waitForEvent("terminated"),
 			dc.launch(config),
 		]);

--- a/src/test/test_projects/hello_world/.vscode/settings.json
+++ b/src/test/test_projects/hello_world/.vscode/settings.json
@@ -9,4 +9,5 @@
 		"lib/excluded"
 	],
 	"dart.showIgnoreQuickFixes": true,
+	"dart.showDartDeveloperLogs": true,
 }

--- a/src/test/test_projects/hello_world/bin/main.dart
+++ b/src/test/test_projects/hello_world/bin/main.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 main() {
   final s = "Hello!";
   final l = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
@@ -21,6 +23,7 @@ main() {
   if (m[true]) {
     print("Hello, world!"); // BREAKPOINT1
   }
+  log("Logging from dart:developer!");
   genericMethod<bool, double, int, String>();
 }
 


### PR DESCRIPTION
~~Required to do https://github.com/Dart-Code/Dart-Code/issues/1824.~~ Not so, Flutter's errors come through as `Flutter.Error` and are separate to `dart:developer`'s `log()`. This just exposes logs that would otherwise not be visible to the user.