### PR TITLE
Add a setting to ignore analyzer error codes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -998,6 +998,15 @@
 					},
 					"scope": "resource"
 				},
+				"dart.analysisIgnoredErrors": {
+					"type": "array",
+					"default": [],
+					"description": "An array of error codes to ignore from Dart analysis. This option should usually be set at the Workspace level.",
+					"items": {
+						"type": "string"
+					},
+					"scope": "window"
+				},
 				"dart.debugSdkLibraries": {
 					"type": "boolean",
 					"default": false,

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -94,6 +94,7 @@ class Config {
 	get showTestCodeLens(): boolean { return this.getConfig<boolean>("showTestCodeLens", true); }
 	get showDartPadSampleCodeLens(): boolean { return this.getConfig<boolean>("showDartPadSampleCodeLens", true); }
 	get showTodos(): boolean { return this.getConfig<boolean>("showTodos", true); }
+	get analysisIgnoredErrors(): string[] { return this.getConfig<string[]>("analysisIgnoredErrors", []); }
 	get triggerSignatureHelpAutomatically(): boolean { return this.getConfig<boolean>("triggerSignatureHelpAutomatically", false); }
 	get useKnownChromeOSPorts(): boolean { return this.getConfig<boolean>("useKnownChromeOSPorts", true); }
 	get warnWhenEditingFilesOutsideWorkspace(): boolean { return this.getConfig<boolean>("warnWhenEditingFilesOutsideWorkspace", true); }

--- a/src/extension/providers/dart_diagnostic_provider.ts
+++ b/src/extension/providers/dart_diagnostic_provider.ts
@@ -32,6 +32,8 @@ export class DartDiagnosticProvider {
 		let errors = notification.errors;
 		if (!config.showTodos)
 			errors = errors.filter((error) => error.type !== "TODO");
+		if (config.analysisIgnoredErrors.length > 0)
+			errors = errors.filter((error) => !config.analysisIgnoredErrors.includes(error.code));
 		this.diagnostics.set(
 			Uri.file(notification.file),
 			errors.map((e) => DartDiagnosticProvider.createDiagnostic(e)),


### PR DESCRIPTION
Intended as a work around for https://github.com/dart-archive/angular_analyzer_plugin/issues/524 , but useful for suppressing any unwanted analyzer warnings.