### PR TITLE
Update analyzer.ts

### DIFF
--- a/src/extension/analysis/analyzer.ts
+++ b/src/extension/analysis/analyzer.ts
@@ -39,7 +39,7 @@ function buildAnalyzerArgs(analyzerPath: string, dartCapabilities: DartCapabilit
 		analyzerArgs.push(`--port=${config.analyzerDiagnosticsPort}`);
 
 	// Add info about the extension that will be collected for crash reports etc.
-	analyzerArgs.push(`--client-id=Dart-Code.dart-code`);
+	analyzerArgs.push(`--client-id=VS-Code`);
 	analyzerArgs.push(`--client-version=${extensionVersion}`);
 
 	// The analysis server supports a verbose instrumentation log file.


### PR DESCRIPTION
- change the client ID we send in for analysis server analytics

This ID (not well documented) is meant to represent the general platform that the analysis server is running from. This might be something like IntelliJ, Android Studio, VS Code, gitpod, ...

The client version similarly should be related to the version of the platform (although this isn't as critical from an analytics point of view). It might be nice to have the VS Code version in here.

cc @DanTup 