### PR TITLE
Properly highlight interpolated expressions

### DIFF
--- a/syntaxes/dart.json
+++ b/syntaxes/dart.json
@@ -318,14 +318,19 @@
 			"patterns": [
 				{
 					"captures": {
-						"2": {
-							"name": "variable.parameter.dart"
-						},
-						"3": {
+						"1": {
 							"name": "variable.parameter.dart"
 						}
 					},
-					"match": "\\$((\\w+)|\\{([^{}]+)\\})"
+					"match": "\\$(\\w+)"
+				},
+				{
+					"captures": {
+						"1": {
+							"name": "variable.parameter.dart"
+						}
+					},
+					"match": "\\$\\{([^{}]+)\\}"
 				},
 				{
 					"match": "\\\\.",

--- a/syntaxes/dart.json
+++ b/syntaxes/dart.json
@@ -317,12 +317,13 @@
 		"string-interp": {
 			"patterns": [
 				{
+					"name": "variable.dart",
+					"match": "(\\$)\\w+",
 					"captures": {
 						"1": {
-							"name": "variable.parameter.dart"
+							"name": "variable.punctuation.dart"
 						}
-					},
-					"match": "\\$(\\w+)"
+					}
 				},
 				{
 					"begin": "\\$\\{",

--- a/syntaxes/dart.json
+++ b/syntaxes/dart.json
@@ -325,12 +325,20 @@
 					"match": "\\$(\\w+)"
 				},
 				{
+					"begin": "\\$\\{",
+					"end": "\\}",
 					"captures": {
-						"1": {
-							"name": "variable.parameter.dart"
+						"0": {
+							"name": "punctuation.definition.template-expression.begin.dart"
 						}
 					},
-					"match": "\\$\\{([^{}]+)\\}"
+					"contentName": "meta.template.expression",
+					"patterns": [
+						{
+							"match": ".+",
+							"include": "$self"
+						}
+					]
 				},
 				{
 					"match": "\\\\.",


### PR DESCRIPTION
The way interpolated expressions are currently highlighted is quite hard to read:

![Before](https://user-images.githubusercontent.com/29176678/67407679-28defa00-f5b8-11e9-86c9-1e296bf590b7.png)

This annoyed me a lot, so I decided to update the Dart grammar to properly highlight the expressions within the curly braces and distinguish the beginning (`${`) and end (`}`) from the rest of the string:

![After](https://user-images.githubusercontent.com/29176678/67407795-54fa7b00-f5b8-11e9-9687-f11b45725f6c.png)

