### PR TITLE
Add CodeLens links for Flutter DartPad samples

### DIFF
--- a/package.json
+++ b/package.json
@@ -1121,6 +1121,12 @@
 					"description": "Whether to show Code Lens actions in the editor for quick running/debugging tests.",
 					"scope": "window"
 				},
+				"dart.showDartPadSampleCodeLens": {
+					"type": "boolean",
+					"default": true,
+					"description": "Whether to show Code Lens actions in the editor for opening online DartPad samples.",
+					"scope": "window"
+				},
 				"dart.showTodos": {
 					"type": "boolean",
 					"default": true,

--- a/src/extension/code_lens/flutter_dartpad_samples.ts
+++ b/src/extension/code_lens/flutter_dartpad_samples.ts
@@ -1,0 +1,79 @@
+import * as path from "path";
+import { CancellationToken, CodeLens, CodeLensProvider, commands, Event, EventEmitter, TextDocument } from "vscode";
+import { FlutterSdks, IAmDisposable, Logger } from "../../shared/interfaces";
+import { fsPath } from "../../shared/utils/fs";
+import { ClassOutlineVisitor } from "../../shared/utils/outline";
+import { envUtils, toRange } from "../../shared/vscode/utils";
+import { DasAnalyzer } from "../analysis/analyzer_das";
+
+const dartPadSamplePattern = new RegExp("\\{@tool\\s+dartpad");
+
+export class FlutterDartPadSamplesCodeLensProvider implements CodeLensProvider, IAmDisposable {
+	private disposables: IAmDisposable[] = [];
+	private onDidChangeCodeLensesEmitter: EventEmitter<void> = new EventEmitter<void>();
+	public readonly onDidChangeCodeLenses: Event<void> = this.onDidChangeCodeLensesEmitter.event;
+	private readonly flutterPackagesFolder: string;
+
+	constructor(private readonly logger: Logger, private readonly analyzer: DasAnalyzer, private readonly sdks: FlutterSdks) {
+		this.disposables.push(this.analyzer.client.registerForAnalysisOutline((n) => {
+			this.onDidChangeCodeLensesEmitter.fire();
+		}));
+
+		this.disposables.push(commands.registerCommand("_dart.openDartPadSample", (sample: DartPadSampleInfo) => {
+			// Link down to first code snippet.
+			const fragment = `#${sample.libraryName}.${sample.className}.1`;
+			const url = `https://api.flutter.dev/flutter/${sample.libraryName}/${sample.className}-class.html${fragment}`;
+			envUtils.openInBrowser(url);
+		}));
+
+		this.flutterPackagesFolder = path.join(sdks.flutter, "packages/flutter/lib/src/").toLowerCase();
+	}
+
+	public provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | undefined {
+		// Ensure this file is a Flutter package file.
+		const filePath = fsPath(document.uri);
+		if (!filePath.toLowerCase().startsWith(this.flutterPackagesFolder))
+			return;
+
+		// This method should be FAST because it affects layout of the document (adds extra lines) so if
+		// we don't already have an outline, we won't wait for one. A new outline arriving will trigger a
+		// re-request anyway.
+		const outline = this.analyzer.fileTracker.getOutlineFor(document.uri);
+		if (!outline || !outline.children || !outline.children.length)
+			return;
+
+		const libraryName = filePath.substr(this.flutterPackagesFolder.length).split("/")[0];
+
+		const visitor = new ClassOutlineVisitor(this.logger);
+		visitor.visit(outline);
+
+		// Filter classes to those with DartPad samples.
+		const samples = visitor.classes.filter((cl) => {
+			// HACK: DartDocs are between the main offset and codeOffset.
+			const docs = document.getText(toRange(document, cl.offset, cl.codeOffset - cl.offset));
+			return dartPadSamplePattern.test(docs);
+		}).map((cl) => ({ ...cl, libraryName }));
+
+		return samples
+			.filter((sample) => sample.codeOffset && sample.codeLength)
+			.map((sample) => new CodeLens(
+				toRange(document, sample.codeOffset, sample.codeLength),
+				{
+					arguments: [sample],
+					command: "_dart.openDartPadSample",
+					title: `Open online interactive samples for ${sample.className}`,
+				},
+			));
+	}
+
+	public dispose(): any {
+		this.disposables.forEach((d) => d.dispose());
+	}
+}
+
+export interface DartPadSampleInfo {
+	libraryName: string;
+	className: string;
+	offset: number;
+	length: number;
+}

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -91,6 +91,7 @@ class Config {
 	get sdkPaths(): string[] { return this.getConfig<string[]>("sdkPaths", []).map(resolvePaths); }
 	get showIgnoreQuickFixes(): boolean { return this.getConfig<boolean>("showIgnoreQuickFixes", false); }
 	get showTestCodeLens(): boolean { return this.getConfig<boolean>("showTestCodeLens", true); }
+	get showDartPadSampleCodeLens(): boolean { return this.getConfig<boolean>("showDartPadSampleCodeLens", true); }
 	get showTodos(): boolean { return this.getConfig<boolean>("showTodos", true); }
 	get triggerSignatureHelpAutomatically(): boolean { return this.getConfig<boolean>("triggerSignatureHelpAutomatically", false); }
 	get useKnownChromeOSPorts(): boolean { return this.getConfig<boolean>("useKnownChromeOSPorts", true); }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -7,7 +7,7 @@ import { DaemonCapabilities, FlutterCapabilities } from "../shared/capabilities/
 import { dartPlatformName, flutterExtensionIdentifier, flutterPath, HAS_LAST_DEBUG_CONFIG, isWin, IS_RUNNING_LOCALLY_CONTEXT, platformDisplayName } from "../shared/constants";
 import { LogCategory } from "../shared/enums";
 import { setUserAgent } from "../shared/fetch";
-import { DartWorkspaceContext, IFlutterDaemon, Sdks } from "../shared/interfaces";
+import { DartWorkspaceContext, FlutterSdks, IFlutterDaemon, Sdks } from "../shared/interfaces";
 import { captureLogs, EmittingLogger, logToConsole, RingLog } from "../shared/logging";
 import { PubApi } from "../shared/pub/api";
 import { internalApiSymbol } from "../shared/symbols";
@@ -24,6 +24,7 @@ import { AnalyzerStatusReporter } from "./analysis/analyzer_status_reporter";
 import { FileChangeHandler } from "./analysis/file_change_handler";
 import { Analytics } from "./analytics";
 import { DartExtensionApi } from "./api";
+import { FlutterDartPadSamplesCodeLensProvider } from "./code_lens/flutter_dartpad_samples";
 import { TestCodeLensProvider } from "./code_lens/test_code_lens_provider";
 import { AnalyzerCommands } from "./commands/analyzer";
 import { DebugCommands } from "./commands/debug";
@@ -267,6 +268,11 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 		rankingCodeActionProvider.registerProvider(new IgnoreLintCodeActionProvider(activeFileFilters));
 		if (config.showTestCodeLens) {
 			const codeLensProvider = new TestCodeLensProvider(logger, dasAnalyzer);
+			context.subscriptions.push(codeLensProvider);
+			context.subscriptions.push(vs.languages.registerCodeLensProvider(DART_MODE, codeLensProvider));
+		}
+		if (config.showDartPadSampleCodeLens && sdks.flutter) {
+			const codeLensProvider = new FlutterDartPadSamplesCodeLensProvider(logger, dasAnalyzer, sdks as FlutterSdks);
 			context.subscriptions.push(codeLensProvider);
 			context.subscriptions.push(vs.languages.registerCodeLensProvider(DART_MODE, codeLensProvider));
 		}

--- a/src/test/flutter/providers/flutter_dartpad_samples_code_lens_provider.test.ts
+++ b/src/test/flutter/providers/flutter_dartpad_samples_code_lens_provider.test.ts
@@ -1,7 +1,8 @@
 import * as assert from "assert";
 import * as path from "path";
+import * as sinon from "sinon";
 import * as vs from "vscode";
-import { activate, extApi, getCodeLens, getPackages, openFile, positionOf, waitForResult } from "../../helpers";
+import { activate, extApi, getCodeLens, getPackages, openFile, positionOf, sb, waitForResult } from "../../helpers";
 
 describe("test_flutter_dartpad_samples", () => {
 	before("get packages", () => getPackages());
@@ -35,5 +36,11 @@ describe("test_flutter_dartpad_samples", () => {
 		const sampleInfo = codeLens.command!.arguments![0] as { libraryName: string, className: string };
 		assert.equal(sampleInfo.libraryName, "material");
 		assert.equal(sampleInfo.className, "AppBar");
+
+		// Execute the command and ensure it tried to open the correct URL.
+		const openBrowserCommand = sb.stub(extApi.envUtils, "openInBrowser").withArgs(sinon.match.any).resolves(true);
+		vs.commands.executeCommand(codeLens.command.command, ...codeLens.command.arguments!);
+		assert.ok(openBrowserCommand.calledOnce);
+		assert.ok(openBrowserCommand.calledWith("https://api.flutter.dev/flutter/material/AppBar-class.html#material.AppBar.1"));
 	});
 });

--- a/src/test/flutter/providers/flutter_dartpad_samples_code_lens_provider.test.ts
+++ b/src/test/flutter/providers/flutter_dartpad_samples_code_lens_provider.test.ts
@@ -1,0 +1,39 @@
+import * as assert from "assert";
+import * as path from "path";
+import * as vs from "vscode";
+import { activate, extApi, getCodeLens, getPackages, openFile, positionOf, waitForResult } from "../../helpers";
+
+describe("test_flutter_dartpad_samples", () => {
+	before("get packages", () => getPackages());
+	beforeEach("activate", () => activate());
+
+	it("includes run/debug actions for tests", async function () {
+		const appBarUri = vs.Uri.file(path.join(extApi.workspaceContext.sdks.flutter!, "packages/flutter/lib/src/material/app_bar.dart"));
+		const editor = await openFile(appBarUri);
+		await waitForResult(() => !!extApi.fileTracker.getOutlineFor(appBarUri));
+
+		const fileCodeLens = await getCodeLens(editor.document);
+		const appBarClassPos = positionOf(`class App^Bar`);
+
+		const codeLenses = fileCodeLens.filter((cl) => cl.range.start.line === appBarClassPos.line);
+		assert.equal(codeLenses.length, 1);
+		const codeLens = codeLenses[0];
+
+		if (!codeLens.command) {
+			// If there's no command, skip the test. This happens very infrequently and appears to be a VS Code
+			// race condition. Rather than failing our test runs, skip.
+			// TODO: Remove this if these issues get reliable fixes:
+			// - https://github.com/microsoft/vscode/issues/79805
+			// - https://github.com/microsoft/vscode/issues/86403
+			this.skip();
+			return;
+		}
+
+		assert.equal(editor.document.getText(codeLens.range).startsWith("class AppBar extends StatefulWidget"), true);
+		assert.equal(codeLens.command!.title, "Open online interactive samples for AppBar");
+		assert.equal(codeLens.command!.command, "_dart.openDartPadSample");
+		const sampleInfo = codeLens.command!.arguments![0] as { libraryName: string, className: string };
+		assert.equal(sampleInfo.libraryName, "material");
+		assert.equal(sampleInfo.className, "AppBar");
+	});
+});


### PR DESCRIPTION
This adds CodeLens links for Flutter files that have `{@tool dartpad` snippets that open the interactive online samples:

![Screenshot 2020-01-24 at 15 13 12](https://user-images.githubusercontent.com/1078012/73079449-27291900-3ebc-11ea-89da-1d89e7de0c0d.png)

![Screenshot 2020-01-24 at 15 13 24](https://user-images.githubusercontent.com/1078012/73079457-2b553680-3ebc-11ea-97e4-e499356c722d.png)

It has some assumptions/caveats:

- Only works for files inside `(Flutter SDK)/packages/flutter/lib/src/material/app_bar.dart`
- Assumes the leaf-most folder name is the package (eg. in the above, "material") and that the `name` from the `Outline` node is the classname, and uses these in the URL as `${sample.libraryName}/${sample.className}-class.html`
- Always links to `https://api.flutter.dev` regardless of your Flutter branch/channel
- Assumes there's an element with the ID `#${sample.libraryName}.${sample.className}.1` at the correct location (this jumps down the page - if this assumption becomes invalid, you'll end up at the top of the docs page for that class)

@devoncarew I think these are the same for the IntelliJ version too (except the last one - though you might wish to add) but shout if anything seems wrong here.

Fixes #2151.