### PR TITLE
Fix debugger initialisation race

### DIFF
--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -466,7 +466,10 @@ export class FlutterDebugSession extends DartDebugSession {
 	}
 
 	// Extension
-	public handleExtensionEvent(event: VMEvent) {
+	public async handleExtensionEvent(event: VMEvent) {
+		// Don't process any events while the debugger is still running init code.
+		await this.debuggerInit;
+
 		if (event.kind === "Extension" && event.extensionKind === "Flutter.FirstFrame") {
 			this.sendEvent(new Event("dart.flutter.firstFrame", {}));
 		} else if (event.kind === "Extension" && event.extensionKind === "Flutter.Error") {


### PR DESCRIPTION
There was a race condition in the debugger connection code. If the thread was in the `PauseStart` state when we first found it, everything worked fine. However if it was in the `None` state initially, and changed to `PauseStart` before we'd finished the rest of the startup code, the event would be dropped (with a warning: "ThreadManager couldn't find thread with ref isolates/1462887175408855 to handle PauseStart").

To fix it, any incoming events wait for the initialisation to complete before being processed.