### PR TITLE
Add prompt for Flutter Q4 survey

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -53,9 +53,16 @@ export const alwaysOpenAction = "Always Open";
 export const notTodayAction = "Not Now";
 export const doNotAskAgainAction = "Never Ask";
 
-export const flutterSurveyPromptWithAnalytics = "Help improve Flutter! Take our Q3 survey. By clicking on this link you agree to share feature usage along with the survey responses.";
-export const flutterSurveyPromptWithoutAnalytics = "Help improve Flutter! Take our Q3 survey.";
+export const surveyBaseUrl = "https://google.qualtrics.com/jfe/form/SV_5BhR2R8DZIEE6dn?Source=VSCode";
+export const flutterSurveyPromptWithAnalytics = "Help improve Flutter! Take our Q4 survey. By clicking on this link you agree to share feature usage along with the survey responses.";
+export const flutterSurveyPromptWithoutAnalytics = "Help improve Flutter! Take our Q4 survey.";
 export const takeSurveyAction = "Take Survey";
+// To confirm dates in PST(/PDT), paste this into Chrome dev console:
+// new Date(Date.UTC(...)).toLocaleString("en-US", {timeZone: "America/Los_Angeles"})
+// "11/23/2019, 9:00:00 AM"
+export const surveyStart = Date.UTC(2019, 10 /* Month is 0-based!! */, 23, 17, 0);
+// "12/1/2019, 6:00:00 PM"
+export const surveyEnd = Date.UTC(2019, 11 /* Month is 0-based!! */, 2, 2, 0);
 
 // Minutes.
 export const fiveMinutesInMs = 1000 * 60 * 5;

--- a/src/shared/vscode/user_prompts.ts
+++ b/src/shared/vscode/user_prompts.ts
@@ -2,14 +2,9 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as vs from "vscode";
-import { alwaysOpenAction, doNotAskAgainAction, flutterSurveyPromptWithAnalytics, flutterSurveyPromptWithoutAnalytics, isWin, longRepeatPromptThreshold, noRepeatPromptThreshold, notTodayAction, openDevToolsAction, takeSurveyAction, wantToTryDevToolsPrompt } from "../constants";
+import { alwaysOpenAction, doNotAskAgainAction, flutterSurveyPromptWithAnalytics, flutterSurveyPromptWithoutAnalytics, isWin, longRepeatPromptThreshold, noRepeatPromptThreshold, notTodayAction, openDevToolsAction, surveyBaseUrl, surveyEnd, surveyStart, takeSurveyAction, wantToTryDevToolsPrompt } from "../constants";
 import { Logger } from "../interfaces";
 import { Context } from "./workspace";
-
-// Mon Aug 12 2019 17:00:00 GMT+0100 (British Summer Time UTC+1) = Mon Aug 12 09:00 PDT (UTC-7)
-export const surveyStart = Date.UTC(2019, 7 /* Month is 0-based!! */, 12, 16, 0);
-// Sun Aug 25 2019 02:00:00 GMT+0100 (British Summer Time UTC+1) = Sat Aug 24 18:00 PDT (UTC-7).
-export const surveyEnd = Date.UTC(2019, 7 /* Month is 0-based!! */, 25, 1, 0);
 
 /// Shows Survey notification if appropriate. Returns whether a notification was shown
 /// (not whether it was clicked/opened).
