### PR TITLE
Add code lens for main methods inc templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1182,6 +1182,12 @@
 					"description": "Whether to insert argument placeholders during code completions. This feature is automatically disabled when enableCompletionCommitCharacters is enabled.",
 					"scope": "resource"
 				},
+				"dart.showMainCodeLens": {
+					"type": "boolean",
+					"default": true,
+					"description": "Whether to show CodeLens actions in the editor for quick running/debugging scripts with main methods.",
+					"scope": "window"
+				},
 				"dart.showTestCodeLens": {
 					"type": "boolean",
 					"default": true,
@@ -1668,10 +1674,12 @@
 								"default": "default"
 							},
 							"template": {
-								"description": "Uses this launch configuration as a template for launching tests.",
+								"description": "Uses this launch configuration as a template for launching scripts and tests.",
 								"enum": [
 									"run-test",
-									"debug-test"
+									"debug-test",
+									"run-file",
+									"debug-file"
 								]
 							},
 							"args": {

--- a/src/extension/code_lens/main_code_lens_provider.ts
+++ b/src/extension/code_lens/main_code_lens_provider.ts
@@ -1,0 +1,62 @@
+import { CancellationToken, CodeLens, CodeLensProvider, Event, EventEmitter, TextDocument, workspace } from "vscode";
+import { IAmDisposable, Logger } from "../../shared/interfaces";
+import { toRange } from "../../shared/vscode/utils";
+import { DasAnalyzer } from "../analysis/analyzer_das";
+
+export class MainCodeLensProvider implements CodeLensProvider, IAmDisposable {
+	private disposables: IAmDisposable[] = [];
+	private onDidChangeCodeLensesEmitter: EventEmitter<void> = new EventEmitter<void>();
+	public readonly onDidChangeCodeLenses: Event<void> = this.onDidChangeCodeLensesEmitter.event;
+
+	constructor(private readonly logger: Logger, private readonly analyzer: DasAnalyzer) {
+		this.disposables.push(this.analyzer.client.registerForAnalysisOutline((n) => {
+			this.onDidChangeCodeLensesEmitter.fire();
+		}));
+	}
+
+	public provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | undefined {
+		// This method has to be FAST because it affects layout of the document (adds extra lines) so
+		// we don't already have an outline, we won't wait for one. A new outline arriving will trigger a
+		// re-request anyway.
+		const outline = this.analyzer.fileTracker.getOutlineFor(document.uri);
+		if (!outline || !outline.children || !outline.children.length)
+			return;
+
+		const runConfigs = workspace.getConfiguration("launch", document.uri).get<any[]>("configurations") || [];
+		const runFileTemplates = runConfigs.filter((c) => c && c.type === "dart" && c.template && (c.template === "run-file" || c.template === "debug-file"));
+
+		const mainMethod = outline.children?.find((o) => o.element.name === "main");
+		if (!mainMethod)
+			return;
+
+		return [
+			new CodeLens(
+				toRange(document, mainMethod.offset, mainMethod.length),
+				{
+					arguments: [document.uri],
+					command: "dart.startWithoutDebugging",
+					title: "Run",
+				},
+			),
+			new CodeLens(
+				toRange(document, mainMethod.offset, mainMethod.length),
+				{
+					arguments: [document.uri],
+					command: "dart.startDebugging",
+					title: "Debug",
+				},
+			),
+		].concat(runFileTemplates.map((t) => new CodeLens(
+			toRange(document, mainMethod.offset, mainMethod.length),
+			{
+				arguments: [document.uri, t],
+				command: t.template === "run-file" ? "dart.startWithoutDebugging" : "dart.startDebugging",
+				title: t.name,
+			},
+		)));
+	}
+
+	public dispose(): any {
+		this.disposables.forEach((d) => d.dispose());
+	}
+}

--- a/src/extension/code_lens/main_code_lens_provider_lsp.ts
+++ b/src/extension/code_lens/main_code_lens_provider_lsp.ts
@@ -1,0 +1,62 @@
+import { CancellationToken, CodeLens, CodeLensProvider, Event, EventEmitter, TextDocument, workspace } from "vscode";
+import { IAmDisposable, Logger } from "../../shared/interfaces";
+import { lspToRange } from "../../shared/vscode/utils";
+import { LspAnalyzer } from "../analysis/analyzer_lsp";
+
+export class LspMainCodeLensProvider implements CodeLensProvider, IAmDisposable {
+	private disposables: IAmDisposable[] = [];
+	private onDidChangeCodeLensesEmitter: EventEmitter<void> = new EventEmitter<void>();
+	public readonly onDidChangeCodeLenses: Event<void> = this.onDidChangeCodeLensesEmitter.event;
+
+	constructor(private readonly logger: Logger, private readonly analyzer: LspAnalyzer) {
+		this.disposables.push(this.analyzer.fileTracker.onOutline.listen((_) => {
+			this.onDidChangeCodeLensesEmitter.fire();
+		}));
+	}
+
+	public provideCodeLenses(document: TextDocument, token: CancellationToken): CodeLens[] | undefined {
+		// This method has to be FAST because it affects layout of the document (adds extra lines) so
+		// we don't already have an outline, we won't wait for one. A new outline arriving will trigger a
+		// re-request anyway.
+		const outline = this.analyzer.fileTracker.getOutlineFor(document.uri);
+		if (!outline || !outline.children || !outline.children.length)
+			return;
+
+		const runConfigs = workspace.getConfiguration("launch", document.uri).get<any[]>("configurations") || [];
+		const runFileTemplates = runConfigs.filter((c) => c && c.type === "dart" && c.template && (c.template === "run-file" || c.template === "debug-file"));
+
+		const mainMethod = outline.children?.find((o) => o.element.name === "main");
+		if (!mainMethod)
+			return;
+
+		return [
+			new CodeLens(
+				lspToRange(mainMethod.range),
+				{
+					arguments: [document.uri],
+					command: "dart.startWithoutDebugging",
+					title: "Run",
+				},
+			),
+			new CodeLens(
+				lspToRange(mainMethod.range),
+				{
+					arguments: [document.uri],
+					command: "dart.startDebugging",
+					title: "Debug",
+				},
+			),
+		].concat(runFileTemplates.map((t) => new CodeLens(
+			lspToRange(mainMethod.range),
+			{
+				arguments: [document.uri, t],
+				command: t.template === "run-file" ? "dart.startWithoutDebugging" : "dart.startDebugging",
+				title: t.name,
+			},
+		)));
+	}
+
+	public dispose(): any {
+		this.disposables.forEach((d) => d.dispose());
+	}
+}

--- a/src/extension/commands/debug.ts
+++ b/src/extension/commands/debug.ts
@@ -144,22 +144,26 @@ export class DebugCommands {
 			debugSessions.forEach((s) => s.session.customRequest("hotRestart", args));
 			analytics.logDebuggerRestart();
 		}));
