### PR TITLE
Change error reporting to just "Show Log"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1139,10 +1139,10 @@
 					"description": "When to automatically switch focus to the test list (array to support multiple values).",
 					"scope": "window"
 				},
-				"dart.reportAnalyzerErrors": {
+				"dart.notifyAnalyzerErrors": {
 					"type": "boolean",
 					"default": true,
-					"description": "Whether to offer to report analysis server exceptions when they occur.",
+					"description": "Whether to show a notification the first few times an analysis server exception occurs.",
 					"scope": "window"
 				},
 				"dart.allowAnalytics": {

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -87,7 +87,7 @@ class Config {
 	get previewNewCompletionPlaceholders(): boolean { return this.getConfig<boolean>("previewNewCompletionPlaceholders", false); }
 	get previewToStringInDebugViews(): boolean { return this.getConfig<boolean>("previewToStringInDebugViews", false); }
 	get promptToRunIfErrors(): boolean { return this.getConfig<boolean>("promptToRunIfErrors", true); }
-	get reportAnalyzerErrors(): boolean { return this.getConfig<boolean>("reportAnalyzerErrors", true); }
+	get notifyAnalyzerErrors(): boolean { return this.getConfig<boolean>("notifyAnalyzerErrors", true); }
 	get sdkPath(): undefined | string { return resolvePaths(this.getConfig<null | string>("sdkPath", null)); }
 	get sdkPaths(): string[] { return this.getConfig<string[]>("sdkPaths", []).map(resolvePaths); }
 	get showIgnoreQuickFixes(): boolean { return this.getConfig<boolean>("showIgnoreQuickFixes", false); }


### PR DESCRIPTION
@devoncarew @bwilkerson This changes the "generate error report" notifications to just "show log" and removes the header about raising on GitHub. It will still only show a maximum of 3 times per-session (and VS Code will "overwrite" notifications if there's already one visible and we send another with the same message to avoid ever seeing more than one on screen).

![Screenshot 2019-12-09 at 6 00 19 pm](https://user-images.githubusercontent.com/1078012/70460556-866acf80-1aae-11ea-9e6b-78debde3c374.png)

![Screenshot 2019-12-09 at 6 00 46 pm](https://user-images.githubusercontent.com/1078012/70460560-89fe5680-1aae-11ea-9d60-cbe6bdfa9892.png)

We do also already have code to detect if the server terminates and show a notification (with Show Log and Restart Analyzer buttons).