### PR TITLE
Update references to "Observatory" to "VM Service" where appropriate

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
 	"dart.flutterTestLogFile": "logs/flutter_test.txt",
 	"dart.pubTestLogFile": "logs/pub_test.txt",
 	"dart.flutterDaemonLogFile": "logs/flutter_daemon.txt",
-	"dart.observatoryLogFile": "logs/observatory.txt",
+	"dart.vmServiceLogFile": "logs/observatory.txt",
 	"dart.analysisExcludedFolders": [
 		"test/test_projects/dart_create_template",
 		"test/test_projects/flutter_create_basic",

--- a/package.json
+++ b/package.json
@@ -1442,13 +1442,13 @@
 					"description": "The path to a log file for communication between Dart Code and the analysis server.",
 					"scope": "machine-overridable"
 				},
-				"dart.analyzerObservatoryPort": {
+				"dart.analyzerVmServicePort": {
 					"type": [
 						"null",
 						"number"
 					],
 					"default": null,
-					"description": "The port number to be used for the Dart analysis server observatory.",
+					"description": "The port number to be used for the Dart analysis server VM service.",
 					"scope": "window"
 				},
 				"dart.analyzerPath": {
@@ -1521,19 +1521,19 @@
 					"description": "The path to a log file for 'pub run test' runs. This is useful when trying to diagnose issues with unit test executions. Use ${name} in the log file name to prevent concurrent debug sessions overwriting each others logs.",
 					"scope": "machine-overridable"
 				},
-				"dart.observatoryLogFile": {
+				"dart.vmServiceLogFile": {
 					"type": [
 						"null",
 						"string"
 					],
 					"default": null,
-					"description": "The path to a log file for communication between Dart Code and Observatory (the VM debugger). This is useful when trying to diagnose issues with debugging such as missed breakpoints. Use ${name} in the log file name to prevent concurrent debug sessions overwriting each others logs.",
+					"description": "The path to a log file for communication between Dart Code and the VM service. This is useful when trying to diagnose issues with debugging such as missed breakpoints. Use ${name} in the log file name to prevent concurrent debug sessions overwriting each others logs.",
 					"scope": "machine-overridable"
 				},
 				"dart.useKnownChromeOSPorts": {
 					"type": "boolean",
 					"default": true,
-					"description": "Whether to use specific ports for Observatory and DevTools when running in Chrome OS. This is required to connect from the native Chrome OS browser but will prevent apps from launching if the ports are already in-use (for example if trying to run a second app).",
+					"description": "Whether to use specific ports for the VM service and DevTools when running in Chrome OS. This is required to connect from the native Chrome OS browser but will prevent apps from launching if the ports are already in-use (for example if trying to run a second app).",
 					"scope": "window"
 				},
 				"dart.webDaemonLogFile": {
@@ -1788,13 +1788,13 @@
 								"type": "string",
 								"description": "Path to the packages file (only required if cannot be discovered from the running process automatically)."
 							},
-							"observatoryUri": {
+							"vmServiceUri": {
 								"type": "string",
-								"description": "URI of the Observatory instance to attach to."
+								"description": "URI of the VM service to attach to."
 							},
 							"serviceInfoFile": {
 								"type": "string",
-								"description": "File to read (expected to be written with --write-service-info) VM service details from if observatoryUri is not supplied."
+								"description": "File to read (expected to be written with --write-service-info) VM service details from if vmServiceUri is not supplied."
 							}
 						}
 					}

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -95,7 +95,6 @@ export class DartDebugSession extends DebugSession {
 	protected logCategory = LogCategory.General; // This isn't used as General, since both debuggers override it.
 	protected supportsRunInTerminalRequest = false;
 	protected supportsDebugInternalLibraries = false;
-	// protected observatoryUriIsProbablyReconnectable = false;
 	protected isTerminating = false;
 	protected readonly logger = new DebugAdapterLogger(this, LogCategory.VmService);
 
@@ -248,7 +247,7 @@ export class DartDebugSession extends DebugSession {
 		this.debugSdkLibraries = args.debugSdkLibraries;
 		this.evaluateGettersInDebugViews = args.evaluateGettersInDebugViews;
 		this.evaluateToStringInDebugViews = args.evaluateToStringInDebugViews;
-		this.logFile = args.observatoryLogFile;
+		this.logFile = args.vmServiceLogFile;
 		this.maxLogLineLength = args.maxLogLineLength;
 		this.sendLogsToClient = !!args.sendLogsToClient;
 		this.showDartDeveloperLogs = args.showDartDeveloperLogs;
@@ -257,18 +256,18 @@ export class DartDebugSession extends DebugSession {
 	}
 
 	protected async attachRequest(response: DebugProtocol.AttachResponse, args: DartAttachRequestArguments): Promise<void> {
-		if (!args || (!args.observatoryUri && !args.serviceInfoFile)) {
+		const vmServiceUri = (args.vmServiceUri || args.observatoryUri);
+		if (!args || (!vmServiceUri && !args.serviceInfoFile)) {
 			return this.errorResponse(response, "Unable to attach; no VM service address or service info file provided.");
 		}
 
 		this.sendEvent(new ProgressStartEvent(debugLaunchProgressId, "Waiting for application"));
 
-		// this.observatoryUriIsProbablyReconnectable = true;
 		this.shouldKillProcessOnTerminate = false;
 		this.cwd = args.cwd;
 		this.readSharedArgs(args);
 
-		this.log(`Attaching to process via ${args.observatoryUri || args.serviceInfoFile}`);
+		this.log(`Attaching to process via ${vmServiceUri || args.serviceInfoFile}`);
 
 		// If we were given an explicity packages path, use it (otherwise we'll try
 		// to extract from the VM)
@@ -288,8 +287,8 @@ export class DartDebugSession extends DebugSession {
 
 		let url: string | undefined;
 		try {
-			if (args.observatoryUri) {
-				url = this.websocketUriForObservatoryUri(args.observatoryUri);
+			if (vmServiceUri) {
+				url = this.websocketUriForObservatoryUri(vmServiceUri);
 			} else {
 				this.vmServiceInfoFile = args.serviceInfoFile;
 				this.sendEvent(new ProgressUpdateEvent(debugLaunchProgressId, `Waiting for ${this.vmServiceInfoFile}…`));
@@ -488,11 +487,6 @@ export class DartDebugSession extends DebugSession {
 		}
 
 		this.sendEvent(new Event("dart.debuggerUris", {
-			// If we won't be killing the process on terminate, then it's likely the
-			// process will remain around and can be reconnected to, so let the
-			// editor know that it should stash this URL for easier re-attaching.
-			// isProbablyReconnectable: this.observatoryUriIsProbablyReconnectable,
-
 			// If we don't support Observatory, don't send its URL back to the editor.
 			observatoryUri: this.supportsObservatory ? browserFriendlyUri.toString() : undefined,
 			vmServiceUri: browserFriendlyUri.toString(),

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -15,7 +15,7 @@ import { errorString, notUndefined, PromiseCompleter, uniq, uriToFilePath } from
 import { sortBy } from "../shared/utils/array";
 import { applyColor, grey, grey2 } from "../shared/utils/colors";
 import { getRandomInt } from "../shared/utils/fs";
-import { DebuggerResult, ObservatoryConnection, Version, VM, VMClass, VMClassRef, VMErrorRef, VMEvent, VMFrame, VMInstance, VMInstanceRef, VMIsolate, VMIsolateRef, VMMapEntry, VMObj, VMScript, VMScriptRef, VMSentinel, VMStack, VMTypeRef } from "./dart_debug_protocol";
+import { DebuggerResult, Version, VM, VMClass, VMClassRef, VMErrorRef, VMEvent, VMFrame, VMInstance, VMInstanceRef, VMIsolate, VMIsolateRef, VMMapEntry, VMObj, VMScript, VMScriptRef, VMSentinel, VmServiceConnection, VMStack, VMTypeRef } from "./dart_debug_protocol";
 import { DebugAdapterLogger } from "./logging";
 import { ThreadInfo, ThreadManager } from "./threads";
 import { DartAttachRequestArguments, DartLaunchRequestArguments, FileLocation, formatPathForVm } from "./utils";
@@ -48,9 +48,9 @@ export class DartDebugSession extends DebugSession {
 
 	protected expectAdditionalPidToTerminate = false;
 	private additionalPidCompleter = new PromiseCompleter<void>();
-	// We normally track the pid from Observatory to terminate the VM afterwards, but for Flutter Run it's
+	// We normally track the pid from the VM service to terminate the VM afterwards, but for Flutter Run it's
 	// a remote PID and therefore doesn't make sense to try and terminate.
-	protected allowTerminatingObservatoryVmPid = true;
+	protected allowTerminatingVmServicePid = true;
 	// Normally we don't connect to the VM when running no noDebug mode, but for
 	// Flutter, this means we can't call service extensions (for ex. toggling
 	// debug modes) so we allow it to override this (and then we skip things
@@ -61,7 +61,7 @@ export class DartDebugSession extends DebugSession {
 	protected connectVmEvenForNoDebug = false;
 	protected allowWriteServiceInfo = true;
 	protected processExited = false;
-	public observatory?: ObservatoryConnection;
+	public vmService?: VmServiceConnection;
 	protected cwd?: string;
 	public noDebug?: boolean;
 	private logFile?: string;
@@ -97,7 +97,7 @@ export class DartDebugSession extends DebugSession {
 	protected supportsDebugInternalLibraries = false;
 	// protected observatoryUriIsProbablyReconnectable = false;
 	protected isTerminating = false;
-	protected readonly logger = new DebugAdapterLogger(this, LogCategory.Observatory);
+	protected readonly logger = new DebugAdapterLogger(this, LogCategory.VmService);
 
 	protected get shouldConnectDebugger() {
 		return !this.noDebug || this.connectVmEvenForNoDebug;
@@ -187,7 +187,7 @@ export class DartDebugSession extends DebugSession {
 				process.stdout.setEncoding("utf8");
 				process.stdout.on("data", async (data) => {
 					let match: RegExpExecArray | null = null;
-					if (this.shouldConnectDebugger && this.parseObservatoryUriFromStdOut && !this.observatory) {
+					if (this.shouldConnectDebugger && this.parseObservatoryUriFromStdOut && !this.vmService) {
 						match = observatoryListeningBannerPattern.exec(data.toString());
 					}
 					if (match) {
@@ -258,7 +258,7 @@ export class DartDebugSession extends DebugSession {
 
 	protected async attachRequest(response: DebugProtocol.AttachResponse, args: DartAttachRequestArguments): Promise<void> {
 		if (!args || (!args.observatoryUri && !args.serviceInfoFile)) {
-			return this.errorResponse(response, "Unable to attach; no Observatory address or service info file provided.");
+			return this.errorResponse(response, "Unable to attach; no VM service address or service info file provided.");
 		}
 
 		this.sendEvent(new ProgressStartEvent(debugLaunchProgressId, "Waiting for application"));
@@ -399,7 +399,7 @@ export class DartDebugSession extends DebugSession {
 		}
 
 		if (this.sendLogsToClient)
-			this.sendEvent(new Event("dart.log", { message, severity, category: LogCategory.Observatory } as LogMessage));
+			this.sendEvent(new Event("dart.log", { message, severity, category: LogCategory.VmService } as LogMessage));
 	}
 
 	private startServiceFilePolling(): Promise<string> {
@@ -504,41 +504,41 @@ export class DartDebugSession extends DebugSession {
 		return new Promise<void>((resolve, reject) => {
 			this.log(`Connecting to VM Service at ${uri}`);
 			this.logToUser(`Connecting to VM Service at ${uri}\n`);
-			this.observatory = new ObservatoryConnection(uri);
-			this.observatory.onLogging((message) => this.log(message));
+			this.vmService = new VmServiceConnection(uri);
+			this.vmService.onLogging((message) => this.log(message));
 			// TODO: Extract some code here and change to async/await. This is
 			// super confusing, for ex. it's not clear the resolve() inside onOpen
 			// fires immediately opon opening, not when all the code in the getVM
 			// callback fires (so it may as well have come first - unless it's
 			// a bug/race and it was supposed to be after all the setup!).
-			this.observatory.onOpen(async () => {
-				if (!this.observatory)
+			this.vmService.onOpen(async () => {
+				if (!this.vmService)
 					return;
 
 				// Read the version to update capabilities before doing anything else.
-				await this.observatory.getVersion().then(async (versionResult) => {
+				await this.vmService.getVersion().then(async (versionResult) => {
 					const version: Version = versionResult.result as Version;
 					this.vmServiceCapabilities.version = `${version.major}.${version.minor}.0`;
 
-					if (!this.observatory)
+					if (!this.vmService)
 						return;
 
-					await this.observatory.getVM().then(async (vmResult): Promise<void> => {
-						if (!this.observatory)
+					await this.vmService.getVM().then(async (vmResult): Promise<void> => {
+						if (!this.vmService)
 							return;
 						const vm: VM = vmResult.result as VM;
 
 						await this.subscribeToStreams();
 
-						// If we own this process (we launched it, didn't attach) and the PID we get from Observatory is different, then
+						// If we own this process (we launched it, didn't attach) and the PID we get from the VM service is different, then
 						// we should keep a ref to this process to terminate when we quit. This avoids issues where our process is a shell
 						// (we use shell execute to fix issues on Windows) and the kill signal isn't passed on correctly.
 						// See: https://github.com/Dart-Code/Dart-Code/issues/907
-						if (this.allowTerminatingObservatoryVmPid && this.childProcess) {
+						if (this.allowTerminatingVmServicePid && this.childProcess) {
 							this.recordAdditionalPid(vm.pid);
 						}
 
-						const isolates = await Promise.all(vm.isolates.map((isolateRef) => this.observatory!.getIsolate(isolateRef.id)));
+						const isolates = await Promise.all(vm.isolates.map((isolateRef) => this.vmService!.getIsolate(isolateRef.id)));
 
 						// TODO: Is it valid to assume the first (only?) isolate with a rootLib is the one we care about here?
 						// If it's always the first, could we even just query the first instead of getting them all before we
@@ -583,9 +583,9 @@ export class DartDebugSession extends DebugSession {
 				resolve();
 			});
 
-			this.observatory.onClose((code: number, message: string) => {
+			this.vmService.onClose((code: number, message: string) => {
 
-				this.log(`Observatory connection closed: ${code} (${message})`);
+				this.log(`VM service connection closed: ${code} (${message})`);
 				if (this.logStream) {
 					this.logStream.end();
 					this.logStream = undefined;
@@ -598,11 +598,11 @@ export class DartDebugSession extends DebugSession {
 				if (!this.childProcess || this.childProcess instanceof RemoteEditorTerminalProcess) {
 					this.sendEvent(new TerminatedEvent());
 				} else {
-					// In some cases Observatory closes but we never get the exit/close events from the process
+					// In some cases the VM service closes but we never get the exit/close events from the process
 					// so this is a fallback to termiante the session after a short period. Without this, we have
 					// issues like https://github.com/Dart-Code/Dart-Code/issues/1268 even though when testing from
 					// the terminal the app does terminate as expected.
-					// 2019-07-10: Increased delay because when we tell Flutter to stop Observatory quits quickly and
+					// 2019-07-10: Increased delay because when we tell Flutter to stop the VM service quits quickly and
 					// this code results in a TerminatedEvent() even though the process hasn't quit. The TerminatedEvent()
 					// results in VS Code sending disconnectRequest() and we then try to more forefully kill.
 					setTimeout(() => {
@@ -612,7 +612,7 @@ export class DartDebugSession extends DebugSession {
 				}
 			});
 
-			this.observatory.onError((error) => {
+			this.vmService.onError((error) => {
 				reject(error);
 			});
 		});
@@ -624,19 +624,19 @@ export class DartDebugSession extends DebugSession {
 	}
 
 	private async subscribeToStreams(): Promise<void> {
-		if (!this.observatory)
+		if (!this.vmService)
 			return;
 
 		const serviceStreamName = this.vmServiceCapabilities.serviceStreamIsPublic ? "Service" : "_Service";
 		await Promise.all([
-			this.observatory.on("Isolate", (event: VMEvent) => this.handleIsolateEvent(event)),
-			this.observatory.on("Extension", (event: VMEvent) => this.handleExtensionEvent(event)),
-			this.observatory.on("Debug", (event: VMEvent) => this.handleDebugEvent(event)),
-			this.observatory.on(serviceStreamName, (event: VMEvent) => this.handleServiceEvent(event)),
+			this.vmService.on("Isolate", (event: VMEvent) => this.handleIsolateEvent(event)),
+			this.vmService.on("Extension", (event: VMEvent) => this.handleExtensionEvent(event)),
+			this.vmService.on("Debug", (event: VMEvent) => this.handleDebugEvent(event)),
+			this.vmService.on(serviceStreamName, (event: VMEvent) => this.handleServiceEvent(event)),
 		]);
 
 		if (this.vmServiceCapabilities.hasLoggingStream && this.showDartDeveloperLogs) {
-			await this.observatory.on("Logging", (event: VMEvent) => this.handleLoggingEvent(event)).catch((e) => {
+			await this.vmService.on("Logging", (event: VMEvent) => this.handleLoggingEvent(event)).catch((e) => {
 				this.logger.info(errorString(e));
 				// For web, the protocol version says this is supported, but it throws.
 				// TODO: Remove this catch block if/when the stable release does not throw.
@@ -685,14 +685,14 @@ export class DartDebugSession extends DebugSession {
 			// test finish) so we may need to send again it we get another disconnectRequest.
 			// We also use !childProcess to mean we're attached.
 			// this.childProcess = undefined;
-		} else if (!this.shouldKillProcessOnTerminate && this.observatory) {
+		} else if (!this.shouldKillProcessOnTerminate && this.vmService) {
 			this.log(`${request}: Disconnecting from process...`);
 			await this.tryRemoveAllBreakpointsAndResumeAllThreads(request);
 			try {
-				this.log(`${request}: Closing observatory...`);
-				this.observatory.close();
+				this.log(`${request}: Closing VM service connection...`);
+				this.vmService.close();
 			} catch { } finally {
-				this.observatory = undefined;
+				this.vmService = undefined;
 			}
 		} else {
 			this.log(`${request}: Did not need to terminate processes`);
@@ -855,12 +855,12 @@ export class DartDebugSession extends DebugSession {
 			return;
 		}
 
-		if (!this.observatory) {
-			this.errorResponse(response, `No observatory connection`);
+		if (!this.vmService) {
+			this.errorResponse(response, `No VM service connection`);
 			return;
 		}
 
-		this.observatory.pause(thread.ref.id)
+		this.vmService.pause(thread.ref.id)
 			.then((_) => this.sendResponse(response))
 			.catch((error) => this.errorResponse(response, `${error}`));
 	}
@@ -896,12 +896,12 @@ export class DartDebugSession extends DebugSession {
 			return;
 		}
 
-		if (!this.observatory) {
-			this.errorResponse(response, `No observatory connection`);
+		if (!this.vmService) {
+			this.errorResponse(response, `No VM service connection`);
 			return;
 		}
 
-		this.observatory.getStack(thread.ref.id).then((result: DebuggerResult) => {
+		this.vmService.getStack(thread.ref.id).then((result: DebuggerResult) => {
 			const stack: VMStack = result.result as VMStack;
 			let vmFrames = stack.asyncCausalFrames || stack.frames;
 			const totalFrames = vmFrames.length;
@@ -1024,8 +1024,8 @@ export class DartDebugSession extends DebugSession {
 	}
 
 	protected async variablesRequest(response: DebugProtocol.VariablesResponse, args: DebugProtocol.VariablesArguments): Promise<void> {
-		if (!this.observatory) {
-			this.errorResponse(response, `No observatory connection`);
+		if (!this.vmService) {
+			this.errorResponse(response, `No VM service connection`);
 			return;
 		}
 
@@ -1054,8 +1054,8 @@ export class DartDebugSession extends DebugSession {
 		} else if (data.data.type === "MapEntry") {
 			const mapRef = data.data as VMMapEntry;
 
-			const keyResult = this.observatory.getObject(thread.ref.id, mapRef.keyId);
-			const valueResult = this.observatory.getObject(thread.ref.id, mapRef.valueId);
+			const keyResult = this.vmService.getObject(thread.ref.id, mapRef.keyId);
+			const valueResult = this.vmService.getObject(thread.ref.id, mapRef.valueId);
 
 			const variables: DebugProtocol.Variable[] = [];
 			let canEvaluateValueName = false;
@@ -1097,7 +1097,7 @@ export class DartDebugSession extends DebugSession {
 			const instanceRef = data.data as InstanceWithEvaluateName;
 
 			try {
-				const result = await this.observatory.getObject(thread.ref.id, instanceRef.id, start, count);
+				const result = await this.vmService.getObject(thread.ref.id, instanceRef.id, start, count);
 				let variables: DebugProtocol.Variable[] = [];
 				// If we're the top-level exception, or our parent has an evaluateName of undefined (its children)
 				// we cannot evaluate (this will disable "Add to Watch" etc).
@@ -1168,7 +1168,7 @@ export class DartDebugSession extends DebugSession {
 								// Call each getter, adding the result as a variable.
 								const getterPromises = getterNames.map(async (getterName, i) => {
 									try {
-										const getterResult = await this.observatory!.evaluate(thread.ref.id, instanceRef.id, getterName, true);
+										const getterResult = await this.vmService!.evaluate(thread.ref.id, instanceRef.id, getterName, true);
 										if (getterResult.result.type === "@Error") {
 											return { name: getterName, value: (getterResult.result as VMErrorRef).message, variablesReference: 0 };
 										} else if (getterResult.result.type === "Sentinel") {
@@ -1226,8 +1226,8 @@ export class DartDebugSession extends DebugSession {
 
 	private async getGetterNamesForHierarchy(thread: VMIsolateRef, classRef: VMClassRef | undefined): Promise<string[]> {
 		let getterNames: string[] = [];
-		while (this.observatory && classRef) {
-			const classResponse = await this.observatory.getObject(thread.id, classRef.id);
+		while (this.vmService && classRef) {
+			const classResponse = await this.vmService.getObject(thread.id, classRef.id);
 			if (classResponse.result.type !== "Class")
 				break;
 
@@ -1252,20 +1252,20 @@ export class DartDebugSession extends DebugSession {
 	}
 
 	private async callToString(isolate: VMIsolateRef, instanceRef: VMInstanceRef, getFullString: boolean = false): Promise<string | undefined> {
-		if (!this.observatory)
+		if (!this.vmService)
 			return;
 
 		try {
 			const result = this.vmServiceCapabilities.hasInvoke
-				? await this.observatory.invoke(isolate.id, instanceRef.id, "toString", [], true)
-				: await this.observatory.evaluate(isolate.id, instanceRef.id, "toString()", true);
+				? await this.vmService.invoke(isolate.id, instanceRef.id, "toString", [], true)
+				: await this.vmService.evaluate(isolate.id, instanceRef.id, "toString()", true);
 			if (result.result.type === "@Error") {
 				return undefined;
 			} else {
 				let evalResult: VMInstanceRef = result.result as VMInstanceRef;
 
 				if (evalResult.valueAsStringIsTruncated && getFullString) {
-					const result = await this.observatory!.getObject(isolate.id, evalResult.id);
+					const result = await this.vmService!.getObject(isolate.id, evalResult.id);
 					evalResult = result.result as VMInstanceRef;
 				}
 
@@ -1369,12 +1369,12 @@ export class DartDebugSession extends DebugSession {
 		try {
 			let result: DebuggerResult | undefined;
 			if (!data) {
-				if (!this.observatory || !thread) {
+				if (!this.vmService || !thread) {
 					this.errorResponse(response, "global evaluation requires a thread to have been loaded");
 					return;
 				}
 
-				const isolate = (await this.observatory.getIsolate(thread.ref.id)).result as VMIsolate;
+				const isolate = (await this.vmService.getIsolate(thread.ref.id)).result as VMIsolate;
 				const rootLib = isolate.rootLib;
 
 				if (!rootLib) {
@@ -1388,7 +1388,7 @@ export class DartDebugSession extends DebugSession {
 				//   2. The VM sometimes doesn't respond to your requests at all
 				//      https://github.com/flutter/flutter/issues/18595
 				result = await Promise.race([
-					this.observatory!.evaluate(thread.ref.id, rootLib.id, expression, true),
+					this.vmService!.evaluate(thread.ref.id, rootLib.id, expression, true),
 					new Promise<never>((resolve, reject) => setTimeout(() => reject(new Error("<timed out>")), 1000)),
 				]);
 			} else {
@@ -1409,7 +1409,7 @@ export class DartDebugSession extends DebugSession {
 					const exceptionId = exceptionInstanceRef && exceptionInstanceRef.id;
 
 					if (exceptionId)
-						result = await this.observatory!.evaluate(thread.ref.id, exceptionId, expression.substr(3), true);
+						result = await this.vmService!.evaluate(thread.ref.id, exceptionId, expression.substr(3), true);
 				}
 				if (!result) {
 					// Don't wait more than a second for the response:
@@ -1418,7 +1418,7 @@ export class DartDebugSession extends DebugSession {
 					//   2. The VM sometimes doesn't respond to your requests at all
 					//      https://github.com/flutter/flutter/issues/18595
 					result = await Promise.race([
-						this.observatory!.evaluateInFrame(thread.ref.id, frame.index, expression, true),
+						this.vmService!.evaluateInFrame(thread.ref.id, frame.index, expression, true),
 						new Promise<never>((resolve, reject) => setTimeout(() => reject(new Error("<timed out>")), 1000)),
 					]);
 				}
@@ -1614,8 +1614,8 @@ export class DartDebugSession extends DebugSession {
 			return;
 		}
 
-		if (!this.observatory) {
-			this.logger.warn("No observatory connection");
+		if (!this.vmService) {
+			this.logger.warn("No VM service connection");
 			return;
 		}
 
@@ -1627,7 +1627,7 @@ export class DartDebugSession extends DebugSession {
 				this.logger.error(e);
 			}
 			try {
-				await this.observatory.resume(event.isolate.id);
+				await this.vmService.resume(event.isolate.id);
 			} catch (e) {
 				// Ignore failed-to-resume errors https://github.com/flutter/flutter/issues/10934
 				if (e.code !== 106)
@@ -1758,16 +1758,16 @@ export class DartDebugSession extends DebugSession {
 	}
 
 	private callService(type: string, args: any): Promise<any> {
-		if (!this.observatory)
-			throw new Error("Observatory connection is not available");
-		return this.observatory.callMethod(type, args);
+		if (!this.vmService)
+			throw new Error("VM service connection is not available");
+		return this.vmService.callMethod(type, args);
 	}
 
 	private async evaluateAndSendErrors(thread: ThreadInfo, expression: string): Promise<VMInstanceRef | undefined> {
-		if (!this.observatory)
+		if (!this.vmService)
 			return;
 		try {
-			const result = await this.observatory.evaluateInFrame(thread.ref.id, 0, expression, true);
+			const result = await this.vmService.evaluateInFrame(thread.ref.id, 0, expression, true);
 			if (result.result.type !== "@Error") {
 				return result.result as VMInstanceRef;
 			} else {
@@ -1937,13 +1937,13 @@ export class DartDebugSession extends DebugSession {
 	}
 
 	private async pollForMemoryUsage(): Promise<void> {
-		if (!this.childProcess || this.childProcess.killed || !this.observatory)
+		if (!this.childProcess || this.childProcess.killed || !this.vmService)
 			return;
 
-		const result = await this.observatory.getVM();
+		const result = await this.vmService.getVM();
 		const vm = result.result as VM;
 
-		const isolatePromises = vm.isolates.map((isolateRef) => this.observatory!.getIsolate(isolateRef.id));
+		const isolatePromises = vm.isolates.map((isolateRef) => this.vmService!.getIsolate(isolateRef.id));
 		const isolatesResponses = await Promise.all(isolatePromises);
 		const isolates = isolatesResponses.map((response) => response.result as VMIsolate);
 

--- a/src/debug/dart_debug_protocol.ts
+++ b/src/debug/dart_debug_protocol.ts
@@ -383,7 +383,7 @@ export class RPCError {
 	}
 }
 
-export class ObservatoryConnection {
+export class VmServiceConnection {
 	public socket: WebSocket;
 	private completers: { [key: string]: PromiseCompleter<DebuggerResult> } = {};
 	private logging?: (message: string) => void;

--- a/src/debug/dart_test_debug_impl.ts
+++ b/src/debug/dart_test_debug_impl.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import { Event, OutputEvent, ProgressUpdateEvent } from "vscode-debugadapter";
-import { debugTerminatingProgressId, observatoryHttpLinkPattern } from "../shared/constants";
+import { debugTerminatingProgressId, vmServiceHttpLinkPattern } from "../shared/constants";
 import { LogCategory } from "../shared/enums";
 import { Logger } from "../shared/interfaces";
 import { ErrorNotification, GroupNotification, PrintNotification, SuiteNotification, Test, TestDoneNotification, TestStartNotification } from "../shared/test_protocol";
@@ -114,9 +114,9 @@ export class DartTestDebugSession extends DartDebugSession {
 			case "debug":
 				const observatoryUri = notification.observatory;
 				if (observatoryUri) {
-					const match = observatoryHttpLinkPattern.exec(observatoryUri);
+					const match = vmServiceHttpLinkPattern.exec(observatoryUri);
 					if (match) {
-						await this.initDebugger(this.websocketUriForObservatoryUri(match[1]));
+						await this.initDebugger(this.vmServiceWsUriFor(match[1]));
 					}
 				}
 				break;

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -82,7 +82,7 @@ export class FlutterDebugSession extends DartDebugSession {
 		// because it's on a remote device, however in the case of the flutter-tester, it is local
 		// and otherwise might be left hanging around.
 		// Unless, of course, we attached in which case we expect to detach by default.
-		this.allowTerminatingObservatoryVmPid = args.deviceId === "flutter-tester" && !isAttach;
+		this.allowTerminatingVmServicePid = args.deviceId === "flutter-tester" && !isAttach;
 
 		const logger = new DebugAdapterLogger(this, this.logCategory);
 		this.expectAdditionalPidToTerminate = true;
@@ -214,7 +214,7 @@ export class FlutterDebugSession extends DartDebugSession {
 	}
 
 	private async connectToObservatoryIfReady() {
-		if (this.observatoryUri && this.appHasStarted && !this.observatory)
+		if (this.observatoryUri && this.appHasStarted && !this.vmService)
 			await this.initDebugger(this.observatoryUri);
 	}
 

--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -67,7 +67,6 @@ export class FlutterDebugSession extends DartDebugSession {
 	protected async attachRequest(response: DebugProtocol.AttachResponse, args: any): Promise<void> {
 		// For flutter attach, we actually do the same thing as launch - we run a flutter process
 		// (flutter attach instead of flutter run).
-		// this.observatoryUriIsProbablyReconnectable = true;
 		return this.launchRequest(response, args);
 	}
 
@@ -161,9 +160,10 @@ export class FlutterDebugSession extends DartDebugSession {
 
 		if (isAttach) {
 			const flutterAttach: FlutterAttachRequestArguments = args as any;
-			if (flutterAttach.observatoryUri) {
+			const vmServiceUri = (flutterAttach.vmServiceUri || flutterAttach.observatoryUri);
+			if (vmServiceUri) {
 				appArgs.push("--debug-uri");
-				appArgs.push(flutterAttach.observatoryUri);
+				appArgs.push(vmServiceUri);
 			}
 		}
 

--- a/src/debug/threads.ts
+++ b/src/debug/threads.ts
@@ -355,7 +355,7 @@ export class ThreadInfo {
 					completer.reject(error);
 				});
 			} else {
-				completer.reject(`Observatory connection is no longer available`);
+				completer.reject(`VM service connection is no longer available`);
 			}
 
 			return completer.promise;

--- a/src/debug/utils.ts
+++ b/src/debug/utils.ts
@@ -27,7 +27,7 @@ export interface DartSharedArgs {
 	evaluateGettersInDebugViews: boolean;
 	evaluateToStringInDebugViews: boolean;
 	maxLogLineLength: number;
-	observatoryLogFile?: string;
+	vmServiceLogFile?: string;
 	sendLogsToClient?: boolean;
 	showDartDeveloperLogs: boolean;
 	toolEnv?: { [key: string]: string | undefined };
@@ -77,7 +77,9 @@ export interface DartAttachRequestArguments extends DebugProtocol.AttachRequestA
 	cwd: string | undefined;
 	program: string | undefined;
 	packages: string | undefined;
+	// For backwards compatibility
 	observatoryUri: string | undefined;
+	vmServiceUri: string | undefined;
 	serviceInfoFile: string | undefined;
 	dartVersion: string;
 }

--- a/src/debug/web_debug_impl.ts
+++ b/src/debug/web_debug_impl.ts
@@ -11,7 +11,7 @@ export class WebDebugSession extends FlutterDebugSession {
 
 		// There is no observatory web app, so we shouldn't send an ObservatoryURI
 		// back to the editor, since that enables "Dart: Open Observatory" and friends.
-		this.supportsObservatory = false;
+		this.supportsObservatoryWebApp = false;
 		this.logCategory = LogCategory.WebDaemon;
 	}
 

--- a/src/extension/analysis/analyzer.ts
+++ b/src/extension/analysis/analyzer.ts
@@ -26,7 +26,7 @@ export function getAnalyzerArgs(logger: Logger, sdks: DartSdks, dartCapabilities
 function buildAnalyzerArgs(analyzerPath: string, dartCapabilities: DartCapabilities, isLsp: boolean) {
 	let analyzerArgs = [];
 
-	// Optionally start Observatory for the analyzer.
+	// Optionally start the VM service for the analyzer.
 	if (config.analyzerObservatoryPort)
 		analyzerArgs.push(`--enable-vm-service=${config.analyzerObservatoryPort}`);
 

--- a/src/extension/analysis/analyzer.ts
+++ b/src/extension/analysis/analyzer.ts
@@ -27,8 +27,8 @@ function buildAnalyzerArgs(analyzerPath: string, dartCapabilities: DartCapabilit
 	let analyzerArgs = [];
 
 	// Optionally start the VM service for the analyzer.
-	if (config.analyzerObservatoryPort)
-		analyzerArgs.push(`--enable-vm-service=${config.analyzerObservatoryPort}`);
+	if (config.analyzerVmServicePort)
+		analyzerArgs.push(`--enable-vm-service=${config.analyzerVmServicePort}`);
 
 	analyzerArgs.push(analyzerPath);
 

--- a/src/extension/commands/debug.ts
+++ b/src/extension/commands/debug.ts
@@ -17,7 +17,6 @@ import { DevToolsManager } from "../sdk/dev_tools";
 import { DartDebugSessionInformation } from "../utils/vscode/debug";
 
 export const debugSessions: DartDebugSessionInformation[] = [];
-// export let mostRecentAttachedProbablyReusableObservatoryUri: string;
 
 // Workaround for https://github.com/microsoft/vscode/issues/100115
 const dynamicDebugSessionName = "Dart ";
@@ -496,12 +495,6 @@ export class DebugCommands {
 					});
 				}
 			}
-
-			// if (e.body.isProbablyReconnectable) {
-			// 	mostRecentAttachedProbablyReusableObservatoryUri = session.observatoryUri;
-			// } else {
-			// 	mostRecentAttachedProbablyReusableObservatoryUri = undefined;
-			// }
 		}
 	}
 

--- a/src/extension/commands/debug.ts
+++ b/src/extension/commands/debug.ts
@@ -230,9 +230,9 @@ export class DebugCommands {
 		context.subscriptions.push(vs.commands.registerCommand("flutter.attachProcess", () => {
 			vs.debug.startDebugging(undefined, {
 				name: "Flutter: Attach to Process",
-				observatoryUri: "${command:dart.promptForVmService}",
 				request: "attach",
 				type: "dart",
+				vmServiceUri: "${command:dart.promptForVmService}",
 			});
 		}));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.attach", () => {
@@ -246,8 +246,8 @@ export class DebugCommands {
 			const defaultValue = typeof defaultValueOrConfig === "string" ? defaultValueOrConfig : undefined;
 			return vs.window.showInputBox({
 				ignoreFocusOut: true, // Don't close the window if the user tabs away to get the uri
-				placeHolder: "Paste an Observatory URI",
-				prompt: "Enter Observatory URI",
+				placeHolder: "Paste an VM Service URI",
+				prompt: "Enter VM Service URI",
 				validateInput: (input) => {
 					if (!input)
 						return;
@@ -262,7 +262,7 @@ export class DebugCommands {
 
 					if (!input.startsWith("http://") && !input.startsWith("https://")
 						&& !input.startsWith("ws://") && !input.startsWith("wss://"))
-						return "Please enter a valid Observatory URI";
+						return "Please enter a valid VM Service URI";
 				},
 				value: defaultValue,
 			});

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -47,9 +47,9 @@ class Config {
 	get analyzerDiagnosticsPort(): undefined | number { return this.getConfig<null | number>("analyzerDiagnosticsPort", null); }
 	get analyzerInstrumentationLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("analyzerInstrumentationLogFile", null))); }
 	get analyzerLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("analyzerLogFile", null))); }
-	get analyzerObservatoryPort(): undefined | number { return this.getConfig<null | number>("analyzerObservatoryPort", null); }
 	get analyzerPath(): undefined | string { return resolvePaths(this.getConfig<null | string>("analyzerPath", null)); }
 	get analyzerSshHost(): undefined | string { return this.getConfig<null | string>("analyzerSshHost", null); }
+	get analyzerVmServicePort(): undefined | number { return this.getConfig<null | number>("analyzerVmServicePort", null); }
 	get autoImportCompletions(): boolean { return this.getConfig<boolean>("autoImportCompletions", true); }
 	get buildRunnerAdditionalArgs(): string[] { return this.getConfig<string[]>("buildRunnerAdditionalArgs", []); }
 	get checkForSdkUpdates(): boolean { return this.getConfig<boolean>("checkForSdkUpdates", true); }
@@ -84,7 +84,6 @@ class Config {
 	get flutterTestLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("flutterTestLogFile", null))); }
 	get maxLogLineLength(): number { return this.getConfig<number>("maxLogLineLength", 2000); }
 	get notifyAnalyzerErrors(): boolean { return this.getConfig<boolean>("notifyAnalyzerErrors", true); }
-	get observatoryLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("observatoryLogFile", null))); }
 	get openDevTools(): "never" | "flutter" | "always" { return this.getConfig<"never" | "flutter" | "always">("openDevTools", "never"); }
 	get openTestView(): Array<"testRunStart" | "testFailure"> { return this.getConfig<Array<"testRunStart" | "testFailure">>("openTestView", ["testRunStart"]); }
 	get previewBazelWorkspaceCustomScripts(): boolean { return this.getConfig<boolean>("previewBazelWorkspaceCustomScripts", false); }
@@ -105,6 +104,7 @@ class Config {
 	get showTodos(): boolean { return this.getConfig<boolean>("showTodos", true); }
 	get triggerSignatureHelpAutomatically(): boolean { return this.getConfig<boolean>("triggerSignatureHelpAutomatically", false); }
 	get useKnownChromeOSPorts(): boolean { return this.getConfig<boolean>("useKnownChromeOSPorts", true); }
+	get vmServiceLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("vmServiceLogFile", null))); }
 	get warnWhenEditingFilesOutsideWorkspace(): boolean { return this.getConfig<boolean>("warnWhenEditingFilesOutsideWorkspace", true); }
 	get webDaemonLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("webDaemonLogFile", null))); }
 
@@ -165,7 +165,6 @@ class ResourceConfig {
 	get flutterTrackWidgetCreation(): boolean { return this.getConfig<boolean>("flutterTrackWidgetCreation", true); }
 	get insertArgumentPlaceholders(): boolean { return this.getConfig<boolean>("insertArgumentPlaceholders", true); }
 	get lineLength(): number { return this.getConfig<number>("lineLength", 80); }
-	get observatoryLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("observatoryLogFile", null))); }
 	get promptToGetPackages(): boolean { return this.getConfig<boolean>("promptToGetPackages", true); }
 	get pubAdditionalArgs(): string[] { return this.getConfig<string[]>("pubAdditionalArgs", []); }
 	get pubTestLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("pubTestLogFile", null))); }
@@ -174,6 +173,7 @@ class ResourceConfig {
 	get sdkPaths(): string[] { return this.getConfig<string[]>("sdkPaths", []).map(resolvePaths); }
 	get showDartDeveloperLogs(): boolean { return this.getConfig<boolean>("showDartDeveloperLogs", true); }
 	get vmAdditionalArgs(): string[] { return this.getConfig<string[]>("vmAdditionalArgs", []); }
+	get vmServiceLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("vmServiceLogFile", null))); }
 	get webDaemonLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("webDaemonLogFile", null))); }
 }
 

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -772,7 +772,7 @@ function getSettingsThatRequireRestart() {
 		+ config.sdkPaths?.length
 		+ config.analyzerPath
 		+ config.analyzerDiagnosticsPort
-		+ config.analyzerObservatoryPort
+		+ config.analyzerVmServicePort
 		+ config.analyzerInstrumentationLogFile
 		+ config.extensionLogFile
 		+ config.analyzerAdditionalArgs

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -232,14 +232,14 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 
 		// If we're attaching to Dart, ensure we get a VM service URI.
 		if (isAttachRequest && !debugConfig.serviceInfoFile) {
-			// For attaching, the Observatory address must be specified. If it's not provided already, prompt for it.
+			// For attaching, the VM service address must be specified. If it's not provided already, prompt for it.
 			if (!isStandardFlutter) { // TEMP Condition because there's no point asking yet as the user doesn't know how to get this..
-				debugConfig.observatoryUri = await this.getFullVmServiceUri(debugConfig.observatoryUri/*, mostRecentAttachedProbablyReusableObservatoryUri*/);
+				debugConfig.vmServiceUri = await this.getFullVmServiceUri(debugConfig.vmServiceUri || debugConfig.observatoryUri);
 			}
 
-			if (!debugConfig.observatoryUri && !isStandardFlutter) {
-				logger.warn("No Observatory URI/port was provided");
-				window.showInformationMessage("You must provide an Observatory URI/port to attach a debugger");
+			if (!debugConfig.vmServiceUri && !isStandardFlutter) {
+				logger.warn("No VM service URI/port was provided");
+				window.showInformationMessage("You must provide a VM service URI/port to attach a debugger");
 				return undefined; // undefined means silent (don't open launch.json).
 			}
 		}
@@ -410,16 +410,16 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			return this.guessBestEntryPoint(undefined, path.join(projectRoot, "example"));
 	}
 
-	private async getFullVmServiceUri(observatoryUri: string | undefined, defaultValue?: string): Promise<string | undefined> {
-		observatoryUri = observatoryUri || await vs.commands.executeCommand("dart.promptForVmService", defaultValue);
-		observatoryUri = observatoryUri && observatoryUri.trim();
+	private async getFullVmServiceUri(vmServiceUriOrPort: string | undefined): Promise<string | undefined> {
+		vmServiceUriOrPort = vmServiceUriOrPort || await vs.commands.executeCommand("dart.promptForVmService");
+		vmServiceUriOrPort = vmServiceUriOrPort && vmServiceUriOrPort.trim();
 
 		// If the input is just a number, treat is as a localhost port.
-		if (observatoryUri && /^[0-9]+$/.exec(observatoryUri)) {
-			observatoryUri = `http://127.0.0.1:${observatoryUri}`;
+		if (vmServiceUriOrPort && /^[0-9]+$/.exec(vmServiceUriOrPort)) {
+			vmServiceUriOrPort = `http://127.0.0.1:${vmServiceUriOrPort}`;
 		}
 
-		return observatoryUri;
+		return vmServiceUriOrPort;
 	}
 
 	private getDebugServer(debugType: DebuggerType, port?: number) {
@@ -480,7 +480,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		debugConfig.vmAdditionalArgs = debugConfig.vmAdditionalArgs || conf.vmAdditionalArgs;
 		debugConfig.vmServicePort = debugConfig.vmServicePort || (isChromeOS && config.useKnownChromeOSPorts ? CHROME_OS_VM_SERVICE_PORT : 0);
 		debugConfig.dartPath = debugConfig.dartPath || path.join(this.wsContext.sdks.dart!, dartVMPath);
-		debugConfig.observatoryLogFile = this.insertSessionName(debugConfig, debugConfig.observatoryLogFile || conf.observatoryLogFile);
+		debugConfig.vmServiceLogFile = this.insertSessionName(debugConfig, debugConfig.vmServiceLogFile || conf.vmServiceLogFile);
 		debugConfig.webDaemonLogFile = this.insertSessionName(debugConfig, debugConfig.webDaemonLogFile || conf.webDaemonLogFile);
 		debugConfig.maxLogLineLength = debugConfig.maxLogLineLength || config.maxLogLineLength;
 		debugConfig.pubPath = debugConfig.pubPath || path.join(this.wsContext.sdks.dart!, pubPath);

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -230,7 +230,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			debugConfig.noDebug = true;
 		}
 
-		// If we're attaching to Dart, ensure we get an observatory URI.
+		// If we're attaching to Dart, ensure we get a VM service URI.
 		if (isAttachRequest && !debugConfig.serviceInfoFile) {
 			// For attaching, the Observatory address must be specified. If it's not provided already, prompt for it.
 			if (!isStandardFlutter) { // TEMP Condition because there's no point asking yet as the user doesn't know how to get this..

--- a/src/extension/utils/log.ts
+++ b/src/extension/utils/log.ts
@@ -13,7 +13,7 @@ export function getExtensionLogPath() {
 export const userSelectableLogCategories: { [key: string]: LogCategory } = {
 	"Analysis Server": LogCategory.Analyzer,
 	"Command Processes": LogCategory.CommandProcesses,
-	"Debugger (Observatory)": LogCategory.Observatory,
+	"Debugger and VM Service": LogCategory.VmService,
 	"DevTools": LogCategory.DevTools,
 	"Flutter Device Daemon": LogCategory.FlutterDaemon,
 	"Flutter Run": LogCategory.FlutterRun,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -110,8 +110,8 @@ export const recommendedSettingsUrl = "https://dartcode.org/docs/recommended-set
 export const openSettingsAction = "Open Settings File";
 export const reactivateDevToolsAction = "Reactivate DevTools";
 
-export const observatoryListeningBannerPattern: RegExp = new RegExp("Observatory (?:listening on|.* is available at:) (http:.+)");
-export const observatoryHttpLinkPattern: RegExp = new RegExp("(http://[\\d\\.:]+/)");
+export const vmServiceListeningBannerPattern: RegExp = new RegExp("Observatory (?:listening on|.* is available at:) (http:.+)");
+export const vmServiceHttpLinkPattern: RegExp = new RegExp("(http://[\\d\\.:]+/)");
 
 export const dartRecommendedConfig = {
 	// Automatically format code on save and during typing of certain characters

--- a/src/shared/enums.ts
+++ b/src/shared/enums.ts
@@ -50,7 +50,7 @@ export enum LogCategory {
 	FlutterDaemon,
 	FlutterRun,
 	FlutterTest,
-	Observatory,
+	VmService,
 	WebDaemon,
 }
 

--- a/src/test/dart_debug/debug/dart_cli.test.ts
+++ b/src/test/dart_debug/debug/dart_cli.test.ts
@@ -33,8 +33,8 @@ describe("dart cli debugger", () => {
 		return config;
 	}
 
-	async function attachDebugger(observatoryUri: string | undefined, extraConfiguration?: { [key: string]: any }): Promise<vs.DebugConfiguration | undefined | null> {
-		const config = await getAttachConfiguration(Object.assign({ observatoryUri }, extraConfiguration));
+	async function attachDebugger(vmServiceUri: string | undefined, extraConfiguration?: { [key: string]: any }): Promise<vs.DebugConfiguration | undefined | null> {
+		const config = await getAttachConfiguration(Object.assign({ vmServiceUri }, extraConfiguration));
 		if (!config)
 			throw new Error(`Could not get launch configuration (got ${config})`);
 		await dc.start(config.debugServer);
@@ -1116,7 +1116,7 @@ insp=<inspected variable>
 	describe("attaches", () => {
 		it("to a paused Dart script and can unpause to run it to completion", async () => {
 			const process = spawnDartProcessPaused(helloWorldMainFile, helloWorldFolder);
-			const observatoryUri = await process.observatoryUri;
+			const observatoryUri = await process.vmServiceUri;
 
 			const config = await attachDebugger(observatoryUri);
 			await Promise.all([
@@ -1144,7 +1144,7 @@ insp=<inspected variable>
 		it("when provided only a port in launch.config", async () => {
 			const vmArgs = extApi.dartCapabilities.supportsDisableServiceTokens ? ["--disable-service-auth-codes"] : [];
 			const process = spawnDartProcessPaused(helloWorldMainFile, helloWorldFolder, ...vmArgs);
-			const observatoryUri = await process.observatoryUri;
+			const observatoryUri = await process.vmServiceUri;
 			const observatoryPort = /:([0-9]+)\//.exec(observatoryUri)![1];
 
 			// Include whitespace as a test for trimming.
@@ -1158,7 +1158,7 @@ insp=<inspected variable>
 
 		it("to the observatory uri provided by the user when not specified in launch.json", async () => {
 			const process = spawnDartProcessPaused(helloWorldMainFile, helloWorldFolder);
-			const observatoryUri = await process.observatoryUri;
+			const observatoryUri = await process.vmServiceUri;
 
 			const showInputBox = sb.stub(vs.window, "showInputBox");
 			showInputBox.resolves(observatoryUri);
@@ -1175,7 +1175,7 @@ insp=<inspected variable>
 
 		it("to a paused Dart script and can set breakpoints", async () => {
 			const process = spawnDartProcessPaused(helloWorldMainFile, helloWorldFolder);
-			const observatoryUri = await process.observatoryUri;
+			const observatoryUri = await process.vmServiceUri;
 
 			const config = await attachDebugger(observatoryUri);
 			await dc.hitBreakpoint(config, {
@@ -1186,7 +1186,7 @@ insp=<inspected variable>
 
 		it("and removes breakpoints and unpauses on detach", async () => {
 			const process = spawnDartProcessPaused(helloWorldMainFile, helloWorldFolder);
-			const observatoryUri = await process.observatoryUri;
+			const observatoryUri = await process.vmServiceUri;
 
 			const config = await attachDebugger(observatoryUri);
 			await dc.hitBreakpoint(config, {

--- a/src/test/debug_helpers.ts
+++ b/src/test/debug_helpers.ts
@@ -3,7 +3,7 @@ import * as os from "os";
 import * as path from "path";
 import { DebugConfiguration, Uri } from "vscode";
 import { DebugProtocol } from "vscode-debugprotocol";
-import { dartVMPath, isWin, observatoryListeningBannerPattern } from "../shared/constants";
+import { dartVMPath, isWin, vmServiceListeningBannerPattern } from "../shared/constants";
 import { LogCategory } from "../shared/enums";
 import { SpawnedProcess } from "../shared/interfaces";
 import { logProcess } from "../shared/logging";
@@ -164,15 +164,15 @@ export async function spawnFlutterProcess(script: string | Uri): Promise<DartPro
 }
 
 export class DartProcess {
-	public readonly observatoryUri: Promise<string>;
+	public readonly vmServiceUri: Promise<string>;
 	public readonly exitCode: Promise<number | null>;
 	public get hasExited() { return this.exited; }
 	private exited: boolean = false;
 
 	constructor(public readonly process: SpawnedProcess) {
-		this.observatoryUri = new Promise((resolve, reject) => {
+		this.vmServiceUri = new Promise((resolve, reject) => {
 			process.stdout.on("data", (data) => {
-				const match = observatoryListeningBannerPattern.exec(data.toString());
+				const match = vmServiceListeningBannerPattern.exec(data.toString());
 				if (match)
 					resolve(match[1]);
 			});

--- a/src/test/flutter_debug/debug/flutter_run_attach.test.ts
+++ b/src/test/flutter_debug/debug/flutter_run_attach.test.ts
@@ -34,7 +34,7 @@ describe("flutter run debugger (attach)", () => {
 		defer(() => dc.stop());
 	});
 
-	async function attachDebugger(observatoryUri?: string): Promise<vs.DebugConfiguration> {
+	async function attachDebugger(vmServiceUri?: string): Promise<vs.DebugConfiguration> {
 		const config = await getAttachConfiguration({
 			// Use pid-file as a convenient way of getting the test name into the command line args
 			// for easier debugging of processes that hang around on CI (we dump the process command
@@ -43,7 +43,7 @@ describe("flutter run debugger (attach)", () => {
 				? ["--pid-file", path.join(os.tmpdir(), fileSafeCurrentTestName)]
 				: [],
 			deviceId: flutterTestDeviceId,
-			observatoryUri,
+			vmServiceUri,
 		});
 		if (!config)
 			throw new Error(`Could not get attach configuration (got ${config})`);
@@ -58,8 +58,8 @@ describe("flutter run debugger (attach)", () => {
 
 	it("attaches to a Flutter application and remains active until told to detach", async () => {
 		const process = await spawnFlutterProcess(flutterHelloWorldMainFile);
-		const observatoryUri = await process.observatoryUri;
-		const config = await attachDebugger(observatoryUri);
+		const vmServiceUri = await process.vmServiceUri;
+		const config = await attachDebugger(vmServiceUri);
 
 		await Promise.all([
 			watchPromise("attaches_and_waits->configurationSequence", dc.configurationSequence()),
@@ -78,8 +78,8 @@ describe("flutter run debugger (attach)", () => {
 
 	it("detaches without terminating the app", async () => {
 		const process = await spawnFlutterProcess(flutterHelloWorldMainFile);
-		const observatoryUri = await process.observatoryUri;
-		const config = await attachDebugger(observatoryUri);
+		const vmServiceUri = await process.vmServiceUri;
+		const config = await attachDebugger(vmServiceUri);
 
 		await Promise.all([
 			watchPromise("attaches_and_waits->configurationSequence", dc.configurationSequence()),


### PR DESCRIPTION
Launch configs will support both `vmServiceUri` and `observatoryUri` for a while. Most user-facing strings are updated. The "Open Observatory" command remains as-is for now, as that's still what it does.

Fixes https://github.com/flutter/devtools/issues/1642.