### PR TITLE
Add command to reanalyze project

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,6 +207,11 @@
 				"category": "Dart"
 			},
 			{
+				"command": "dart.reanalyze",
+				"title": "Reanalyze",
+				"category": "Dart"
+			},
+			{
 				"command": "dart.changeSdk",
 				"title": "Change SDK",
 				"category": "Dart"
@@ -518,6 +523,10 @@
 				},
 				{
 					"command": "dart.openAnalyzerDiagnostics",
+					"when": "dart-code:dartProjectLoaded"
+				},
+				{
+					"command": "dart.reanalyze",
 					"when": "dart-code:dartProjectLoaded"
 				},
 				{

--- a/src/extension/commands/analyzer.ts
+++ b/src/extension/commands/analyzer.ts
@@ -9,5 +9,9 @@ export class AnalyzerCommands {
 			const res = await analyzer.diagnosticGetServerPort();
 			await envUtils.openInBrowser(`http://127.0.0.1:${res.port}/`);
 		}));
+
+		context.subscriptions.push(vs.commands.registerCommand("dart.reanalyze", async () => {
+			await analyzer.analysisReanalyze();
+		}));
 	}
 }


### PR DESCRIPTION
This is slightly related to #1970.

Ideally it would not be needed, but I had few situations where I had to run "reload window" because analyzer was not handling updated packages, etc. 

So instead of "reload window" I could just force the analyzer to reanalyze. The additional bonus is that other extensions can also run this command, which will be useful for my extension for r_flutter.

I basically copied the implementation of `dart.openAnalyzerDiagnostics` so there are no tests or anything because the original command didn't have them. 