### PR TITLE
Keep stdout buffers to concat instead of converting to strings

### DIFF
--- a/src/extension/services/stdio_service.ts
+++ b/src/extension/services/stdio_service.ts
@@ -37,15 +37,15 @@ export abstract class StdIOService<T> implements IAmDisposable {
 
 		this.logTraffic(`    PID: ${process.pid}`);
 
-		this.process.stdout.on("data", (data: Buffer) => {
+		this.process.stdout.on("data", (data: Buffer | string) => {
 			// Add this message to the buffer for processing.
-			this.messageBuffers.push(data);
+			this.messageBuffers.push(Buffer.isBuffer(data) ? data : Buffer.from(data));
 
 			// Kick off processing if we have a full message.
 			if (data.toString().indexOf("\n") >= 0)
 				this.processMessageBuffer();
 		});
-		this.process.stderr.on("data", (data: Buffer) => {
+		this.process.stderr.on("data", (data: Buffer | string) => {
 			this.logTraffic(`${data.toString()}`, true);
 		});
 		this.process.on("exit", (code, signal) => {

--- a/src/test/dart/providers/dart_formatting_edit_provider.test.ts
+++ b/src/test/dart/providers/dart_formatting_edit_provider.test.ts
@@ -85,7 +85,7 @@ describe("dart_formatting_edit_provider", () => {
 		assert.equal(currentDoc().getText(), unformattedContent);
 	});
 
-	it.skip("formats a huge document of unicode characters without corrupting", async () => {
+	it("formats a huge document of unicode characters without corrupting", async () => {
 		// https://github.com/Dart-Code/Dart-Code/issues/2140
 		// Set the test document to 130 lines of 62 commented emojis
 		const testDocument = `// ${`🙈`.repeat(62)}${documentEol}`.repeat(130);


### PR DESCRIPTION
This seems to fix an issue with some unicode characters becoming "broken" which is likely when their bytes split across buffers and we convert them to strings before joining back together.

Fixes #2140.