### PR TITLE
Add support for running "pub outdated"

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,11 @@
 				}
 			},
 			{
+				"command": "pub.outdated",
+				"title": "List Outdated Packages",
+				"category": "Pub"
+			},
+			{
 				"command": "dart.attach",
 				"title": "Attach to Dart Process",
 				"category": "Debug"
@@ -240,6 +245,11 @@
 					"light": "./media/commands/pull.svg",
 					"dark": "./media/commands/pull-inverse.svg"
 				}
+			},
+			{
+				"command": "flutter.packages.outdated",
+				"title": "List Outdated Packages",
+				"category": "Flutter"
 			},
 			{
 				"command": "flutter.clean",
@@ -482,6 +492,10 @@
 					"when": "dart-code:dartProjectLoaded"
 				},
 				{
+					"command": "pub.outdated",
+					"when": "dart-code:dartProjectLoaded"
+				},
+				{
 					"command": "dart.startDebugging",
 					"when": "false"
 				},
@@ -567,6 +581,10 @@
 				},
 				{
 					"command": "flutter.packages.upgrade",
+					"when": "dart-code:anyFlutterProjectLoaded"
+				},
+				{
+					"command": "flutter.packages.outdated",
 					"when": "dart-code:anyFlutterProjectLoaded"
 				},
 				{
@@ -770,12 +788,20 @@
 					"command": "pub.upgrade"
 				},
 				{
+					"when": "resourceFilename == pubspec.yaml && dart-code:dartProjectLoaded && !dart-code:anyFlutterProjectLoaded",
+					"command": "pub.outdated"
+				},
+				{
 					"when": "resourceFilename == pubspec.yaml && dart-code:anyFlutterProjectLoaded",
 					"command": "flutter.packages.get"
 				},
 				{
 					"when": "resourceFilename == pubspec.yaml && dart-code:anyFlutterProjectLoaded",
 					"command": "flutter.packages.upgrade"
+				},
+				{
+					"when": "resourceFilename == pubspec.yaml && dart-code:anyFlutterProjectLoaded",
+					"command": "flutter.packages.outdated"
 				}
 			],
 			"explorer/context": [
@@ -788,12 +814,20 @@
 					"command": "pub.upgrade"
 				},
 				{
+					"when": "resourceFilename == pubspec.yaml && dart-code:dartProjectLoaded && !dart-code:anyFlutterProjectLoaded",
+					"command": "pub.outdated"
+				},
+				{
 					"when": "resourceFilename == pubspec.yaml && dart-code:anyFlutterProjectLoaded",
 					"command": "flutter.packages.get"
 				},
 				{
 					"when": "resourceFilename == pubspec.yaml && dart-code:anyFlutterProjectLoaded",
 					"command": "flutter.packages.upgrade"
+				},
+				{
+					"when": "resourceFilename == pubspec.yaml && dart-code:anyFlutterProjectLoaded",
+					"command": "flutter.packages.outdated"
 				},
 				{
 					"when": "resourceLangId == dart && dart-code:dartProjectLoaded && !inDebugMode",

--- a/package.json
+++ b/package.json
@@ -493,7 +493,7 @@
 				},
 				{
 					"command": "pub.outdated",
-					"when": "dart-code:dartProjectLoaded"
+					"when": "dart-code:dartProjectLoaded && dart-code:pubOutdatedSupported"
 				},
 				{
 					"command": "dart.startDebugging",
@@ -585,7 +585,7 @@
 				},
 				{
 					"command": "flutter.packages.outdated",
-					"when": "dart-code:anyFlutterProjectLoaded"
+					"when": "dart-code:anyFlutterProjectLoaded && dart-code:pubOutdatedSupported"
 				},
 				{
 					"command": "flutter.clean",
@@ -788,7 +788,7 @@
 					"command": "pub.upgrade"
 				},
 				{
-					"when": "resourceFilename == pubspec.yaml && dart-code:dartProjectLoaded && !dart-code:anyFlutterProjectLoaded",
+					"when": "resourceFilename == pubspec.yaml && dart-code:dartProjectLoaded && !dart-code:anyFlutterProjectLoaded && dart-code:pubOutdatedSupported",
 					"command": "pub.outdated"
 				},
 				{
@@ -800,7 +800,7 @@
 					"command": "flutter.packages.upgrade"
 				},
 				{
-					"when": "resourceFilename == pubspec.yaml && dart-code:anyFlutterProjectLoaded",
+					"when": "resourceFilename == pubspec.yaml && dart-code:anyFlutterProjectLoaded && dart-code:pubOutdatedSupported",
 					"command": "flutter.packages.outdated"
 				}
 			],
