### PR TITLE
Update from flutter.io to flutter.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Dart Code extends [VS Code](https://code.visualstudio.com/) with support for the
 [Dart](https://www.dartlang.org/) programming language, and provides tools for
-effectively editing, refactoring, running, and reloading [Flutter](https://flutter.io/)
+effectively editing, refactoring, running, and reloading [Flutter](https://flutter.dev/)
 mobile apps, and [AngularDart](https://angulardart.org) web apps.
 
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -24,7 +24,7 @@ export const analyzerSnapshotPath = "bin/snapshots/analysis_server.dart.snapshot
 export const flutterPath = "bin/" + flutterExecutableName;
 export const androidStudioPaths = androidStudioExecutableNames.map((s) => "bin/" + s);
 export const DART_DOWNLOAD_URL = "https://dart.dev/get-dart";
-export const FLUTTER_DOWNLOAD_URL = "https://flutter.io/setup/";
+export const FLUTTER_DOWNLOAD_URL = "https://flutter.dev/setup/";
 
 export const IS_LSP_CONTEXT = "dart-code:isLsp";
 


### PR DESCRIPTION
These were the only two remaining instances I could see in the codebase. Fixes dialogs like this:
![image](https://user-images.githubusercontent.com/2319867/86630214-62f2ff00-bf81-11ea-9849-0302a39ec6e3.png)

