### PR TITLE
Fix "tasks unexpectedly provided a task of type" error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1950,15 +1950,6 @@
 						"type": "string"
 					}
 				}
-			},
-			{
-				"type": "flutter",
-				"required": [],
-				"properties": {
-					"command": {
-						"type": "string"
-					}
-				}
 			}
 		],
 		"problemMatchers": [

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -331,7 +331,8 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 
 	// Task handlers.
 	if (config.previewBuildRunnerTasks) {
-		context.subscriptions.push(vs.tasks.registerTaskProvider("pub", new PubBuildRunnerTaskProvider(sdks)));
+		const provider = new PubBuildRunnerTaskProvider(sdks);
+		context.subscriptions.push(vs.tasks.registerTaskProvider(provider.type, provider));
 	}
 
 	// Snippets are language-specific

--- a/src/extension/pub/build_runner_task_provider.ts
+++ b/src/extension/pub/build_runner_task_provider.ts
@@ -10,6 +10,8 @@ import * as util from "../utils";
 import { getToolEnv } from "../utils/processes";
 
 export class PubBuildRunnerTaskProvider implements vs.TaskProvider {
+	readonly type = "pub"; // also referenced in package.json
+
 	constructor(private sdks: Sdks) { }
 
 	public provideTasks(token?: vs.CancellationToken): vs.ProviderResult<vs.Task[]> {
@@ -30,7 +32,7 @@ export class PubBuildRunnerTaskProvider implements vs.TaskProvider {
 
 	private createBuildRunnerCommandBackgroundTask(folder: vs.WorkspaceFolder, subCommand: string, group: vs.TaskGroup) {
 		const isFlutter = util.isFlutterWorkspaceFolder(folder) && this.sdks.flutter;
-		const type = isFlutter ? "flutter" : "pub";
+		const type = this.type;
 		const program = isFlutter ? path.join(this.sdks.flutter!, flutterPath) : path.join(this.sdks.dart!, pubPath);
 		const args = isFlutter ? ["pub", "run", "build_runner", subCommand] : ["run", "build_runner", subCommand];
 		if (config.buildRunnerAdditionalArgs) {


### PR DESCRIPTION
Enable previewBuildRunnerTasks in flutter project and then execute
Command Palette > Tasks: Run task > Show all tasks...

You will see this error:
The task provider for "pub" tasks unexpectedly provided a task of type "flutter".

Probably because pub is hardcoded here:
https://github.com/Dart-Code/Dart-Code/blob/b6aac604c02af46d66f99e01650c2b4b50c9edfc/src/extension/extension.ts#L337

So I changed the code to always use "pub".