### PR TITLE
Change Flutter Q1 survey date

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -60,10 +60,10 @@ export const takeSurveyAction = "Take Survey";
 // To confirm dates in PST(/PDT), paste this into Chrome dev console:
 // new Date(Date.UTC(...)).toLocaleString("en-US", {timeZone: "America/Los_Angeles"})
 // Paste the results into comments for easier reviewing!
-// "2/24/2020, 9:00:00 AM"
-export const surveyStart = Date.UTC(2020, 1 /* Month is 0-based!! */, 24, 17, 0);
-// "3/2/2020, 9:00:00 AM"
-export const surveyEnd = Date.UTC(2020, 2 /* Month is 0-based!! */, 2, 17, 0);
+// "3/3/2020, 9:00:00 AM"
+export const surveyStart = Date.UTC(2020, 2 /* Month is 0-based!! */, 3, 17, 0);
+// "3/10/2020, 9:00:00 AM"
+export const surveyEnd = Date.UTC(2020, 2 /* Month is 0-based!! */, 10, 16, 0);
 
 // Minutes.
 export const fiveMinutesInMs = 1000 * 60 * 5;


### PR DESCRIPTION
@pq @jayoung-lee FYI!

Note: I changed the close time from 5pm to 4pm UTC because otherwise it came out at 10am (because you go into PST?) and wasn't sure if which timezone the survey close date is in (I'd rather stop showing the prompt an hour before it ends than continue an hour after).