### PR TITLE
Use Fluttered structured error events (behind preview flag)

### DIFF
--- a/package.json
+++ b/package.json
@@ -801,6 +801,12 @@
 					"description": "Whether to show logs from dart:developer's log() function in the debug console.",
 					"scope": "resource"
 				},
+				"dart.previewFlutterStructuredErrors": {
+					"type": "boolean",
+					"default": false,
+					"description": "Whether to enable Flutter's structured error support for improve error display.",
+					"scope": "resource"
+				},
 				"dart.enableCompletionCommitCharacters": {
 					"type": "boolean",
 					"default": false,

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -120,6 +120,7 @@ class ResourceConfig {
 	get insertArgumentPlaceholders(): boolean { return this.getConfig<boolean>("insertArgumentPlaceholders", true); }
 	get lineLength(): number { return this.getConfig<number>("lineLength", 80); }
 	get observatoryLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("observatoryLogFile", null))); }
+	get previewFlutterStructuredErrors(): boolean { return this.getConfig<boolean>("previewFlutterStructuredErrors", false); }
 	get promptToGetPackages(): boolean { return this.getConfig<boolean>("promptToGetPackages", true); }
 	get pubAdditionalArgs(): string[] { return this.getConfig<string[]>("pubAdditionalArgs", []); }
 	get pubTestLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("pubTestLogFile", null))); }

