### PR TITLE
Extend analysis to to custom file extensions; folding for non-Dart files

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -82,6 +82,10 @@ import { TestItemTreeItem, TestResultsProvider } from "./views/test_view";
 const DART_MODE = { language: "dart", scheme: "file" };
 const HTML_MODE = { language: "html", scheme: "file" };
 
+const additionalModes = config.additionalAnalyzerFileExtensions.map((ext) => {
+	return {scheme: "file", pattern: `**/*.${ext}`};
+});
+
 const DART_PROJECT_LOADED = "dart-code:dartProjectLoaded";
 // TODO: Define what this means better. Some commands a general Flutter (eg. Hot
 // Reload) and some are more specific (eg. Attach).
@@ -233,10 +237,12 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 	const renameProvider = new DartRenameProvider(analyzer);
 	const implementationProvider = new DartImplementationProvider(analyzer);
 
-	const activeFileFilters = [DART_MODE];
+	const activeFileFilters: vs.DocumentSelector = [DART_MODE];
+
 	if (config.analyzeAngularTemplates) {
-		// Analyze Angular2 templates, requires the angular_analyzer_plugin.
+		// Analyze files supported by plugins
 		activeFileFilters.push(HTML_MODE);
+		activeFileFilters.push(...additionalModes);
 	}
 
 	// This is registered with VS Code further down, so it's metadata can be collected from all
@@ -352,7 +358,7 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 		}
 
 		if (analyzer.capabilities.supportsCustomFolding && config.analysisServerFolding)
-			context.subscriptions.push(vs.languages.registerFoldingRangeProvider(DART_MODE, new DartFoldingProvider(analyzer)));
+			context.subscriptions.push(vs.languages.registerFoldingRangeProvider(activeFileFilters, new DartFoldingProvider(analyzer)));
 
 		if (analyzer.capabilities.supportsGetSignature)
 			context.subscriptions.push(vs.languages.registerSignatureHelpProvider(

--- a/src/extension/providers/dart_document_symbol_provider.ts
+++ b/src/extension/providers/dart_document_symbol_provider.ts
@@ -20,12 +20,13 @@ export class DartDocumentSymbolProvider implements DocumentSymbolProvider {
 		const name = outline.element.name
 			? outline.element.name
 			: (outline.element.kind === "EXTENSION" ? "<unnamed extension>" : "<unnamed>");
+		const location = outline.element.location || outline;
 		const symbol = new DocumentSymbol(
 			name,
 			outline.element.parameters,
 			getSymbolKindForElementKind(this.logger, outline.element.kind),
 			this.getCodeOffset(document, outline),
-			toRange(document, outline.element.location.offset, outline.element.location.length),
+			toRange(document, location.offset, location.length),
 		);
 
 		if (outline.children && outline.children.length) {


### PR DESCRIPTION
To better support analyzer plugins on custom file endings, I've made two changes:

1. Register providers that aren't specific to Dart (all those we register on `MODE_HTML`) for extensions declared in `additionalAnalyzerFileExtensions` if the option to use the Angular plugin is turned on.
2. Use the analysis server folding for both html and custom files if enabled.

With a plugin I'm writing, I could verify that auto-complete, folding, outline, problems, fixes and navigation are all working with this setup.

Fixes #1981

## Potential problems

In the linked issue, you asked whether the analysis server would send problematic responses when used with unsupported files. I played around with this as the plugin was turned off, and I didn't run into any problems.
Further, that shouldn't have any impact on the first change because it only effects users who explicitly added a file to `additionalAnalyzerFileExtensions`, which only makes sense when an appropriate plugin is available.