### PR TITLE
Fixes Flutter app from being incorrectly set as a Web debug target

### DIFF
--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -150,10 +150,10 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			&& !isInsideFolderNamed(debugConfig.program, "tool")
 			&& !isInsideFolderNamed(debugConfig.program, ".dart_tool")) {
 			// Check if we're a Flutter or Web project.
-			if (isInsideFolderNamed(debugConfig.program, "web") && !isInsideFolderNamed(debugConfig.program, "test")) {
-				debugType = DebuggerType.Web;
-			} else if (isFlutterProjectFolder(debugConfig.cwd as string))
+			if (isFlutterProjectFolder(debugConfig.cwd as string)) {
 				debugType = DebuggerType.Flutter;
+			} else if (isInsideFolderNamed(debugConfig.program, "web") && !isInsideFolderNamed(debugConfig.program, "test"))
+				debugType = DebuggerType.Web;
 			else
 				logger.info(`Project (${debugConfig.program}) not recognised as Flutter or Web, will use Dart debugger`);
 		}


### PR DESCRIPTION
The conditionals to determine the debug type to use (eg. Flutter) is too aggressive and prevented the use of a launch path such as `lib/web/myfile.dart` due to being misconstrued as a Web project.

Fixes #2690.