### PR TITLE
Include "unsupported" devices in the device picker, offer to run "flutter create ." when selected

### DIFF
--- a/src/extension/commands/sdk.ts
+++ b/src/extension/commands/sdk.ts
@@ -238,7 +238,13 @@ export class SdkCommands {
 		await util.promptToReloadExtension();
 	}
 
-	private flutterCreate(projectPath: string, projectName?: string, sampleID?: string) {
+	private async flutterCreate(projectPath: string | undefined, projectName?: string, sampleID?: string) {
+		if (!projectPath) {
+			projectPath = await this.getFolderToRunCommandIn(`Select the folder to run "flutter create" in`, undefined, true);
+			if (!projectPath)
+				return;
+		}
+
 		const args = ["create"];
 		if (config.flutterCreateOffline) {
 			args.push("--offline");

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -117,6 +117,10 @@ export const reactivateDevToolsAction = "Reactivate DevTools";
 export const vmServiceListeningBannerPattern: RegExp = new RegExp("Observatory (?:listening on|.* is available at:) (http:.+)");
 export const vmServiceHttpLinkPattern: RegExp = new RegExp("(http://[\\d\\.:]+/)");
 
+export const runFlutterCreateDotPrompt = (deviceName: string) => `You must run 'flutter create .' to create the files required to use the ${deviceName} device for this project.`;
+export const runFlutterCreateDotAction = "Run 'flutter create .'";
+export const cancelAction = "Cancel";
+
 export const dartRecommendedConfig = {
 	// Automatically format code on save and during typing of certain characters
 	// (like `;` and `}`).

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -103,6 +103,7 @@ export interface IFlutterDaemon extends IAmDisposable {
 }
 
 export type Emulator = (f.FlutterEmulator & { type: "emulator" }) | CustomEmulator;
+export type DisabledDevice = f.Device & { type: "disabled-device" };
 
 export interface CustomEmulator {
 	id: string;

--- a/src/shared/vscode/device_manager.ts
+++ b/src/shared/vscode/device_manager.ts
@@ -131,10 +131,8 @@ export class FlutterDeviceManager implements vs.Disposable {
 		deviceAddedSubscription.dispose();
 		deviceRemovedSubscription.dispose();
 
-		if (selection) {
-			await this.selectDevice(selection);
+		if (selection && await this.selectDevice(selection))
 			return this.currentDevice;
-		}
 
 		return undefined;
 	}
@@ -176,15 +174,21 @@ export class FlutterDeviceManager implements vs.Disposable {
 					if (action === runFlutterCreateDotAction)
 						await vs.commands.executeCommand("_flutter.create");
 					else
-						break;
+						return false;
 				}
 				this.currentDevice = selection.device;
 				this.updateStatusBar();
 				break;
 		}
+
+		return true;
 	}
 
 	private shortCacheForSupportedPlatforms: Promise<f.PlatformType[]> | undefined;
+
+	public getDevice(id: string | undefined) {
+		return this.devices.find((d) => d.id === id);
+	}
 
 	public async getPickableDevices(supportedTypes: string[] | undefined, emulatorDevices?: PickableDevice[] | undefined): Promise<PickableDevice[]> {
 		const sortedDevices = this.devices.sort(this.deviceSortComparer.bind(this));


### PR DESCRIPTION
Devices that are available in Flutter (`flutter devices`) but not supported according to Daemon's `getSupportedPlatforms`) will now be shown in the device picker prefixed with "Enable ":

<img width="699" alt="Screenshot 2020-07-16 at 15 48 55" src="https://user-images.githubusercontent.com/1078012/87685974-e5e33900-c77b-11ea-88fe-3e6e12981089.png">

Selecting one will prompt to run `flutter create .` for you:

<img width="557" alt="Screenshot 2020-07-16 at 15 49 01" src="https://user-images.githubusercontent.com/1078012/87685984-e7acfc80-c77b-11ea-857b-046d6da8b94a.png">

Once that completes, it'll select that device for you.

Fixes #2602.