### PR TITLE
Add Flutter 2020 Q1 survey details

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -53,16 +53,17 @@ export const alwaysOpenAction = "Always Open";
 export const notTodayAction = "Not Now";
 export const doNotAskAgainAction = "Never Ask";
 
-export const surveyBaseUrl = "https://google.qualtrics.com/jfe/form/SV_5BhR2R8DZIEE6dn?Source=VSCode";
-export const flutterSurveyPromptWithAnalytics = "Help improve Flutter! Take our Q4 survey. By clicking on this link you agree to share feature usage along with the survey responses.";
-export const flutterSurveyPromptWithoutAnalytics = "Help improve Flutter! Take our Q4 survey.";
+export const surveyBaseUrl = "https://google.qualtrics.com/jfe/form/SV_6YBXYxIR69pgpr7?Source=VSCode";
+export const flutterSurveyPromptWithAnalytics = "Help improve Flutter! Take our Q1 survey. By clicking on this link you agree to share feature usage along with the survey responses.";
+export const flutterSurveyPromptWithoutAnalytics = "Help improve Flutter! Take our Q1 survey.";
 export const takeSurveyAction = "Take Survey";
 // To confirm dates in PST(/PDT), paste this into Chrome dev console:
 // new Date(Date.UTC(...)).toLocaleString("en-US", {timeZone: "America/Los_Angeles"})
-// "11/23/2019, 9:00:00 AM"
-export const surveyStart = Date.UTC(2019, 10 /* Month is 0-based!! */, 22, 17, 0);
-// "12/1/2019, 6:00:00 PM"
-export const surveyEnd = Date.UTC(2019, 11 /* Month is 0-based!! */, 2, 2, 0);
+// Paste the results into comments for easier reviewing!
+// "2/24/2020, 9:00:00 AM"
+export const surveyStart = Date.UTC(2020, 1 /* Month is 0-based!! */, 24, 17, 0);
+// "3/2/2020, 9:00:00 AM"
+export const surveyEnd = Date.UTC(2020, 2 /* Month is 0-based!! */, 2, 17, 0);
 
 // Minutes.
 export const fiveMinutesInMs = 1000 * 60 * 5;