@@ -814,7 +814,7 @@
 					"command": "pub.upgrade"
 				},
 				{
-					"when": "resourceFilename == pubspec.yaml && dart-code:dartProjectLoaded && !dart-code:anyFlutterProjectLoaded",
+					"when": "resourceFilename == pubspec.yaml && dart-code:dartProjectLoaded && !dart-code:anyFlutterProjectLoaded && dart-code:pubOutdatedSupported",
 					"command": "pub.outdated"
 				},
 				{
@@ -826,7 +826,7 @@
 					"command": "flutter.packages.upgrade"
 				},
 				{
-					"when": "resourceFilename == pubspec.yaml && dart-code:anyFlutterProjectLoaded",
+					"when": "resourceFilename == pubspec.yaml && dart-code:anyFlutterProjectLoaded && dart-code:pubOutdatedSupported",
 					"command": "flutter.packages.outdated"
 				},
 				{

--- a/src/extension/commands/sdk.ts
+++ b/src/extension/commands/sdk.ts
@@ -80,7 +80,7 @@ export class SdkCommands {
 				uri = vs.Uri.file(uri);
 
 			if (util.isInsideFlutterProject(uri))
-				return this.runFlutter(["packages", "outdated"], uri, true);
+				return this.runFlutter(["pub", "outdated"], uri, true);
 			else
 				return this.runPub(["outdated"], uri, true);
 		}));

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -4,7 +4,7 @@ import { isArray } from "util";
 import * as vs from "vscode";
 import { Analyzer } from "../shared/analyzer";
 import { DaemonCapabilities, FlutterCapabilities } from "../shared/capabilities/flutter";
-import { dartPlatformName, flutterExtensionIdentifier, flutterPath, HAS_LAST_DEBUG_CONFIG, isWin, IS_LSP_CONTEXT, IS_RUNNING_LOCALLY_CONTEXT, platformDisplayName } from "../shared/constants";
+import { dartPlatformName, flutterExtensionIdentifier, flutterPath, HAS_LAST_DEBUG_CONFIG, isWin, IS_LSP_CONTEXT, IS_RUNNING_LOCALLY_CONTEXT, platformDisplayName, PUB_OUTDATED_SUPPORTED_CONTEXT } from "../shared/constants";
 import { LogCategory } from "../shared/enums";
 import { WebClient } from "../shared/fetch";
 import { DartWorkspaceContext, FlutterSdks, IFlutterDaemon, Sdks } from "../shared/interfaces";
@@ -192,6 +192,7 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 		checkForStandardDartSdkUpdates(logger, workspaceContext);
 		context.subscriptions.push(new StatusBarVersionTracker(workspaceContext));
 	}