-		context.subscriptions.push(vs.commands.registerCommand("dart.startDebugging", (resource: vs.Uri) => {
-			vs.debug.startDebugging(vs.workspace.getWorkspaceFolder(resource), {
-				name: "Dart",
-				program: fsPath(resource),
-				request: "launch",
-				type: "dart",
-			});
+		context.subscriptions.push(vs.commands.registerCommand("dart.startDebugging", (resource: vs.Uri, launchTemplate: any | undefined) => {
+			const launchConfig = Object.assign(
+				{},
+				launchTemplate,
+				{
+					program: fsPath(resource),
+				},
+			);
+			vs.debug.startDebugging(vs.workspace.getWorkspaceFolder(resource), launchConfig);
 		}));
-		context.subscriptions.push(vs.commands.registerCommand("dart.startWithoutDebugging", (resource: vs.Uri) => {
-			vs.debug.startDebugging(vs.workspace.getWorkspaceFolder(resource), {
-				name: "Dart",
-				noDebug: true,
-				program: fsPath(resource),
-				request: "launch",
-				type: "dart",
-			});
+		context.subscriptions.push(vs.commands.registerCommand("dart.startWithoutDebugging", (resource: vs.Uri, launchTemplate: any | undefined) => {
+			const launchConfig = Object.assign(
+				{},
+				launchTemplate,
+				{
+					noDebug: true,
+					program: fsPath(resource),
+				},
+			);
+			vs.debug.startDebugging(vs.workspace.getWorkspaceFolder(resource), launchConfig);
 		}));
 		context.subscriptions.push(vs.commands.registerCommand("dart.runAllTestsWithoutDebugging", async () => {
 			const topLevelFolders = getDartWorkspaceFolders().map((w) => fsPath(w.uri));

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -92,6 +92,7 @@ class Config {
 	get sdkPath(): undefined | string { return resolvePaths(this.getConfig<null | string>("sdkPath", null)); }
 	get sdkPaths(): string[] { return this.getConfig<string[]>("sdkPaths", []).map(resolvePaths); }
 	get showIgnoreQuickFixes(): boolean { return this.getConfig<boolean>("showIgnoreQuickFixes", false); }
+	get showMainCodeLens(): boolean { return this.getConfig<boolean>("showMainCodeLens", true); }
 	get showTestCodeLens(): boolean { return this.getConfig<boolean>("showTestCodeLens", true); }
 	get showDartPadSampleCodeLens(): boolean { return this.getConfig<boolean>("showDartPadSampleCodeLens", true); }
 	get showTodos(): boolean { return this.getConfig<boolean>("showTodos", true); }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -27,6 +27,8 @@ import { FileChangeHandler } from "./analysis/file_change_handler";
 import { Analytics } from "./analytics";
 import { DartExtensionApi } from "./api";
 import { FlutterDartPadSamplesCodeLensProvider } from "./code_lens/flutter_dartpad_samples";
+import { MainCodeLensProvider } from "./code_lens/main_code_lens_provider";
+import { LspMainCodeLensProvider } from "./code_lens/main_code_lens_provider_lsp";
 import { TestCodeLensProvider } from "./code_lens/test_code_lens_provider";
 import { LspTestCodeLensProvider } from "./code_lens/test_code_lens_provider_lsp";
 import { AnalyzerCommands } from "./commands/analyzer";
@@ -288,6 +290,11 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 		context.subscriptions.push(vs.languages.registerCodeActionsProvider(DART_MODE, new SourceCodeActionProvider(), SourceCodeActionProvider.metadata));
 		context.subscriptions.push(vs.languages.registerImplementationProvider(DART_MODE, new DartImplementationProvider(dasAnalyzer)));
 
+		if (config.showMainCodeLens) {
+			const codeLensProvider = new MainCodeLensProvider(logger, dasAnalyzer);
+			context.subscriptions.push(codeLensProvider);
+			context.subscriptions.push(vs.languages.registerCodeLensProvider(DART_MODE, codeLensProvider));
+		}
 		if (config.showTestCodeLens) {
 			const codeLensProvider = new TestCodeLensProvider(logger, dasAnalyzer);
 			context.subscriptions.push(codeLensProvider);
@@ -300,6 +307,11 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 		}
 	}
 	if (isUsingLsp && lspClient && lspAnalyzer) {
+		if (config.showMainCodeLens) {
+			const codeLensProvider = new LspMainCodeLensProvider(logger, lspAnalyzer);
+			context.subscriptions.push(codeLensProvider);
+			context.subscriptions.push(vs.languages.registerCodeLensProvider(DART_MODE, codeLensProvider));
+		}
 		if (config.showTestCodeLens) {
 			const codeLensProvider = new LspTestCodeLensProvider(logger, lspAnalyzer);
 			context.subscriptions.push(codeLensProvider);

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -763,6 +763,7 @@ function getSettingsThatRequireRestart() {
 		+ config.closingLabels
 		+ config.analyzeAngularTemplates
 		+ config.analysisServerFolding
+		+ config.showMainCodeLens
 		+ config.showTestCodeLens
 		+ config.previewBuildRunnerTasks
 		+ config.flutterOutline

--- a/src/test/dart/providers/main_code_lens_provider.test.ts
+++ b/src/test/dart/providers/main_code_lens_provider.test.ts
@@ -1,0 +1,85 @@
+import * as assert from "assert";
+import * as vs from "vscode";
+import { fsPath } from "../../../shared/utils/fs";
+import { activate, addLaunchConfigsForTest, extApi, getCodeLens, getPackages, helloWorldMainFile, openFile, positionOf, waitForResult } from "../../helpers";
+
+describe("main_code_lens", () => {
+	before("get packages", () => getPackages());
+	beforeEach("activate", () => activate());
+
+	it("includes run/debug actions for main methods", async function () {
+		const editor = await openFile(helloWorldMainFile);
+		await waitForResult(() => !!extApi.fileTracker.getOutlineFor(helloWorldMainFile));
+
+		const fileCodeLens = await getCodeLens(editor.document);
+		const mainMethodPos = positionOf(`main^() async {`);
+
+		const codeLensForMainMethod = fileCodeLens.filter((cl) => cl.range.start.line === mainMethodPos.line);
+		assert.equal(codeLensForMainMethod.length, 2);
+
+		if (!codeLensForMainMethod[0].command) {
+			// If there's no command, skip the test. This happens very infrequently and appears to be a VS Code
+			// race condition. Rather than failing our test runs, skip.
+			// TODO: Remove this if https://github.com/microsoft/vscode/issues/79805 gets a reliable fix.
+			this.skip();
+			return;
+		}
+
+		const runAction = codeLensForMainMethod.find((cl) => cl.command!.title === "Run")!;
+		assert.equal(runAction!.command!.command, "dart.startWithoutDebugging");
+		assert.equal(fsPath(runAction!.command!.arguments![0]), fsPath(helloWorldMainFile));
+
+		const debugAction = codeLensForMainMethod.find((cl) => cl.command!.title === "Debug");
+		assert.equal(debugAction!.command!.command, "dart.startDebugging");
+		assert.equal(fsPath(debugAction!.command!.arguments![0]), fsPath(helloWorldMainFile));
+	});
+
+	it("includes custom run/debug actions from launch templates for files", async function () {
+		await addLaunchConfigsForTest(
+			vs.workspace.workspaceFolders![0].uri,
+			[
+				{
+					console: "terminal",
+					name: "Run in Terminal",
+					request: "launch",
+					template: "run-file",
+					type: "dart",
+				},
+				{
+					console: "terminal",
+					name: "Debug in Terminal",
+					request: "launch",
+					template: "debug-file",
+					type: "dart",
+				},
+			],
+		);
+
+		const editor = await openFile(helloWorldMainFile);
+		await waitForResult(() => !!extApi.fileTracker.getOutlineFor(helloWorldMainFile));
+
+		const fileCodeLens = await getCodeLens(editor.document);
+		const mainMethodPos = positionOf(`main^() async {`);
+
+		const codeLensForMainMethod = fileCodeLens.filter((cl) => cl.range.start.line === mainMethodPos.line);
+		assert.equal(codeLensForMainMethod.length, 4);
+
+		if (!codeLensForMainMethod[0].command) {
+			// If there's no command, skip the test. This happens very infrequently and appears to be a VS Code
+			// race condition. Rather than failing our test runs, skip.
+			// TODO: Remove this if https://github.com/microsoft/vscode/issues/79805 gets a reliable fix.
+			this.skip();
+			return;
+		}
+
+		const runAction = codeLensForMainMethod.find((cl) => cl.command!.title === "Run in Terminal")!;
+		assert.equal(runAction!.command!.command, "dart.startWithoutDebugging");
+		assert.equal(fsPath(runAction!.command!.arguments![0]), fsPath(helloWorldMainFile));
+		assert.equal(runAction!.command!.arguments![1].console, "terminal");
+
+		const debugAction = codeLensForMainMethod.find((cl) => cl.command!.title === "Debug in Terminal");
+		assert.equal(debugAction!.command!.command, "dart.startDebugging");
+		assert.equal(fsPath(debugAction!.command!.arguments![0]), fsPath(helloWorldMainFile));
+		assert.equal(debugAction!.command!.arguments![1].console, "terminal");
+	});
+});

--- a/src/test/dart/providers/test_code_lens_provider.test.ts
+++ b/src/test/dart/providers/test_code_lens_provider.test.ts
@@ -42,7 +42,7 @@ describe("test_code_lens", () => {
 		const fileCodeLens = await getCodeLens(editor.document);
 		const groupPos = positionOf("group^(");
 
-		const codeLensForGroup = fileCodeLens.filter((cl) => cl.range.contains(groupPos));
+		const codeLensForGroup = fileCodeLens.filter((cl) => cl.range.start.line === groupPos.line);
 		assert.equal(codeLensForGroup.length, 2);
 
 		const runAction = codeLensForGroup.find((cl) => cl.command!.title === "Run");
@@ -134,7 +134,7 @@ describe("test_code_lens", () => {
 		const fileCodeLens = await getCodeLens(editor.document);
 		const groupPos = positionOf("group^(");
 
-		const codeLensForGroup = fileCodeLens.filter((cl) => cl.range.contains(groupPos));
+		const codeLensForGroup = fileCodeLens.filter((cl) => cl.range.start.line === groupPos.line);
 		assert.equal(codeLensForGroup.length, 4);
 
 		if (!codeLensForGroup[0].command) {


### PR DESCRIPTION
Fixes #2356.

Can be turned off with the `dart.showMainCodeLens` setting.