--- a/src/shared/vscode/user_prompts.ts
+++ b/src/shared/vscode/user_prompts.ts
@@ -12,8 +12,8 @@ export function showFlutterSurveyNotificationIfAppropriate(context: Context, ope
 	if (now <= surveyStart || now >= surveyEnd)
 		return false;
 
-	const lastShown = context.flutterSurvey2019Q4NotificationLastShown;
-	const doNotShow = context.flutterSurvey2019Q4NotificationDoNotShow;
+	const lastShown = context.flutterSurvey2020Q1NotificationLastShown;
+	const doNotShow = context.flutterSurvey2020Q1NotificationDoNotShow;
 
 	// Don't show this notification if user previously said not to.
 	if (doNotShow)
@@ -48,16 +48,16 @@ export function showFlutterSurveyNotificationIfAppropriate(context: Context, ope
 
 	// Mark the last time we've shown it (now) so we can avoid showing again for
 	// 40 hours.
-	context.flutterSurvey2019Q4NotificationLastShown = Date.now();
+	context.flutterSurvey2020Q1NotificationLastShown = Date.now();
 
 	// Prompt to show and handle response.
 	vs.window.showInformationMessage(prompt, takeSurveyAction, doNotAskAgainAction).then(async (choice) => {
 		if (choice === doNotAskAgainAction) {
-			context.flutterSurvey2019Q4NotificationDoNotShow = true;
+			context.flutterSurvey2020Q1NotificationDoNotShow = true;
 		} else if (choice === takeSurveyAction) {
 			// Mark as do-not-show-again if they answer it, since it seems silly
 			// to show them again if they already completed it.
-			context.flutterSurvey2019Q4NotificationDoNotShow = true;
+			context.flutterSurvey2020Q1NotificationDoNotShow = true;
 			await openInBrowser(surveyUrl);
 		}
 	});

--- a/src/shared/vscode/workspace.ts
+++ b/src/shared/vscode/workspace.ts
@@ -15,10 +15,10 @@ export class Context {
 	set devToolsNotificationLastShown(value: number | undefined) { this.context.globalState.update("devToolsNotificationLastShown", value); }
 	get devToolsNotificationDoNotShow(): boolean | undefined { return !!this.context.globalState.get("devToolsNotificationDoNotShowAgain"); }
 	set devToolsNotificationDoNotShow(value: boolean | undefined) { this.context.globalState.update("devToolsNotificationDoNotShowAgain", value); }
-	get flutterSurvey2019Q4NotificationLastShown(): number | undefined { return this.context.globalState.get("flutterSurvey2019Q4NotificationLastShown") as number; }
-	set flutterSurvey2019Q4NotificationLastShown(value: number | undefined) { this.context.globalState.update("flutterSurvey2019Q4NotificationLastShown", value); }
-	get flutterSurvey2019Q4NotificationDoNotShow(): boolean | undefined { return !!this.context.globalState.get("flutterSurvey2019Q4NotificationDoNotShowAgain"); }
-	set flutterSurvey2019Q4NotificationDoNotShow(value: boolean | undefined) { this.context.globalState.update("flutterSurvey2019Q4NotificationDoNotShowAgain", value); }
+	get flutterSurvey2020Q1NotificationLastShown(): number | undefined { return this.context.globalState.get("flutterSurvey2020Q1NotificationLastShown") as number; }
+	set flutterSurvey2020Q1NotificationLastShown(value: number | undefined) { this.context.globalState.update("flutterSurvey2020Q1NotificationLastShown", value); }
+	get flutterSurvey2020Q1NotificationDoNotShow(): boolean | undefined { return !!this.context.globalState.get("flutterSurvey2020Q1NotificationDoNotShowAgain"); }
+	set flutterSurvey2020Q1NotificationDoNotShow(value: boolean | undefined) { this.context.globalState.update("flutterSurvey2020Q1NotificationDoNotShowAgain", value); }
 	get hasWarnedAboutFormatterSyntaxLimitation(): boolean { return !!this.context.globalState.get("hasWarnedAboutFormatterSyntaxLimitation"); }
 	set hasWarnedAboutFormatterSyntaxLimitation(value: boolean) { this.context.globalState.update("hasWarnedAboutFormatterSyntaxLimitation", value); }
 	get lastSeenVersion(): string | undefined { return this.context.globalState.get("lastSeenVersion"); }

--- a/src/test/dart/user_prompts.test.ts
+++ b/src/test/dart/user_prompts.test.ts
@@ -139,14 +139,14 @@ describe("Survey notification", async () => {
 
 		// Flags were updated.
 		const context = extApi.context;
-		assert.equal(context.flutterSurvey2019Q4NotificationDoNotShow, true);
+		assert.equal(context.flutterSurvey2020Q1NotificationDoNotShow, true);
 		// Marked as shown within the last 10 seconds.
-		assert.equal(context.flutterSurvey2019Q4NotificationLastShown && context.flutterSurvey2019Q4NotificationLastShown > Date.now() - 10000 && context.flutterSurvey2019Q4NotificationLastShown <= Date.now(), true);
+		assert.equal(context.flutterSurvey2020Q1NotificationLastShown && context.flutterSurvey2020Q1NotificationLastShown > Date.now() - 10000 && context.flutterSurvey2020Q1NotificationLastShown <= Date.now(), true);
 	});
 
 	it("shows and updates context values when already seen", async () => {
 		const context = extApi.context;
-		context.flutterSurvey2019Q4NotificationLastShown = surveyIsOpenDate - (longRepeatPromptThreshold + twoHoursInMs);
+		context.flutterSurvey2020Q1NotificationLastShown = surveyIsOpenDate - (longRepeatPromptThreshold + twoHoursInMs);
 
 		const showInformationMessage = sb.stub(vs.window, "showInformationMessage");
 		const openSurveyPrompt = showInformationMessage.withArgs(matchPrompt, sinon.match.any).resolves(takeSurveyAction);
@@ -162,16 +162,16 @@ describe("Survey notification", async () => {
 		assert.equal(res, true);
 
 		// Flags were updated.
-		assert.equal(context.flutterSurvey2019Q4NotificationDoNotShow, true);
+		assert.equal(context.flutterSurvey2020Q1NotificationDoNotShow, true);
 		// Marked as shown within the last 10 seconds.
-		assert.equal(context.flutterSurvey2019Q4NotificationLastShown > Date.now() - 10000 && context.flutterSurvey2019Q4NotificationLastShown <= Date.now(), true);
+		assert.equal(context.flutterSurvey2020Q1NotificationLastShown > Date.now() - 10000 && context.flutterSurvey2020Q1NotificationLastShown <= Date.now(), true);
 	});
 
 	it("does not show if shown in the last 40 hours", async () => {
 		const context = extApi.context;
 		const now = surveyIsOpenDate;
 		const fiveHoursInMs = 1000 * 60 * 60 * 5;
-		context.flutterSurvey2019Q4NotificationLastShown = now - fiveHoursInMs;
+		context.flutterSurvey2020Q1NotificationLastShown = now - fiveHoursInMs;
 
 		const showInformationMessage = sb.stub(vs.window, "showInformationMessage");
 		const openSurveyPrompt = showInformationMessage.withArgs(matchPrompt, sinon.match.any).resolves(takeSurveyAction);
@@ -200,12 +200,12 @@ describe("Survey notification", async () => {
 		assert.equal(res, true);
 
 		// Flag was written.
-		await waitFor(() => extApi.context.flutterSurvey2019Q4NotificationDoNotShow);
-		assert.equal(extApi.context.flutterSurvey2019Q4NotificationDoNotShow, true);
+		await waitFor(() => extApi.context.flutterSurvey2020Q1NotificationDoNotShow);
+		assert.equal(extApi.context.flutterSurvey2020Q1NotificationDoNotShow, true);
 	});
 
 	it("does not prompt if told not to ask again", async () => {
-		extApi.context.flutterSurvey2019Q4NotificationDoNotShow = true;
+		extApi.context.flutterSurvey2020Q1NotificationDoNotShow = true;
 
 		const showInformationMessage = sb.stub(vs.window, "showInformationMessage");
 		const openSurveyPrompt = showInformationMessage.withArgs(matchPrompt, sinon.match.any).resolves(doNotAskAgainAction);

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -925,8 +925,8 @@ export async function addLaunchConfigsForTest(workspaceUri: vs.Uri, configs: any
 export function clearAllContext(context: Context): Promise<void> {
 	context.devToolsNotificationLastShown = undefined;
 	context.devToolsNotificationDoNotShow = undefined;
-	context.flutterSurvey2019Q4NotificationLastShown = undefined;
-	context.flutterSurvey2019Q4NotificationDoNotShow = undefined;
+	context.flutterSurvey2020Q1NotificationLastShown = undefined;
+	context.flutterSurvey2020Q1NotificationDoNotShow = undefined;
 
 	// HACK Updating context is async, but since we use setters we can't easily wait
 	// and this is only test code...


### PR DESCRIPTION
@pq @jayoung-lee FYI. A lot of the change here is just renaming the fields (so we don't reuse values from previous surveys). The date/link change is in the second commit (5a09f8e69ba983a95b357b3107680bc37cf67dc9).