### PR TITLE
Remove the hardcoded repo name from the workflow logic

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
     # by the push to the branch.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'Dart-Code/Dart-Code'
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
As mentioned on https://github.community/t5/GitHub-Actions/Duplicate-checks-on-quot-push-quot-and-quot-pull-request-quot/m-p/54956#M9370, this should work with a pull request from a fork. Fingers crossed.