### PR TITLE
[experimental] Semantic token highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
 	"version": "3.8.0-dev",
 	"publisher": "Dart-Code",
 	"engines": {
-		"vscode": "^1.40.0"
+		"vscode": "^1.41.0"
 	},
+	"enableProposedApi": true,
 	"extensionKind": [
 		"workspace"
 	],
@@ -61,8 +62,9 @@
 				"configuration": "./syntaxes/dart-language-configuration.json"
 			}
 		],
-		"grammars": [
+		"$commented_out$grammars": [
 			{
+				"$reason": "Temporariliy commented out so that server highlights are more obvious. Undo before merge",
 				"language": "dart",
 				"scopeName": "source.dart",
 				"path": "./syntaxes/dart.json"
@@ -981,6 +983,12 @@
 					"type": "boolean",
 					"default": true,
 					"description": "Whether to use folding data from the Dart analysis server instead of the built-in VS Code indent-based folding.",
+					"scope": "window"
+				},
+				"dart.analysisServerHighlighting": {
+					"type": "boolean",
+					"default": false,
+					"description": "(Experimental) Whether to use syntax highlighting data form the Dart analysis server in addition to the built-in grammar.",
 					"scope": "window"
 				},
 				"dart.analysisExcludedFolders": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"version": "3.8.0-dev",
 	"publisher": "Dart-Code",
 	"engines": {
-		"vscode": "^1.41.0"
+		"vscode": "^1.42.0"
 	},
 	"enableProposedApi": true,
 	"extensionKind": [

--- a/src/extension/analysis/analyzer.ts
+++ b/src/extension/analysis/analyzer.ts
@@ -46,6 +46,10 @@ function buildAnalyzerArgs(analyzerPath: string, dartCapabilities: DartCapabilit
 	if (config.analyzerInstrumentationLogFile)
 		analyzerArgs.push(`--instrumentation-log-file=${config.analyzerInstrumentationLogFile}`);
 
+	// Enable more detailed highlighting when enabled
+	if (config.analysisServerHighlighting)
+		analyzerArgs.push(`--useAnalysisHighlight2`);
+
 	// Allow arbitrary args to be passed to the analysis server.
 	if (config.analyzerAdditionalArgs)
 		analyzerArgs = analyzerArgs.concat(config.analyzerAdditionalArgs);

--- a/src/extension/analysis/open_file_tracker.ts
+++ b/src/extension/analysis/open_file_tracker.ts
@@ -15,7 +15,7 @@ export class DasFileTracker implements IAmDisposable {
 	private readonly flutterOutlines: { [key: string]: FlutterOutline } = {};
 	private readonly occurrences: { [key: string]: Occurrences[] } = {};
 	private readonly folding: { [key: string]: FoldingRegion[] } = {};
-	private readonly highlights: {[key: string]: HighlightRegion[]} = {};
+	private readonly highlights: {[key: string]: HighlightRegion[] } = {};
 	private readonly pubRunTestSupport: { [key: string]: boolean } = {};
 	private lastPriorityFiles: string[] = [];
 	private lastSubscribedFiles: string[] = [];

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -41,6 +41,7 @@ class Config {
 	get additionalAnalyzerFileExtensions(): string[] { return this.getConfig<string[]>("additionalAnalyzerFileExtensions", []); }
 	get allowAnalytics(): boolean { return this.getConfig<boolean>("allowAnalytics", true); }
 	get analysisServerFolding(): boolean { return this.getConfig<boolean>("analysisServerFolding", true); }
+	get analysisServerHighlighting(): boolean { return this.getConfig<boolean>("analysisServerHighlighting", false); }
 	get analyzeAngularTemplates(): boolean { return this.getConfig<boolean>("analyzeAngularTemplates", true); }
 	get analyzerAdditionalArgs(): string[] { return this.getConfig<string[]>("analyzerAdditionalArgs", []); }
 	get analyzerDiagnosticsPort(): undefined | number { return this.getConfig<null | number>("analyzerDiagnosticsPort", null); }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -238,7 +238,7 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 		formattingEditProvider.registerDocumentFormatter(activeFileFilters);
 
 		if (config.analysisServerHighlighting) {
-			context.subscriptions.push(vs.languages.registerSemanticTokensProvider(activeFileFilters, new AnalysisTokensProvider(dasAnalyzer), dasTokenLegend));
+			vs.languages.registerDocumentSemanticTokensProvider(activeFileFilters, new AnalysisTokensProvider(dasAnalyzer), dasTokenLegend);
 		}
 
 		// Only for Dart.

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -46,6 +46,7 @@ import { setUpDaemonMessageHandler } from "./flutter/daemon_message_handler";
 import { FlutterDaemon } from "./flutter/flutter_daemon";
 import { FlutterOutlineProvider } from "./flutter/flutter_outline_view";
 import { HotReloadOnSaveHandler } from "./flutter/hot_reload_save_handler";
+import { AnalysisTokensProvider, dasTokenLegend } from "./providers/analysis_tokens_provider";
 import { AssistCodeActionProvider } from "./providers/assist_code_action_provider";
 import { DartCompletionItemProvider } from "./providers/dart_completion_item_provider";
 import { DartDiagnosticProvider } from "./providers/dart_diagnostic_provider";
@@ -235,6 +236,11 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 		const formattingEditProvider = new DartFormattingEditProvider(logger, dasClient, extContext);
 		context.subscriptions.push(formattingEditProvider);
 		formattingEditProvider.registerDocumentFormatter(activeFileFilters);
+
+		if (config.analysisServerHighlighting) {
+			context.subscriptions.push(vs.languages.registerSemanticTokensProvider(activeFileFilters, new AnalysisTokensProvider(dasAnalyzer), dasTokenLegend));
+		}
+
 		// Only for Dart.
 		formattingEditProvider.registerTypingFormatter(DART_MODE, "}", ";");
 	}

--- a/src/extension/providers/analysis_tokens_provider.ts
+++ b/src/extension/providers/analysis_tokens_provider.ts
@@ -56,6 +56,10 @@ export class AnalysisTokensProvider implements SemanticTokensProvider {
 				return Type.enum;
 			case "TYPE_PARAMETER":
 				return Type.parameterType;
+			case "INSTANCE_METHOD_DECLARATION":
+			case "INSTANCE_METHOD_REFERENCE":
+			case "STATIC_METHOD_DECLARATION":
+			case "STATIC_METHOD_REFERENCE":
 			case "TOP_LEVEL_FUNCTION_DECLARATION":
 			case "TOP_LEVEL_FUNCTION_REFERENCE":
 			case "LOCAL_FUNCTION_DECLARATION":

--- a/src/extension/providers/analysis_tokens_provider.ts
+++ b/src/extension/providers/analysis_tokens_provider.ts
@@ -1,0 +1,200 @@
+import { CancellationToken, SemanticTokens, SemanticTokensBuilder, SemanticTokensLegend, SemanticTokensProvider, SemanticTokensRequestOptions, TextDocument } from "vscode";
+import { HighlightRegion, HighlightRegionType } from "../../shared/analysis_server_types";
+import { DasAnalyzer } from "../analysis/analyzer_das";
+
+const emptyBuffer = new Uint32Array();
+
+export class AnalysisTokensProvider implements SemanticTokensProvider {
+
+	constructor(private readonly analyzer: DasAnalyzer) { }
+
+	public async provideSemanticTokens(document: TextDocument, options: SemanticTokensRequestOptions, token: CancellationToken): Promise<SemanticTokens> {
+		let dasHightlights: HighlightRegion[] | undefined;
+
+		for (let i = 0; i < 5; i++) {
+			dasHightlights = this.analyzer.fileTracker.getHighlightsFor(document.uri);
+			if (dasHightlights) break;
+
+			await new Promise((resolve) => setTimeout(resolve, (i + 1) * 1000).unref());
+			if (token?.isCancellationRequested ?? false) break;
+		}
+
+		if (!dasHightlights) {
+			// no data available, so don't report any tokens
+			return new SemanticTokens(emptyBuffer);
+		}
+
+		// tokens must be sorted because VS Code encodes positions with deltas
+		dasHightlights.sort((a, b) => a.offset - b.offset);
+
+		const builder = new SemanticTokensBuilder();
+		dasHightlights.forEach((token) => {
+			const type = this.mappedType(token.type);
+			if (type === undefined) return;
+
+			const location = document.positionAt(token.offset);
+			builder.push(location.line, location.character, token.length, type, 0);
+		});
+
+		return new SemanticTokens(builder.build());
+	}
+
+	private mappedType(regionType: HighlightRegionType): number| undefined {
+		// mapping oriented on how the IntelliJ plugins handles highlighting:
+		// https://github.com/JetBrains/intellij-plugins/blob/e280cb041505b0fb706d1ce852e3c1f38ffdf896/Dart/src/com/jetbrains/lang/dart/ide/annotator/DartAnnotator.java#L48-L143
+		switch (regionType) {
+			case "ANNOTATION":
+				return Type.annotation;
+			case "BUILT_IN":
+			case "KEYWORD":
+			case "LITERAL_BOOLEAN":
+			case "TYPE_NAME_DYNAMIC":
+				return Type.keyword;
+			case "CLASS":
+				return Type.class;
+			case "ENUM":
+				return Type.enum;
+			case "TYPE_PARAMETER":
+				return Type.parameterType;
+			case "TOP_LEVEL_FUNCTION_DECLARATION":
+			case "TOP_LEVEL_FUNCTION_REFERENCE":
+			case "LOCAL_FUNCTION_DECLARATION":
+			case "LOCAL_FUNCTION_REFERENCE":
+				return Type.function;
+			case "DYNAMIC_PARAMETER_DECLARATION":
+			case "DYNAMIC_PARAMETER_REFERENCE":
+			case "PARAMETER_DECLARATION":
+			case "PARAMETER_REFERENCE":
+				return Type.parameter;
+			case "COMMENT_BLOCK":
+			case "COMMENT_END_OF_LINE":
+			case "COMMENT_DOCUMENTATION":
+				return Type.comment;
+			case "DYNAMIC_TYPE":
+			case "FUNCTION_TYPE_ALIAS":
+				return Type.type;
+			case "STATIC_FIELD_DECLARATION":
+			case "STATIC_SETTER_DECLARATION":
+			case "STATIC_SETTER_REFERENCE":
+			case "STATIC_GETTER_DECLARATION":
+			case "STATIC_GETTER_REFERENCE":
+			case "INSTANCE_FIELD_DECLARATION":
+			case "INSTANCE_FIELD_REFERENCE":
+			case "INSTANCE_GETTER_DECLARATION":
+			case "INSTANCE_SETTER_REFERENCE":
+			case "TOP_LEVEL_GETTER_DECLARATION":
+			case "TOP_LEVEL_GETTER_REFERENCE":
+			case "TOP_LEVEL_SETTER_DECLARATION":
+			case "TOP_LEVEL_SETTER_REFERENCE":
+			case "ENUM_CONSTANT":
+				return Type.property;
+			case "TOP_LEVEL_VARIABLE_DECLARATION":
+			case "LOCAL_VARIABLE_DECLARATION":
+			case "LOCAL_VARIABLE_REFERENCE":
+			case "DYNAMIC_LOCAL_VARIABLE_DECLARATION":
+			case "DYNAMIC_LOCAL_VARIABLE_REFERENCE":
+				return Type.variable;
+			case "LABEL":
+				return Type.label;
+			case "LIBRARY_NAME":
+				return Type.namespace;
+			case "LITERAL_DOUBLE":
+			case "LITERAL_INTEGER":
+				return Type.number;
+			case "LITERAL_STRING":
+				return Type.string;
+		}
+	}
+
+	private modifierBitmask(regionType: HighlightRegionType): number {
+		// tslint:disable: no-bitwise
+		let modifier = 0;
+		if (AnalysisTokensProvider.staticRegionTypes.has(regionType)) {
+			modifier |= 1 << Modifier.static;
+		}
+		if (AnalysisTokensProvider.declarationRegionTypes.has(regionType)) {
+			modifier |= 1 << Modifier.declaration;
+		}
+		if (regionType === "COMMENT_DOCUMENTATION") {
+			modifier |= 1 << Modifier.documentationComment;
+		}
+		// tslint:enable: no-bitwise
+		return modifier;
+	}
+
+	private static staticRegionTypes: Set<HighlightRegionType> = new Set([
+		"STATIC_GETTER_DECLARATION",
+		"STATIC_SETTER_DECLARATION",
+		"STATIC_FIELD_DECLARATION",
+		"STATIC_METHOD_DECLARATION",
+		"STATIC_GETTER_REFERENCE",
+		"STATIC_SETTER_REFERENCE",
+		"ENUM_CONSTANT",
+	]);
+
+	private static declarationRegionTypes: Set<HighlightRegionType> = new Set([
+		"INSTANCE_FIELD_DECLARATION",
+		"INSTANCE_GETTER_DECLARATION",
+		"INSTANCE_METHOD_DECLARATION",
+		"INSTANCE_SETTER_DECLARATION",
+		"STATIC_FIELD_DECLARATION",
+		"STATIC_GETTER_DECLARATION",
+		"STATIC_METHOD_DECLARATION",
+		"TOP_LEVEL_FUNCTION_DECLARATION",
+		"TOP_LEVEL_VARIABLE_DECLARATION",
+		"TOP_LEVEL_SETTER_DECLARATION",
+		"TOP_LEVEL_GETTER_DECLARATION",
+		"STATIC_METHOD_DECLARATION",
+		"TOP_LEVEL_FUNCTION_DECLARATION",
+		"DYNAMIC_LOCAL_VARIABLE_DECLARATION",
+		"DYNAMIC_PARAMETER_DECLARATION",
+		"PARAMETER_DECLARATION",
+		"LOCAL_FUNCTION_DECLARATION",
+		"LOCAL_VARIABLE_DECLARATION",
+	]);
+}
+
+enum Modifier {
+	// these are standardized by VS Code
+	abstract,
+	async,
+	declaration,
+	deprecated,
+	documentation,
+	member,
+	modification,
+	static,
+	// Dart-specific additions.
+	documentationComment,
+}
+
+enum Type {
+	// these are standardized by VS Code
+	comment,
+	string,
+	keyword,
+	number,
+	regexp,
+	operator,
+	namespace,
+	type,
+	struct,
+	class,
+	interface,
+	enum,
+	parameterType,
+	function,
+	macro,
+	variable,
+	constant,
+	parameter,
+	property,
+	label,
+	// Dart-specific additions
+	annotation,
+}
+
+export const dasTokenLegend: SemanticTokensLegend = {
+	tokenModifiers: Object.keys(Modifier).filter((k) => typeof Modifier[k as any] === "number"),
+	tokenTypes: Object.keys(Type).filter((k) => typeof Type[k as any] === "number"),
+};

--- a/src/extension/providers/analysis_tokens_provider.ts
+++ b/src/extension/providers/analysis_tokens_provider.ts
@@ -1,15 +1,15 @@
-import { CancellationToken, SemanticTokens, SemanticTokensBuilder, SemanticTokensLegend, SemanticTokensProvider, SemanticTokensRequestOptions, TextDocument, TextLine } from "vscode";
+import { CancellationToken, DocumentSemanticTokensProvider, SemanticTokens, SemanticTokensBuilder, SemanticTokensLegend, TextDocument, TextLine } from "vscode";
 import { HighlightRegionType } from "../../shared/analysis_server_types";
 import { MappedRegion, removeOverlappings } from "../../shared/utils/region_split";
 import { DasAnalyzer } from "../analysis/analyzer_das";
 
 const emptyBuffer = new Uint32Array();
 
-export class AnalysisTokensProvider implements SemanticTokensProvider {
+export class AnalysisTokensProvider implements DocumentSemanticTokensProvider {
 
 	constructor(private readonly analyzer: DasAnalyzer) { }
 
-	public async provideSemanticTokens(document: TextDocument, options: SemanticTokensRequestOptions, token: CancellationToken): Promise<SemanticTokens> {
+	public async provideDocumentSemanticTokens(document: TextDocument, token: CancellationToken): Promise<SemanticTokens> {
 		const dasHightlights = await this.analyzer.fileTracker.awaitHighlights(document.uri, token);
 
 		if (!dasHightlights) {

--- a/src/extension/providers/analysis_tokens_provider.ts
+++ b/src/extension/providers/analysis_tokens_provider.ts
@@ -40,7 +40,7 @@ export class AnalysisTokensProvider implements SemanticTokensProvider {
 	}
 
 	private mappedType(regionType: HighlightRegionType): number| undefined {
-		// mapping oriented on how the IntelliJ plugins handles highlighting:
+		// mapping oriented on how the IntelliJ plugin handles highlighting:
 		// https://github.com/JetBrains/intellij-plugins/blob/e280cb041505b0fb706d1ce852e3c1f38ffdf896/Dart/src/com/jetbrains/lang/dart/ide/annotator/DartAnnotator.java#L48-L143
 		switch (regionType) {
 			case "ANNOTATION":
@@ -60,6 +60,7 @@ export class AnalysisTokensProvider implements SemanticTokensProvider {
 			case "TOP_LEVEL_FUNCTION_REFERENCE":
 			case "LOCAL_FUNCTION_DECLARATION":
 			case "LOCAL_FUNCTION_REFERENCE":
+			case "CONSTRUCTOR":
 				return Type.function;
 			case "DYNAMIC_PARAMETER_DECLARATION":
 			case "DYNAMIC_PARAMETER_REFERENCE":

--- a/src/extension/providers/analysis_tokens_provider.ts
+++ b/src/extension/providers/analysis_tokens_provider.ts
@@ -33,7 +33,7 @@ export class AnalysisTokensProvider implements SemanticTokensProvider {
 			if (type === undefined) return;
 
 			const location = document.positionAt(token.offset);
-			builder.push(location.line, location.character, token.length, type, 0);
+			builder.push(location.line, location.character, token.length, type, this.modifierBitmask(token.type));
 		});
 
 		return new SemanticTokens(builder.build());

--- a/src/extension/utils/vscode/events.ts
+++ b/src/extension/utils/vscode/events.ts
@@ -1,0 +1,25 @@
+import { Disposable, Event } from "vscode";
+
+/**
+ * Listens for two events and returns a promise resolving when the first event completes.
+ *
+ * @param a the first event to subscribe to
+ * @param b the second event to subscribe to
+ */
+export function firstOf<T1, T2>(a: Event<T1>, b: Event<T2>): Promise<T1 | T2> {
+	return new Promise((resolve) => {
+		let completed = false;
+		const disposables = Array<Disposable>();
+
+		function complete(value: T1 | T2) {
+			if (completed) return;
+			completed = true;
+
+			disposables.forEach((d) => d.dispose());
+			resolve(value);
+		}
+
+		a(complete, disposables);
+		b(complete, disposables);
+	});
+}

--- a/src/shared/utils/region_split.ts
+++ b/src/shared/utils/region_split.ts
@@ -19,12 +19,14 @@ export class MappedRegion {
 }
 
 /**
- * Transform regions so that there are no overlappings between them. Regions with a higher start
- * offset overidde previous regions.
+ * Transform regions so that there are no two regions that overlap each other. For this purpose,
+ * regions with a higher start offset take priority over regions with a lower start offset.
  *
- * Some examples (numbers indicate region type, dashes indicate offsets):
- *
- *  * 00000 and --1-- would be tranformed to 00100
+ * For instance, let's say we had a string literal token `'hello\nworld'` with a start offset
+ * of 0 and a length of 16. We also have a valid string escape token from offset 7 and a length
+ * of 2. To remove overlapping regions, we would transform this into three tokens: A string literal
+ * `'hello` from 0..6 (inclusive). Next, we'd emit the string escape token unchanged (7..8) followed
+ * by the string literal `world'` from 9..16.
  *
  * The output will also be sorted by start offsets.
  *

--- a/src/shared/utils/region_split.ts
+++ b/src/shared/utils/region_split.ts
@@ -1,0 +1,94 @@
+import { sortBy } from "./array";
+
+export class MappedRegion {
+
+	constructor(
+		readonly offset: number,
+		readonly length: number,
+		readonly tokenType: number,
+		readonly tokenModifier: number = 0,
+	) { }
+
+	get endOffset(): number {
+		return this.offset + this.length;
+	}
+
+	public copyWithRange(start: number, endExclusive: number) {
+		return new MappedRegion(start, endExclusive - start, this.tokenType, this.tokenModifier);
+	}
+}
+
+/**
+ * Transform regions so that there are no overlappings between them. Regions with a higher start
+ * offset overidde previous regions.
+ *
+ * Some examples (numbers indicate region type, dashes indicate offsets):
+ *
+ *  * 00000 and --1-- would be tranformed to 00100
+ *
+ * The output will also be sorted by start offsets.
+ *
+ * @param regions array of regions where the overlappings should be removed
+ */
+export function removeOverlappings(regions: MappedRegion[]): MappedRegion[] {
+	if (regions.length === 0) return [];
+
+	sortBy(regions, (r) => r.offset);
+	const output = Array<MappedRegion>();
+
+	// current region we might have to split when an overlapping occurs.
+	let currentStart = regions[0].offset;
+	let currentEnd = currentStart + regions[0].length;
+	let currentTargets = [regions[0]];
+
+	regions.splice(0, 1);
+	regions.forEach((region) => {
+		const start = region.offset;
+		const end = region.endOffset;
+
+		if (start < currentEnd) {
+			// we know start >= currentStart, since they're sorted. This is an overlap!
+			let target = currentTargets[0];
+			// find the first region in currentTarget that overlaps with the current
+			while (target.endOffset <= region.offset) {
+				// target is unaffected. Sorting guarantees there won't be any other regions
+				// overlapping with it.
+				output.push(target);
+				currentTargets.splice(0, 1);
+				currentStart = target.endOffset;
+
+				target = currentTargets[0];
+			}
+
+			// replace target with splitted subregions
+			currentTargets.splice(0, 1, ...splitSingle(target, region));
+		} else {
+			// region appears after what we're currently interested in. Since the list is
+			// sorted by start offset, this means that there can't be more overlappings in
+			// currentStart..currentEnd.
+			output.push(...currentTargets);
+			currentTargets = [region];
+			currentStart = start;
+			currentEnd = end;
+		}
+	});
+
+	// add remaining
+	output.push(...currentTargets);
+
+	return output;
+}
+
+function splitSingle(target: MappedRegion, overlap: MappedRegion): MappedRegion[] {
+	const output = Array<MappedRegion>();
+	if (target.offset !== overlap.offset) {
+		// some region of target comes before the overlap starts
+		output.push(target.copyWithRange(target.offset, overlap.offset));
+	}
+	output.push(overlap);
+	if (target.endOffset > overlap.endOffset) {
+		// more of target after overlap ended
+		output.push(target.copyWithRange(overlap.endOffset, target.endOffset));
+	}
+	return output;
+}

--- a/src/test/utils/region_split_test.ts
+++ b/src/test/utils/region_split_test.ts
@@ -1,0 +1,27 @@
+import { MappedRegion, removeOverlappings } from "../../shared/utils/region_split";
+import assert = require("assert");
+
+describe("removeOverlappings", () => {
+	it("splits nested tokens", () => {
+		const input: MappedRegion[] = [
+			new MappedRegion(0, 5, 0), // 00000
+			new MappedRegion(2, 2, 1), // --11-
+		];
+		// should be flattened to 00110
+		assert.equal(removeOverlappings(input), [
+			new MappedRegion(0, 2, 0), // 00---
+			new MappedRegion(2, 2, 1), // --11-
+			new MappedRegion(4, 1, 0), // ----0
+		]);
+	});
+
+	it("doesn't change anything when regions don't overlap", () => {
+		const input: MappedRegion[] = [
+			new MappedRegion(0, 5, 0),
+			new MappedRegion(5, 2, 1),
+			new MappedRegion(7, 3, 2),
+			new MappedRegion(10, 5, 3),
+		];
+		assert.equal(removeOverlappings(input), input);
+	});
+});

--- a/tslint.json
+++ b/tslint.json
@@ -27,6 +27,7 @@
 			"options": "allow-empty-catch"
 		},
 		"space-before-function-paren": false,
+		"no-duplicate-switch-case": true,
 		// TODO: These don't seem to work?
 		// "no-unused-expression": true,
 		// "no-floating-promises": true,

--- a/vscode.proposed.d.ts
+++ b/vscode.proposed.d.ts
@@ -1,0 +1,234 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * This is the place for API experiments and proposals.
+ * These API are NOT stable and subject to change. They are only available in the Insiders
+ * distribution and CANNOT be used in published extensions.
+ *
+ * To test these API in local environment:
+ * - Use Insiders release of VS Code.
+ * - Add `"enableProposedApi": true` to your package.json.
+ * - Copy this file to your project.
+ */
+
+declare module 'vscode' {
+
+	//#region Semantic tokens: https://github.com/microsoft/vscode/issues/86415
+
+	export class SemanticTokensLegend {
+		public readonly tokenTypes: string[];
+		public readonly tokenModifiers: string[];
+
+		constructor(tokenTypes: string[], tokenModifiers: string[]);
+	}
+
+	export class SemanticTokensBuilder {
+		constructor();
+		push(line: number, char: number, length: number, tokenType: number, tokenModifiers: number): void;
+		build(): Uint32Array;
+	}
+
+	export class SemanticTokens {
+		/**
+		 * The result id of the tokens.
+		 *
+		 * On a next call to `provideSemanticTokens`, if VS Code still holds in memory this result,
+		 * the result id will be passed in as `SemanticTokensRequestOptions.previousResultId`.
+		 */
+		readonly resultId?: string;
+		readonly data: Uint32Array;
+
+		constructor(data: Uint32Array, resultId?: string);
+	}
+
+	export class SemanticTokensEdits {
+		/**
+		 * The result id of the tokens.
+		 *
+		 * On a next call to `provideSemanticTokens`, if VS Code still holds in memory this result,
+		 * the result id will be passed in as `SemanticTokensRequestOptions.previousResultId`.
+		 */
+		readonly resultId?: string;
+		readonly edits: SemanticTokensEdit[];
+
+		constructor(edits: SemanticTokensEdit[], resultId?: string);
+	}
+
+	export class SemanticTokensEdit {
+		readonly start: number;
+		readonly deleteCount: number;
+		readonly data?: Uint32Array;
+
+		constructor(start: number, deleteCount: number, data?: Uint32Array);
+	}
+
+	export interface SemanticTokensRequestOptions {
+		readonly ranges?: readonly Range[];
+		/**
+		 * The previous result id that the editor still holds in memory.
+		 *
+		 * Only when this is set it is safe for a `SemanticTokensProvider` to return `SemanticTokensEdits`.
+		 */
+		readonly previousResultId?: string;
+	}
+
+	/**
+	 * The semantic tokens provider interface defines the contract between extensions and
+	 * semantic tokens.
+	 */
+	export interface SemanticTokensProvider {
+		/**
+		 * A file can contain many tokens, perhaps even hundreds of thousands of tokens. Therefore, to improve
+		 * the memory consumption around describing semantic tokens, we have decided to avoid allocating an object
+		 * for each token and we represent tokens from a file as an array of integers. Furthermore, the position
+		 * of each token is expressed relative to the token before it because most tokens remain stable relative to
+		 * each other when edits are made in a file.
+		 *
+		 *
+		 * ---
+		 * In short, each token takes 5 integers to represent, so a specific token `i` in the file consists of the following fields:
+		 *  - at index `5*i`   - `deltaLine`: token line number, relative to the previous token
+		 *  - at index `5*i+1` - `deltaStart`: token start character, relative to the previous token (relative to 0 or the previous token's start if they are on the same line)
+		 *  - at index `5*i+2` - `length`: the length of the token. A token cannot be multiline.
+		 *  - at index `5*i+3` - `tokenType`: will be looked up in `SemanticTokensLegend.tokenTypes`
+		 *  - at index `5*i+4` - `tokenModifiers`: each set bit will be looked up in `SemanticTokensLegend.tokenModifiers`
+		 *
+		 *
+		 *
+		 * ---
+		 * ### How to encode tokens
+		 *
+		 * Here is an example for encoding a file with 3 tokens:
+		 * ```
+		 *    { line: 2, startChar:  5, length: 3, tokenType: "properties", tokenModifiers: ["private", "static"] },
+		 *    { line: 2, startChar: 10, length: 4, tokenType: "types",      tokenModifiers: [] },
+		 *    { line: 5, startChar:  2, length: 7, tokenType: "classes",    tokenModifiers: [] }
+		 * ```
+		 *
+		 * 1. First of all, a legend must be devised. This legend must be provided up-front and capture all possible token types.
+		 * For this example, we will choose the following legend which must be passed in when registering the provider:
+		 * ```
+		 *    tokenTypes: ['properties', 'types', 'classes'],
+		 *    tokenModifiers: ['private', 'static']
+		 * ```
+		 *
+		 * 2. The first transformation step is to encode `tokenType` and `tokenModifiers` as integers using the legend. Token types are looked
+		 * up by index, so a `tokenType` value of `1` means `tokenTypes[1]`. Multiple token modifiers can be set by using bit flags,
+		 * so a `tokenModifier` value of `3` is first viewed as binary `0b00000011`, which means `[tokenModifiers[0], tokenModifiers[1]]` because
+		 * bits 0 and 1 are set. Using this legend, the tokens now are:
+		 * ```
+		 *    { line: 2, startChar:  5, length: 3, tokenType: 0, tokenModifiers: 3 },
+		 *    { line: 2, startChar: 10, length: 4, tokenType: 1, tokenModifiers: 0 },
+		 *    { line: 5, startChar:  2, length: 7, tokenType: 2, tokenModifiers: 0 }
+		 * ```
+		 *
+		 * 3. The next steps is to encode each token relative to the previous token in the file. In this case, the second token
+		 * is on the same line as the first token, so the `startChar` of the second token is made relative to the `startChar`
+		 * of the first token, so it will be `10 - 5`. The third token is on a different line than the second token, so the
+		 * `startChar` of the third token will not be altered:
+		 * ```
+		 *    { deltaLine: 2, deltaStartChar: 5, length: 3, tokenType: 0, tokenModifiers: 3 },
+		 *    { deltaLine: 0, deltaStartChar: 5, length: 4, tokenType: 1, tokenModifiers: 0 },
+		 *    { deltaLine: 3, deltaStartChar: 2, length: 7, tokenType: 2, tokenModifiers: 0 }
+		 * ```
+		 *
+		 * 4. Finally, the last step is to inline each of the 5 fields for a token in a single array, which is a memory friendly representation:
+		 * ```
+		 *    // 1st token,  2nd token,  3rd token
+		 *    [  2,5,3,0,3,  0,5,4,1,0,  3,2,7,2,0 ]
+		 * ```
+		 *
+		 *
+		 *
+		 * ---
+		 * ### How tokens change when the document changes
+		 *
+		 * Let's look at how tokens might change.
+		 *
+		 * Continuing with the above example, suppose a new line was inserted at the top of the file.
+		 * That would make all the tokens move down by one line (notice how the line has changed for each one):
+		 * ```
+		 *    { line: 3, startChar:  5, length: 3, tokenType: "properties", tokenModifiers: ["private", "static"] },
+		 *    { line: 3, startChar: 10, length: 4, tokenType: "types",      tokenModifiers: [] },
+		 *    { line: 6, startChar:  2, length: 7, tokenType: "classes",    tokenModifiers: [] }
+		 * ```
+		 * The integer encoding of the tokens does not change substantially because of the delta-encoding of positions:
+		 * ```
+		 *    // 1st token,  2nd token,  3rd token
+		 *    [  3,5,3,0,3,  0,5,4,1,0,  3,2,7,2,0 ]
+		 * ```
+		 * It is possible to express these new tokens in terms of an edit applied to the previous tokens:
+		 * ```
+		 *    [  2,5,3,0,3,  0,5,4,1,0,  3,2,7,2,0 ]
+		 *    [  3,5,3,0,3,  0,5,4,1,0,  3,2,7,2,0 ]
+		 *
+		 *    edit: { start:  0, deleteCount: 1, data: [3] } // replace integer at offset 0 with 3
+		 * ```
+		 *
+		 * Furthermore, let's assume that a new token has appeared on line 4:
+		 * ```
+		 *    { line: 3, startChar:  5, length: 3, tokenType: "properties", tokenModifiers: ["private", "static"] },
+		 *    { line: 3, startChar: 10, length: 4, tokenType: "types",      tokenModifiers: [] },
+		 *    { line: 4, startChar:  3, length: 5, tokenType: "properties", tokenModifiers: ["static"] },
+		 *    { line: 6, startChar:  2, length: 7, tokenType: "classes",    tokenModifiers: [] }
+		 * ```
+		 * The integer encoding of the tokens is:
+		 * ```
+		 *    // 1st token,  2nd token,  3rd token,  4th token
+		 *    [  3,5,3,0,3,  0,5,4,1,0,  1,3,5,0,2,  2,2,7,2,0, ]
+		 * ```
+		 * Again, it is possible to express these new tokens in terms of an edit applied to the previous tokens:
+		 * ```
+		 *    [  3,5,3,0,3,  0,5,4,1,0,  3,2,7,2,0 ]
+		 *    [  3,5,3,0,3,  0,5,4,1,0,  1,3,5,0,2,  2,2,7,2,0, ]
+		 *
+		 *    edit: { start: 10, deleteCount: 1, data: [1,3,5,0,2,2] } // replace integer at offset 10 with [1,3,5,0,2,2]
+		 * ```
+		 *
+		 *
+		 *
+		 * ---
+		 * ### When to return `SemanticTokensEdits`
+		 *
+		 * When doing edits, it is possible that multiple edits occur until VS Code decides to invoke the semantic tokens provider.
+		 * In principle, each call to `provideSemanticTokens` can return a full representations of the semantic tokens, and that would
+		 * be a perfectly reasonable semantic tokens provider implementation.
+		 *
+		 * However, when having a language server running in a separate process, transferring all the tokens between processes
+		 * might be slow, so VS Code allows to return the new tokens expressed in terms of multiple edits applied to the previous
+		 * tokens.
+		 *
+		 * To clearly define what "previous tokens" means, it is possible to return a `resultId` with the semantic tokens. If the
+		 * editor still has in memory the previous result, the editor will pass in options the previous `resultId` at
+		 * `SemanticTokensRequestOptions.previousResultId`. Only when the editor passes in the previous `resultId`, it is allowed
+		 * that a semantic tokens provider returns the new tokens expressed as edits to be applied to the previous result. Even in this
+		 * case, the semantic tokens provider needs to return a new `resultId` that will identify these new tokens as a basis
+		 * for the next request.
+		 *
+		 * *NOTE 1*: It is illegal to return `SemanticTokensEdits` if `options.previousResultId` is not set.
+		 * *NOTE 2*: All edits in `SemanticTokensEdits` contain indices in the old integers array, so they all refer to the previous result state.
+		 */
+		provideSemanticTokens(document: TextDocument, options: SemanticTokensRequestOptions, token: CancellationToken): ProviderResult<SemanticTokens | SemanticTokensEdits>;
+	}
+
+	export namespace languages {
+		/**
+		 * Register a semantic tokens provider.
+		 *
+		 * Multiple providers can be registered for a language. In that case providers are sorted
+		 * by their [score](#languages.match) and the best-matching provider is used. Failure
+		 * of the selected provider will cause a failure of the whole operation.
+		 *
+		 * @param selector A selector that defines the documents this provider is applicable to.
+		 * @param provider A semantic tokens provider.
+		 * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+		 */
+		export function registerSemanticTokensProvider(selector: DocumentSelector, provider: SemanticTokensProvider, legend: SemanticTokensLegend): Disposable;
+	}
+
+	//#endregion
+
+}

--- a/vscode.proposed.d.ts
+++ b/vscode.proposed.d.ts
@@ -35,8 +35,7 @@ declare module 'vscode' {
 		/**
 		 * The result id of the tokens.
 		 *
-		 * On a next call to `provideSemanticTokens`, if VS Code still holds in memory this result,
-		 * the result id will be passed in as `SemanticTokensRequestOptions.previousResultId`.
+		 * This is the id that will be passed to `DocumentSemanticTokensProvider.provideDocumentSemanticTokensEdits` (if implemented).
 		 */
 		readonly resultId?: string;
 		readonly data: Uint32Array;
@@ -48,8 +47,7 @@ declare module 'vscode' {
 		/**
 		 * The result id of the tokens.
 		 *
-		 * On a next call to `provideSemanticTokens`, if VS Code still holds in memory this result,
-		 * the result id will be passed in as `SemanticTokensRequestOptions.previousResultId`.
+		 * This is the id that will be passed to `DocumentSemanticTokensProvider.provideDocumentSemanticTokensEdits` (if implemented).
 		 */
 		readonly resultId?: string;
 		readonly edits: SemanticTokensEdit[];
@@ -65,21 +63,11 @@ declare module 'vscode' {
 		constructor(start: number, deleteCount: number, data?: Uint32Array);
 	}
 
-	export interface SemanticTokensRequestOptions {
-		readonly ranges?: readonly Range[];
-		/**
-		 * The previous result id that the editor still holds in memory.
-		 *
-		 * Only when this is set it is safe for a `SemanticTokensProvider` to return `SemanticTokensEdits`.
-		 */
-		readonly previousResultId?: string;
-	}
-
 	/**
-	 * The semantic tokens provider interface defines the contract between extensions and
+	 * The document semantic tokens provider interface defines the contract between extensions and
 	 * semantic tokens.
 	 */
-	export interface SemanticTokensProvider {
+	export interface DocumentSemanticTokensProvider {
 		/**
 		 * A file can contain many tokens, perhaps even hundreds of thousands of tokens. Therefore, to improve
 		 * the memory consumption around describing semantic tokens, we have decided to avoid allocating an object
@@ -87,31 +75,28 @@ declare module 'vscode' {
 		 * of each token is expressed relative to the token before it because most tokens remain stable relative to
 		 * each other when edits are made in a file.
 		 *
-		 *
 		 * ---
-		 * In short, each token takes 5 integers to represent, so a specific token `i` in the file consists of the following fields:
+		 * In short, each token takes 5 integers to represent, so a specific token `i` in the file consists of the following array indices:
 		 *  - at index `5*i`   - `deltaLine`: token line number, relative to the previous token
 		 *  - at index `5*i+1` - `deltaStart`: token start character, relative to the previous token (relative to 0 or the previous token's start if they are on the same line)
 		 *  - at index `5*i+2` - `length`: the length of the token. A token cannot be multiline.
-		 *  - at index `5*i+3` - `tokenType`: will be looked up in `SemanticTokensLegend.tokenTypes`
+		 *  - at index `5*i+3` - `tokenType`: will be looked up in `SemanticTokensLegend.tokenTypes`. We currently ask that `tokenType` < 65536.
 		 *  - at index `5*i+4` - `tokenModifiers`: each set bit will be looked up in `SemanticTokensLegend.tokenModifiers`
-		 *
-		 *
 		 *
 		 * ---
 		 * ### How to encode tokens
 		 *
-		 * Here is an example for encoding a file with 3 tokens:
+		 * Here is an example for encoding a file with 3 tokens in a uint32 array:
 		 * ```
-		 *    { line: 2, startChar:  5, length: 3, tokenType: "properties", tokenModifiers: ["private", "static"] },
-		 *    { line: 2, startChar: 10, length: 4, tokenType: "types",      tokenModifiers: [] },
-		 *    { line: 5, startChar:  2, length: 7, tokenType: "classes",    tokenModifiers: [] }
+		 *    { line: 2, startChar:  5, length: 3, tokenType: "property",  tokenModifiers: ["private", "static"] },
+		 *    { line: 2, startChar: 10, length: 4, tokenType: "type",      tokenModifiers: [] },
+		 *    { line: 5, startChar:  2, length: 7, tokenType: "class",     tokenModifiers: [] }
 		 * ```
 		 *
 		 * 1. First of all, a legend must be devised. This legend must be provided up-front and capture all possible token types.
 		 * For this example, we will choose the following legend which must be passed in when registering the provider:
 		 * ```
-		 *    tokenTypes: ['properties', 'types', 'classes'],
+		 *    tokenTypes: ['property', 'type', 'class'],
 		 *    tokenModifiers: ['private', 'static']
 		 * ```
 		 *
@@ -125,7 +110,7 @@ declare module 'vscode' {
 		 *    { line: 5, startChar:  2, length: 7, tokenType: 2, tokenModifiers: 0 }
 		 * ```
 		 *
-		 * 3. The next steps is to encode each token relative to the previous token in the file. In this case, the second token
+		 * 3. The next step is to represent each token relative to the previous token in the file. In this case, the second token
 		 * is on the same line as the first token, so the `startChar` of the second token is made relative to the `startChar`
 		 * of the first token, so it will be `10 - 5`. The third token is on a different line than the second token, so the
 		 * `startChar` of the third token will not be altered:
@@ -140,8 +125,12 @@ declare module 'vscode' {
 		 *    // 1st token,  2nd token,  3rd token
 		 *    [  2,5,3,0,3,  0,5,4,1,0,  3,2,7,2,0 ]
 		 * ```
-		 *
-		 *
+		 */
+		provideDocumentSemanticTokens(document: TextDocument, token: CancellationToken): ProviderResult<SemanticTokens>;
+
+		/**
+		 * Instead of always returning all the tokens in a file, it is possible for a `DocumentSemanticTokensProvider` to implement
+		 * this method (`updateSemanticTokens`) and then return incremental updates to the previously provided semantic tokens.
 		 *
 		 * ---
 		 * ### How tokens change when the document changes
@@ -151,9 +140,9 @@ declare module 'vscode' {
 		 * Continuing with the above example, suppose a new line was inserted at the top of the file.
 		 * That would make all the tokens move down by one line (notice how the line has changed for each one):
 		 * ```
-		 *    { line: 3, startChar:  5, length: 3, tokenType: "properties", tokenModifiers: ["private", "static"] },
-		 *    { line: 3, startChar: 10, length: 4, tokenType: "types",      tokenModifiers: [] },
-		 *    { line: 6, startChar:  2, length: 7, tokenType: "classes",    tokenModifiers: [] }
+		 *    { line: 3, startChar:  5, length: 3, tokenType: "property", tokenModifiers: ["private", "static"] },
+		 *    { line: 3, startChar: 10, length: 4, tokenType: "type",     tokenModifiers: [] },
+		 *    { line: 6, startChar:  2, length: 7, tokenType: "class",    tokenModifiers: [] }
 		 * ```
 		 * The integer encoding of the tokens does not change substantially because of the delta-encoding of positions:
 		 * ```
@@ -162,18 +151,18 @@ declare module 'vscode' {
 		 * ```
 		 * It is possible to express these new tokens in terms of an edit applied to the previous tokens:
 		 * ```
-		 *    [  2,5,3,0,3,  0,5,4,1,0,  3,2,7,2,0 ]
-		 *    [  3,5,3,0,3,  0,5,4,1,0,  3,2,7,2,0 ]
+		 *    [  2,5,3,0,3,  0,5,4,1,0,  3,2,7,2,0 ] // old tokens
+		 *    [  3,5,3,0,3,  0,5,4,1,0,  3,2,7,2,0 ] // new tokens
 		 *
 		 *    edit: { start:  0, deleteCount: 1, data: [3] } // replace integer at offset 0 with 3
 		 * ```
 		 *
 		 * Furthermore, let's assume that a new token has appeared on line 4:
 		 * ```
-		 *    { line: 3, startChar:  5, length: 3, tokenType: "properties", tokenModifiers: ["private", "static"] },
-		 *    { line: 3, startChar: 10, length: 4, tokenType: "types",      tokenModifiers: [] },
-		 *    { line: 4, startChar:  3, length: 5, tokenType: "properties", tokenModifiers: ["static"] },
-		 *    { line: 6, startChar:  2, length: 7, tokenType: "classes",    tokenModifiers: [] }
+		 *    { line: 3, startChar:  5, length: 3, tokenType: "property", tokenModifiers: ["private", "static"] },
+		 *    { line: 3, startChar: 10, length: 4, tokenType: "type",      tokenModifiers: [] },
+		 *    { line: 4, startChar:  3, length: 5, tokenType: "property", tokenModifiers: ["static"] },
+		 *    { line: 6, startChar:  2, length: 7, tokenType: "class",    tokenModifiers: [] }
 		 * ```
 		 * The integer encoding of the tokens is:
 		 * ```
@@ -182,51 +171,56 @@ declare module 'vscode' {
 		 * ```
 		 * Again, it is possible to express these new tokens in terms of an edit applied to the previous tokens:
 		 * ```
-		 *    [  3,5,3,0,3,  0,5,4,1,0,  3,2,7,2,0 ]
-		 *    [  3,5,3,0,3,  0,5,4,1,0,  1,3,5,0,2,  2,2,7,2,0, ]
+		 *    [  3,5,3,0,3,  0,5,4,1,0,  3,2,7,2,0 ]               // old tokens
+		 *    [  3,5,3,0,3,  0,5,4,1,0,  1,3,5,0,2,  2,2,7,2,0, ]  // new tokens
 		 *
 		 *    edit: { start: 10, deleteCount: 1, data: [1,3,5,0,2,2] } // replace integer at offset 10 with [1,3,5,0,2,2]
 		 * ```
 		 *
-		 *
-		 *
-		 * ---
-		 * ### When to return `SemanticTokensEdits`
-		 *
-		 * When doing edits, it is possible that multiple edits occur until VS Code decides to invoke the semantic tokens provider.
-		 * In principle, each call to `provideSemanticTokens` can return a full representations of the semantic tokens, and that would
-		 * be a perfectly reasonable semantic tokens provider implementation.
-		 *
-		 * However, when having a language server running in a separate process, transferring all the tokens between processes
-		 * might be slow, so VS Code allows to return the new tokens expressed in terms of multiple edits applied to the previous
-		 * tokens.
-		 *
-		 * To clearly define what "previous tokens" means, it is possible to return a `resultId` with the semantic tokens. If the
-		 * editor still has in memory the previous result, the editor will pass in options the previous `resultId` at
-		 * `SemanticTokensRequestOptions.previousResultId`. Only when the editor passes in the previous `resultId`, it is allowed
-		 * that a semantic tokens provider returns the new tokens expressed as edits to be applied to the previous result. Even in this
-		 * case, the semantic tokens provider needs to return a new `resultId` that will identify these new tokens as a basis
-		 * for the next request.
-		 *
-		 * *NOTE 1*: It is illegal to return `SemanticTokensEdits` if `options.previousResultId` is not set.
-		 * *NOTE 2*: All edits in `SemanticTokensEdits` contain indices in the old integers array, so they all refer to the previous result state.
+		 * *NOTE*: When doing edits, it is possible that multiple edits occur until VS Code decides to invoke the semantic tokens provider.
+		 * *NOTE*: If the provider cannot compute `SemanticTokensEdits`, it can "give up" and return all the tokens in the document again.
+		 * *NOTE*: All edits in `SemanticTokensEdits` contain indices in the old integers array, so they all refer to the previous result state.
 		 */
-		provideSemanticTokens(document: TextDocument, options: SemanticTokensRequestOptions, token: CancellationToken): ProviderResult<SemanticTokens | SemanticTokensEdits>;
+		provideDocumentSemanticTokensEdits?(document: TextDocument, previousResultId: string, token: CancellationToken): ProviderResult<SemanticTokens | SemanticTokensEdits>;
+	}
+
+	/**
+	 * The document range semantic tokens provider interface defines the contract between extensions and
+	 * semantic tokens.
+	 */
+	export interface DocumentRangeSemanticTokensProvider {
+		/**
+		 * See [provideDocumentSemanticTokens](#DocumentSemanticTokensProvider.provideDocumentSemanticTokens).
+		 */
+		provideDocumentRangeSemanticTokens(document: TextDocument, range: Range, token: CancellationToken): ProviderResult<SemanticTokens>;
 	}
 
 	export namespace languages {
 		/**
-		 * Register a semantic tokens provider.
+		 * Register a semantic tokens provider for a whole document.
 		 *
 		 * Multiple providers can be registered for a language. In that case providers are sorted
 		 * by their [score](#languages.match) and the best-matching provider is used. Failure
 		 * of the selected provider will cause a failure of the whole operation.
 		 *
 		 * @param selector A selector that defines the documents this provider is applicable to.
-		 * @param provider A semantic tokens provider.
+		 * @param provider A document semantic tokens provider.
 		 * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
 		 */
-		export function registerSemanticTokensProvider(selector: DocumentSelector, provider: SemanticTokensProvider, legend: SemanticTokensLegend): Disposable;
+		export function registerDocumentSemanticTokensProvider(selector: DocumentSelector, provider: DocumentSemanticTokensProvider, legend: SemanticTokensLegend): Disposable;
+
+		/**
+		 * Register a semantic tokens provider for a document range.
+		 *
+		 * Multiple providers can be registered for a language. In that case providers are sorted
+		 * by their [score](#languages.match) and the best-matching provider is used. Failure
+		 * of the selected provider will cause a failure of the whole operation.
+		 *
+		 * @param selector A selector that defines the documents this provider is applicable to.
+		 * @param provider A document range semantic tokens provider.
+		 * @return A [disposable](#Disposable) that unregisters this provider when being disposed.
+		 */
+		export function registerDocumentRangeSemanticTokensProvider(selector: DocumentSelector, provider: DocumentRangeSemanticTokensProvider, legend: SemanticTokensLegend): Disposable;
 	}
 
 	//#endregion

--- a/vscode.proposed.d.ts
+++ b/vscode.proposed.d.ts
@@ -69,6 +69,11 @@ declare module 'vscode' {
 	 */
 	export interface DocumentSemanticTokensProvider {
 		/**
+		 * An optional event to signal that the semantic tokens from this provider have changed.
+		 */
+		onDidChangeSemanticTokens?: Event<void>;
+
+		/**
 		 * A file can contain many tokens, perhaps even hundreds of thousands of tokens. Therefore, to improve
 		 * the memory consumption around describing semantic tokens, we have decided to avoid allocating an object
 		 * for each token and we represent tokens from a file as an array of integers. Furthermore, the position


### PR DESCRIPTION
## Changes

Recent insider builds of VS Code include an experimental api for semantic token highlighting. It allows extensions to report token types (like comment, string, keyword, class, function, variable, ...) and token modifiers (like static, abstract, member, ...). In this PR, I've added a contributor that's based on the Dart analysis server.

To make problems in the new highlighter easier to spot, I've temporarily removed the contributed grammar.

Server highlighting needs to be enabled via `"dart.analysisServerHighlighting": true`, `"editor.semanticHighlighting.enabled": true` also needs to be enabled.

### Problems and todos

- It seems like VS Code cancels a highlighting operation pretty fast if it takes to long. Sometimes files aren't analyzed at plugin start because the server takes to long. This is fixed after the first edit (and we still have the grammar-based highlighter), so I assume this shouldn't be much of an issue
- I haven't tested if this interferes with the grammar-based highlighter
- ~~I still need to go through more `HighlightRegionType`s from the analyzer and map them~~ done
- ~~Support nested highlight regions and multi-line tokens~~ done
- Of course, this is still blocked on VS Code and only available on an insiders build

## Screenshots

Note that all screenshots use server highlighting only. I also didn't go through all token types yet.
![grafik](https://user-images.githubusercontent.com/5738860/71919548-3d796a00-3185-11ea-87a1-9af95d7d4c3c.png)

From an analyzer plugin:
![grafik](https://user-images.githubusercontent.com/5738860/71919704-95b06c00-3185-11ea-8827-049da88afdee.png)


Closes #2202, #1688