--- a/src/extension/debug/dart_debug_impl.ts
+++ b/src/extension/debug/dart_debug_impl.ts
@@ -56,6 +56,7 @@ export class DartDebugSession extends DebugSession {
 	public debugSdkLibraries = false;
 	public debugExternalLibraries = false;
 	public showDartDeveloperLogs = true;
+	public useFlutterStructuredErrors = false;
 	public evaluateGettersInDebugViews = false;
 	protected threadManager: ThreadManager;
 	public packageMap?: PackageMap;
@@ -122,6 +123,7 @@ export class DartDebugSession extends DebugSession {
 		this.debugSdkLibraries = args.debugSdkLibraries;
 		this.debugExternalLibraries = args.debugExternalLibraries;
 		this.showDartDeveloperLogs = args.showDartDeveloperLogs;
+		this.useFlutterStructuredErrors = args.useFlutterStructuredErrors;
 		this.evaluateGettersInDebugViews = args.evaluateGettersInDebugViews;
 		this.logFile = args.observatoryLogFile;
 		this.maxLogLineLength = args.maxLogLineLength;

--- a/src/extension/debug/dart_debug_impl.ts
+++ b/src/extension/debug/dart_debug_impl.ts
@@ -23,8 +23,8 @@ const maxValuesToCallToString = 15;
 // Prefix that appears at the start of stack frame names that are unoptimized
 // which we'd prefer not to show to the user.
 const unoptimizedPrefix = "[Unoptimized] ";
-const stackFrameWithUriPattern = new RegExp(`(.*#\\d+)(.*)\\(((?:package|dart|file):.*\\.dart):(\\d+):(\\d+)\\)\\s*$`);
-const webStackFrameWithUriPattern = new RegExp(`((?:package|dart|file):.*\\.dart) (\\d+):(\\d+)\\s*(\\S+)\\s*$`);
+const stackFrameWithUriPattern = new RegExp(`(.*#\\d+)(.*)\\(((?:package|dart|file):.*\\.dart):(\\d+):(\\d+)\\)\\s*$`, "m");
+const webStackFrameWithUriPattern = new RegExp(`((?:package|dart|file):.*\\.dart) (\\d+):(\\d+)\\s*(\\S+)\\s*$`, "m");
 
 // TODO: supportsSetVariable
 // TODO: class variables?
@@ -1668,8 +1668,9 @@ export class DartDebugSession extends DebugSession {
 				|| (this.isExternalLibrary(frame.sourceUri) && frame.sourceUri.startsWith("package:flutter/"))
 				|| (this.isExternalLibrary(frame.sourceUri) && frame.sourceUri.startsWith("package:flutter_web/"));
 
+			text = `${frame.prefix || ""}${text}`;
 			const colouredText = isFramework ? col.grey(text) : text;
-			output.body.output = `${frame.prefix || ""}${colouredText}\n`;
+			output.body.output = `${colouredText}\n`;
 		}
 
 		this.sendEvent(output);

--- a/src/extension/debug/flutter_debug_impl.ts
+++ b/src/extension/debug/flutter_debug_impl.ts
@@ -341,6 +341,9 @@ export class FlutterDebugSession extends DartDebugSession {
 		if (node.description && node.description.startsWith("◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤"))
 			return;
 
+		if (node.type === DiagnosticsNodeType.ErrorSpacer)
+			return;
+
 		// TODO: Where should we show up to? Currently only doing top.
 		if (level > 0)
 			return;

--- a/src/extension/debug/flutter_debug_impl.ts
+++ b/src/extension/debug/flutter_debug_impl.ts
@@ -366,6 +366,8 @@ export class FlutterDebugSession extends DartDebugSession {
 			: grey;
 
 		this.logToUser(`${colorText(line)}\n`, "stderr");
+		if (node.level === DiagnosticsNodeLevel.Summary)
+			this.logToUser("\n");
 
 		const childLevel = node.style === DiagnosticsNodeStyle.Flat
 			? level

--- a/src/extension/debug/flutter_debug_impl.ts
+++ b/src/extension/debug/flutter_debug_impl.ts
@@ -379,9 +379,9 @@ export class FlutterDebugSession extends DartDebugSession {
 		if (level > 1)
 			return;
 
-		if (node.children)
+		if (node.style !== DiagnosticsNodeStyle.Shallow && node.children)
 			node.children.forEach((child) => this.logDiagnosticNodeToUser(child, { parent: node, level }));
-		// TODO: Put blank line between non-hint/hints
+		// TODO: Put blank line between non-hint/hints?
 		if (node.properties)
 			node.properties.forEach((child) => this.logDiagnosticNodeToUser(child, { parent: node, level }));
 	}

--- a/src/extension/debug/flutter_debug_impl.ts
+++ b/src/extension/debug/flutter_debug_impl.ts
@@ -359,7 +359,7 @@ export class FlutterDebugSession extends DartDebugSession {
 		// want to override the default red text for the stderr category to grey.
 		const isErrorMessage = node.level === DiagnosticsNodeLevel.Error
 			|| node.level === DiagnosticsNodeLevel.Summary;
-		const isTruncationText = node.description = "...";
+		const isTruncationText = node.description === "...";
 		const isStackFrame = parent.type === DiagnosticsNodeType.DiagnosticsStackTrace && !isTruncationText;
 		const colorText = isStackFrame || isErrorMessage
 			? (s: string) => s

--- a/src/extension/debug/utils.ts
+++ b/src/extension/debug/utils.ts
@@ -31,6 +31,7 @@ export interface DartLaunchRequestArguments extends DebugProtocol.LaunchRequestA
 	debugSdkLibraries: boolean;
 	debugExternalLibraries: boolean;
 	showDartDeveloperLogs: boolean;
+	useFlutterStructuredErrors: boolean;
 	evaluateGettersInDebugViews: boolean;
 	env: any;
 	program: string;

--- a/src/extension/flutter/vm_service_extensions.ts
+++ b/src/extension/flutter/vm_service_extensions.ts
@@ -78,6 +78,8 @@ export class FlutterVmServiceExtensions {
 			// If the isWidgetCreationTracked extension loads, send a command to the debug adapter
 			// asking it to query whether it's enabled (it'll send us an event back with the answer).
 			if (e.body.id === "ext.flutter.inspector.isWidgetCreationTracked") {
+				// TODO: Why do we send these events to the editor for it to send one back? Why don't we just
+				// do the second request in the debug adapter directly and only transmit the result?
 				e.session.customRequest("checkIsWidgetCreationTracked");
 				// If it's the PlatformOverride, send a request to get the current value.
 			} else if (e.body.id === FlutterServiceExtension.PlatformOverride) {

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -462,6 +462,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			? debugConfig.debugExternalLibraries
 			: conf.debugExternalLibraries;
 		debugConfig.showDartDeveloperLogs = conf.showDartDeveloperLogs;
+		debugConfig.useFlutterStructuredErrors = conf.previewFlutterStructuredErrors;
 		debugConfig.evaluateGettersInDebugViews = debugConfig.evaluateGettersInDebugViews || conf.evaluateGettersInDebugViews;
 		if (isFlutter) {
 			debugConfig.forceFlutterVerboseMode = isLogging || isCI;

--- a/src/shared/enums.ts
+++ b/src/shared/enums.ts
@@ -20,6 +20,7 @@ export enum FlutterServiceExtension {
 	PaintBaselines = "ext.flutter.debugPaintBaselinesEnabled",
 	InspectorSelectMode = "ext.flutter.inspector.show",
 	InspectorSetPubRootDirectories = "ext.flutter.inspector.setPubRootDirectories",
+	InspectorStructuredErrors = "ext.flutter.inspector.structuredErrors",
 	RepaintRainbow = "ext.flutter.repaintRainbow",
 	PerformanceOverlay = "ext.flutter.showPerformanceOverlay",
 	SlowAnimations = "ext.flutter.timeDilation",

--- a/src/shared/flutter/structured_errors.ts
+++ b/src/shared/flutter/structured_errors.ts
@@ -31,4 +31,5 @@ export enum DiagnosticsNodeLevel {
 
 export enum DiagnosticsNodeStyle {
 	Flat = "flat",
+	Shallow = "shallow",
 }

--- a/src/shared/flutter/structured_errors.ts
+++ b/src/shared/flutter/structured_errors.ts
@@ -2,12 +2,14 @@ export type FlutterErrorData = DiagnosticsNode;
 
 export interface DiagnosticsNode {
 	type: DiagnosticsNodeType;
+	level: DiagnosticsNodeLevel;
 	description: string;
 	name: string;
 	showName: boolean | undefined;
 	showSeparator: boolean | undefined;
 	properties: DiagnosticsNode[];
 	children: DiagnosticsNode[];
+	style: DiagnosticsNodeStyle;
 }
 
 // If we have per-type properties, handle them like this.
@@ -19,4 +21,14 @@ export enum DiagnosticsNodeType {
 	ErrorDescription = "ErrorDescription",
 	ErrorSpacer = "ErrorSpacer",
 	DiagnosticsStackTrace = "DiagnosticsStackTrace",
+}
+
+export enum DiagnosticsNodeLevel {
+	Error = "error",
+	Summary = "summary",
+	Hint = "hint",
+}
+
+export enum DiagnosticsNodeStyle {
+	Flat = "flat",
 }

--- a/src/shared/flutter/structured_errors.ts
+++ b/src/shared/flutter/structured_errors.ts
@@ -1,0 +1,22 @@
+export type FlutterErrorData = DiagnosticsNode;
+
+export interface DiagnosticsNode {
+	type: DiagnosticsNodeType;
+	description: string;
+	name: string;
+	showName: boolean | undefined;
+	showSeparator: boolean | undefined;
+	properties: DiagnosticsNode[];
+	children: DiagnosticsNode[];
+}
+
+// If we have per-type properties, handle them like this.
+// export interface DescriptionDiagnosticsNode {
+// 	type: DiagnosticsNodeType.ErrorDescription;
+// }
+
+export enum DiagnosticsNodeType {
+	ErrorDescription = "ErrorDescription",
+	ErrorSpacer = "ErrorSpacer",
+	DiagnosticsStackTrace = "DiagnosticsStackTrace",
+}


### PR DESCRIPTION
@jacob314 @InMatrix @devoncarew I've made some progress on this, trying to make them look like IntelliJ's (so please let me know if they change - for ex the yellow ascii banner - so I can copy).

Two of the examples in @InMatrix's repo don't look too bad:

![Screenshot 2019-07-17 at 12 58 56 pm](https://user-images.githubusercontent.com/1078012/61373798-a77a1c00-a892-11e9-81a5-f6a62ecf985e.png)

![Screenshot 2019-07-17 at 12 59 42 pm](https://user-images.githubusercontent.com/1078012/61373834-c37dbd80-a892-11e9-81f5-2ce6026b2d86.png)

However the Material one looks really bad:

![Screenshot 2019-07-17 at 1 00 34 pm](https://user-images.githubusercontent.com/1078012/61373881-e9a35d80-a892-11e9-839c-8225455178f4.png)
![Screenshot 2019-07-17 at 1 00 42 pm](https://user-images.githubusercontent.com/1078012/61373882-e9a35d80-a892-11e9-89e4-768b186fddfd.png)

I think probably I'm rendering more nodes than I should (though it's not clear how I should decide which to show), but also some of it's just in the source (like the top line is like this in one big string). How should that be handled?

- [ ] Also needs tests