@@ -17,8 +12,8 @@ export function showFlutterSurveyNotificationIfAppropriate(context: Context, ope
 	if (now <= surveyStart || now >= surveyEnd)
 		return false;
 
-	const lastShown = context.flutterSurvey2019Q3NotificationLastShown;
-	const doNotShow = context.flutterSurvey2019Q3NotificationDoNotShow;
+	const lastShown = context.flutterSurvey2019Q4NotificationLastShown;
+	const doNotShow = context.flutterSurvey2019Q4NotificationDoNotShow;
 
 	// Don't show this notification if user previously said not to.
 	if (doNotShow)
@@ -48,21 +43,21 @@ export function showFlutterSurveyNotificationIfAppropriate(context: Context, ope
 	}
 
 	const prompt = clientID ? flutterSurveyPromptWithAnalytics : flutterSurveyPromptWithoutAnalytics;
-	const surveyUrl = "https://google.qualtrics.com/jfe/form/SV_3kiGXYfYOfXUjB3?Source=VSCode"
+	const surveyUrl = surveyBaseUrl
 		+ (clientID ? `&ClientID=${encodeURIComponent(clientID)}` : "");
 
 	// Mark the last time we've shown it (now) so we can avoid showing again for
 	// 40 hours.
-	context.flutterSurvey2019Q3NotificationLastShown = Date.now();
+	context.flutterSurvey2019Q4NotificationLastShown = Date.now();
 
 	// Prompt to show and handle response.
 	vs.window.showInformationMessage(prompt, takeSurveyAction, doNotAskAgainAction).then(async (choice) => {
 		if (choice === doNotAskAgainAction) {
-			context.flutterSurvey2019Q3NotificationDoNotShow = true;
+			context.flutterSurvey2019Q4NotificationDoNotShow = true;
 		} else if (choice === takeSurveyAction) {
 			// Mark as do-not-show-again if they answer it, since it seems silly
 			// to show them again if they already completed it.
-			context.flutterSurvey2019Q3NotificationDoNotShow = true;
+			context.flutterSurvey2019Q4NotificationDoNotShow = true;
 			await openInBrowser(surveyUrl);
 		}
 	});

--- a/src/shared/vscode/workspace.ts
+++ b/src/shared/vscode/workspace.ts
@@ -15,10 +15,10 @@ export class Context {
 	set devToolsNotificationLastShown(value: number | undefined) { this.context.globalState.update("devToolsNotificationLastShown", value); }
 	get devToolsNotificationDoNotShow(): boolean | undefined { return !!this.context.globalState.get("devToolsNotificationDoNotShowAgain"); }
 	set devToolsNotificationDoNotShow(value: boolean | undefined) { this.context.globalState.update("devToolsNotificationDoNotShowAgain", value); }
-	get flutterSurvey2019Q3NotificationLastShown(): number | undefined { return this.context.globalState.get("flutterSurvey2019Q3NotificationLastShown") as number; }
-	set flutterSurvey2019Q3NotificationLastShown(value: number | undefined) { this.context.globalState.update("flutterSurvey2019Q3NotificationLastShown", value); }
-	get flutterSurvey2019Q3NotificationDoNotShow(): boolean | undefined { return !!this.context.globalState.get("flutterSurvey2019Q3NotificationDoNotShowAgain"); }
-	set flutterSurvey2019Q3NotificationDoNotShow(value: boolean | undefined) { this.context.globalState.update("flutterSurvey2019Q3NotificationDoNotShowAgain", value); }
+	get flutterSurvey2019Q4NotificationLastShown(): number | undefined { return this.context.globalState.get("flutterSurvey2019Q4NotificationLastShown") as number; }
+	set flutterSurvey2019Q4NotificationLastShown(value: number | undefined) { this.context.globalState.update("flutterSurvey2019Q4NotificationLastShown", value); }
+	get flutterSurvey2019Q4NotificationDoNotShow(): boolean | undefined { return !!this.context.globalState.get("flutterSurvey2019Q4NotificationDoNotShowAgain"); }
+	set flutterSurvey2019Q4NotificationDoNotShow(value: boolean | undefined) { this.context.globalState.update("flutterSurvey2019Q4NotificationDoNotShowAgain", value); }
 	get hasWarnedAboutFormatterSyntaxLimitation(): boolean { return !!this.context.globalState.get("hasWarnedAboutFormatterSyntaxLimitation"); }
 	set hasWarnedAboutFormatterSyntaxLimitation(value: boolean) { this.context.globalState.update("hasWarnedAboutFormatterSyntaxLimitation", value); }
 	get lastSeenVersion(): string | undefined { return this.context.globalState.get("lastSeenVersion"); }

--- a/src/test/dart_only/user_prompts.test.ts
+++ b/src/test/dart_only/user_prompts.test.ts
@@ -1,9 +1,9 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
 import * as vs from "vscode";
-import { doNotAskAgainAction, flutterSurveyPromptWithoutAnalytics, longRepeatPromptThreshold, noRepeatPromptThreshold, openDevToolsAction, takeSurveyAction, twoHoursInMs, wantToTryDevToolsPrompt } from "../../shared/constants";
+import { doNotAskAgainAction, flutterSurveyPromptWithoutAnalytics, longRepeatPromptThreshold, noRepeatPromptThreshold, openDevToolsAction, surveyEnd, surveyStart, takeSurveyAction, twoHoursInMs, wantToTryDevToolsPrompt } from "../../shared/constants";
 import { waitFor } from "../../shared/utils/promises";
-import { showDevToolsNotificationIfAppropriate, showFlutterSurveyNotificationIfAppropriate, surveyEnd, surveyStart } from "../../shared/vscode/user_prompts";
+import { showDevToolsNotificationIfAppropriate, showFlutterSurveyNotificationIfAppropriate } from "../../shared/vscode/user_prompts";
 import { activateWithoutAnalysis, clearAllContext, extApi, logger, sb } from "../helpers";
 
 describe("DevTools notification", async () => {
@@ -139,14 +139,14 @@ describe("Survey notification", async () => {
 
 		// Flags were updated.
 		const context = extApi.context;
-		assert.equal(context.flutterSurvey2019Q3NotificationDoNotShow, true);
+		assert.equal(context.flutterSurvey2019Q4NotificationDoNotShow, true);
 		// Marked as shown within the last 10 seconds.
-		assert.equal(context.flutterSurvey2019Q3NotificationLastShown && context.flutterSurvey2019Q3NotificationLastShown > Date.now() - 10000 && context.flutterSurvey2019Q3NotificationLastShown <= Date.now(), true);
+		assert.equal(context.flutterSurvey2019Q4NotificationLastShown && context.flutterSurvey2019Q4NotificationLastShown > Date.now() - 10000 && context.flutterSurvey2019Q4NotificationLastShown <= Date.now(), true);
 	});
 
 	it("shows and updates context values when already seen", async () => {
 		const context = extApi.context;
-		context.flutterSurvey2019Q3NotificationLastShown = surveyIsOpenDate - (longRepeatPromptThreshold + twoHoursInMs);
+		context.flutterSurvey2019Q4NotificationLastShown = surveyIsOpenDate - (longRepeatPromptThreshold + twoHoursInMs);
 
 		const showInformationMessage = sb.stub(vs.window, "showInformationMessage");
 		const openSurveyPrompt = showInformationMessage.withArgs(matchPrompt, sinon.match.any).resolves(takeSurveyAction);
@@ -162,16 +162,16 @@ describe("Survey notification", async () => {
 		assert.equal(res, true);
 
 		// Flags were updated.
-		assert.equal(context.flutterSurvey2019Q3NotificationDoNotShow, true);
+		assert.equal(context.flutterSurvey2019Q4NotificationDoNotShow, true);
 		// Marked as shown within the last 10 seconds.
-		assert.equal(context.flutterSurvey2019Q3NotificationLastShown > Date.now() - 10000 && context.flutterSurvey2019Q3NotificationLastShown <= Date.now(), true);
+		assert.equal(context.flutterSurvey2019Q4NotificationLastShown > Date.now() - 10000 && context.flutterSurvey2019Q4NotificationLastShown <= Date.now(), true);
 	});
 
 	it("does not show if shown in the last 40 hours", async () => {
 		const context = extApi.context;
 		const now = surveyIsOpenDate;
 		const fiveHoursInMs = 1000 * 60 * 60 * 5;
-		context.flutterSurvey2019Q3NotificationLastShown = now - fiveHoursInMs;
+		context.flutterSurvey2019Q4NotificationLastShown = now - fiveHoursInMs;
 
 		const showInformationMessage = sb.stub(vs.window, "showInformationMessage");
 		const openSurveyPrompt = showInformationMessage.withArgs(matchPrompt, sinon.match.any).resolves(takeSurveyAction);
@@ -200,12 +200,12 @@ describe("Survey notification", async () => {
 		assert.equal(res, true);
 
 		// Flag was written.
-		await waitFor(() => extApi.context.flutterSurvey2019Q3NotificationDoNotShow);
-		assert.equal(extApi.context.flutterSurvey2019Q3NotificationDoNotShow, true);
+		await waitFor(() => extApi.context.flutterSurvey2019Q4NotificationDoNotShow);
+		assert.equal(extApi.context.flutterSurvey2019Q4NotificationDoNotShow, true);
 	});
 
 	it("does not prompt if told not to ask again", async () => {
-		extApi.context.flutterSurvey2019Q3NotificationDoNotShow = true;
+		extApi.context.flutterSurvey2019Q4NotificationDoNotShow = true;
 
 		const showInformationMessage = sb.stub(vs.window, "showInformationMessage");
 		const openSurveyPrompt = showInformationMessage.withArgs(matchPrompt, sinon.match.any).resolves(doNotAskAgainAction);

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -867,8 +867,8 @@ export async function addLaunchConfigsForTest(workspaceUri: vs.Uri, configs: any
 export function clearAllContext(context: Context): Promise<void> {
 	context.devToolsNotificationLastShown = undefined;
 	context.devToolsNotificationDoNotShow = undefined;
-	context.flutterSurvey2019Q3NotificationLastShown = undefined;
-	context.flutterSurvey2019Q3NotificationDoNotShow = undefined;
+	context.flutterSurvey2019Q4NotificationLastShown = undefined;
+	context.flutterSurvey2019Q4NotificationDoNotShow = undefined;
 
 	// HACK Updating context is async, but since we use setters we can't easily wait
 	// and this is only test code...


### PR DESCRIPTION
@pq @jayoung-lee for sanity checking.. Here's screenshots of the prompt with/without analytics, and also the URL we're opening when clicking.

As always, JavaScript dates have 0-based months (!) and are in UTC, so I included the time for America/LA in comments above it from evaluating in Chrome.

I've put 23rd for now to match IntelliJ, though we discussed making this 22nd.. I'll update this if you can confirm the preferred date/time.

<img width="514" alt="Screenshot 2019-10-30 at 2 44 18 pm" src="https://user-images.githubusercontent.com/1078012/67868619-2171a080-fb24-11e9-8566-b3f498cc09ee.png">

<img width="530" alt="Screenshot 2019-10-30 at 2 44 44 pm" src="https://user-images.githubusercontent.com/1078012/67868632-25052780-fb24-11e9-85ae-3a01507a9d78.png">

![Screenshot 2019-10-30 at 2 45 02 pm](https://user-images.githubusercontent.com/1078012/67868695-36e6ca80-fb24-11e9-8c88-625971942a64.png)