+	vs.commands.executeCommand("setContext", PUB_OUTDATED_SUPPORTED_CONTEXT, dartCapabilities.supportsPubOutdated);
 
 	if (config.previewLsp || process.env.DART_CODE_FORCE_LSP) {
 		isUsingLsp = true;

--- a/src/extension/sdk/capabilities.ts
+++ b/src/extension/sdk/capabilities.ts
@@ -17,6 +17,7 @@ export class DartCapabilities {
 	get handlesPathsEverywhereForBreakpoints() { return versionIsAtLeast(this.version, "2.2.1-edge"); }
 	get supportsDisableServiceTokens() { return versionIsAtLeast(this.version, "2.2.1-dev.4.2"); }
 	get supportsWriteServiceInfo() { return versionIsAtLeast(this.version, "2.7.1"); }
+	get supportsPubOutdated() { return versionIsAtLeast(this.version, "2.8.0-a"); }
 	// TODO: Update this (along with Flutter) when supported.
 	get webSupportsEvaluation() { return false; }
 	get webSupportsDebugging() { return false; }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -37,6 +37,7 @@ export const DART_DEP_PACKAGE_NODE_CONTEXT = "dart-code:depPackageNode";
 export const DART_DEP_FOLDER_NODE_CONTEXT = "dart-code:depFolderNode";
 export const DART_DEP_FILE_NODE_CONTEXT = "dart-code:depFileNode";
 export const DART_IS_CAPTURING_LOGS_CONTEXT = "dart-code:isCapturingLogs";
+export const PUB_OUTDATED_SUPPORTED_CONTEXT = "dart-code:pubOutdatedSupported";
 
 export const IS_RUNNING_LOCALLY_CONTEXT = "dart-code:isRunningLocally";
 

--- a/src/shared/vscode/interfaces.ts
+++ b/src/shared/vscode/interfaces.ts
@@ -43,6 +43,7 @@ export interface InternalExtensionApi {
 		handlesBreakpointsInPartFiles: boolean;
 		hasDocumentationInCompletions: boolean;
 		supportsDisableServiceTokens: boolean;
+		supportsPubOutdated: boolean;
 		webSupportsDebugging: boolean;
 		webSupportsEvaluation: boolean;
 	};

--- a/src/test/dart/commands/outdated.test.ts
+++ b/src/test/dart/commands/outdated.test.ts
@@ -1,11 +1,16 @@
 import * as assert from "assert";
 import * as vs from "vscode";
 import { pubExecutableName } from "../../../shared/constants";
-import { activate, captureOutput, getPackages } from "../../helpers";
+import { activate, captureOutput, extApi, getPackages } from "../../helpers";
 
 describe("pub outdated", () => {
 	before("get packages", () => getPackages());
 	beforeEach("activate", () => activate());
+
+	beforeEach("skip if not supported", function () {
+		if (!extApi.dartCapabilities.supportsPubOutdated)
+			this.skip();
+	});
 
 	it("runs and prints output", async () => {
 		const buffer = captureOutput("pub");

--- a/src/test/dart/commands/outdated.test.ts
+++ b/src/test/dart/commands/outdated.test.ts
@@ -1,0 +1,19 @@
+import * as assert from "assert";
+import * as vs from "vscode";
+import { pubExecutableName } from "../../../shared/constants";
+import { activate, captureOutput, getPackages } from "../../helpers";
+
+describe("pub outdated", () => {
+	before("get packages", () => getPackages());
+	beforeEach("activate", () => activate());
+
+	it("runs and prints output", async () => {
+		const buffer = captureOutput("pub");
+		const exitCode = await vs.commands.executeCommand("pub.outdated");
+		assert.equal(exitCode, 0);
+
+		const output = buffer.buffer.join("").trim();
+		assert.equal(output.startsWith(`[hello_world] ${pubExecutableName} outdated`), true);
+		assert.equal(output.endsWith("exit code 0"), true);
+	});
+});

--- a/src/test/flutter/commands/outdated.test.ts
+++ b/src/test/flutter/commands/outdated.test.ts
@@ -19,7 +19,7 @@ describe("flutter packages outdated", () => {
 		assert.equal(exitCode, 0);
 
 		const output = buffer.buffer.join("").trim();
-		assert.equal(output.startsWith(`[flutter_hello_world] ${flutterExecutableName} --suppress-analytics packages outdated`), true);
+		assert.equal(output.startsWith(`[flutter_hello_world] ${flutterExecutableName} --suppress-analytics pub outdated`), true);
 		assert.equal(output.endsWith("exit code 0"), true);
 	});
 });

--- a/src/test/flutter/commands/outdated.test.ts
+++ b/src/test/flutter/commands/outdated.test.ts
@@ -1,20 +1,20 @@
 import * as assert from "assert";
 import * as vs from "vscode";
 import { flutterExecutableName } from "../../../shared/constants";
-import { activate, captureOutput } from "../../helpers";
+import { activate, captureOutput, getPackages } from "../../helpers";
 
-describe("flutter doctor", () => {
+describe("flutter packages outdated", () => {
 
+	before("get packages", () => getPackages());
 	beforeEach("activate", () => activate());
 
 	it("runs and prints output", async () => {
 		const buffer = captureOutput("flutter");
-		const exitCode = await vs.commands.executeCommand("flutter.doctor");
+		const exitCode = await vs.commands.executeCommand("flutter.packages.outdated");
 		assert.equal(exitCode, 0);
 
 		const output = buffer.buffer.join("").trim();
-		assert.equal(output.startsWith(`[flutter] ${flutterExecutableName} --suppress-analytics doctor -v`), true);
-		assert.notEqual(output.indexOf("] Flutter (Channel"), -1);
+		assert.equal(output.startsWith(`[flutter_hello_world] ${flutterExecutableName} --suppress-analytics packages outdated`), true);
 		assert.equal(output.endsWith("exit code 0"), true);
 	});
 });

--- a/src/test/flutter/commands/outdated.test.ts
+++ b/src/test/flutter/commands/outdated.test.ts
@@ -1,12 +1,17 @@
 import * as assert from "assert";
 import * as vs from "vscode";
 import { flutterExecutableName } from "../../../shared/constants";
-import { activate, captureOutput, getPackages } from "../../helpers";
+import { activate, captureOutput, extApi, getPackages } from "../../helpers";
 
 describe("flutter packages outdated", () => {
 
 	before("get packages", () => getPackages());
 	beforeEach("activate", () => activate());
+
+	beforeEach("skip if not supported", function () {
+		if (!extApi.dartCapabilities.supportsPubOutdated)
+			this.skip();
+	});
 
 	it("runs and prints output", async () => {
 		const buffer = captureOutput("flutter");


### PR DESCRIPTION
- [x] Use a context to hide the commands if it's not supported
- [x] Skip tests if current SDK doesn't support it

Fixes #2322, though there may be ways we can integrate this better than just dumping the text to an output window (using `--json`).