### PR TITLE
Switch to a single webpack'd debug adapter

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,27 @@
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}"
 			],
+			"preLaunchTask": "npm: watch",
+			"presentation": {
+				"order": 0
+			},
+			"request": "launch",
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"smartStep": true,
+			"skipFiles": [
+				"<node_internals>/**",
+				"**/app/out/vs/**"
+			]
+		},
+		{
+			"name": "Extension (Debuggable)",
+			"type": "extensionHost",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}"
+			],
 			"env": {
 				"DART_CODE_USE_DEBUG_SERVERS": "true"
 			},
@@ -693,9 +714,9 @@
 	],
 	"compounds": [
 		{
-			"name": "Extension + DAs",
+			"name": "Extension (Debuggable) + DAs",
 			"configurations": [
-				"Extension",
+				"Extension (Debuggable)",
 				"Dart Debug Server",
 				"Dart Test Debug Server",
 				"Web Debug Server",
@@ -704,7 +725,7 @@
 				"Flutter Test Debug Server"
 			],
 			"presentation": {
-				"order": 1
+				"order": 0
 			},
 			"stopAll": true
 		},

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,6 +31,7 @@
 			"type": "node",
 			"cwd": "${workspaceFolder}",
 			"program": "${workspaceFolder}/src/tool/generate_launch_configs.ts",
+			"preLaunchTask": "npm: watch",
 			"presentation": {
 				"order": 2
 			},
@@ -48,8 +49,9 @@
 			"name": "Dart Debug Server",
 			"type": "node",
 			"cwd": "${workspaceFolder}",
-			"program": "${workspaceFolder}/src/debug/dart_debug_entry.ts",
+			"program": "${workspaceFolder}/out/dist/debug.js",
 			"args": [
+				"dart",
 				"--server=4715"
 			],
 			"preLaunchTask": "npm: watch",
@@ -70,53 +72,10 @@
 			"name": "Dart Test Debug Server",
 			"type": "node",
 			"cwd": "${workspaceFolder}",
-			"program": "${workspaceFolder}/src/debug/dart_test_debug_entry.ts",
+			"program": "${workspaceFolder}/out/dist/debug.js",
 			"args": [
+				"dart_test",
 				"--server=4716"
-			],
-			"preLaunchTask": "npm: watch",
-			"presentation": {
-				"hidden": true
-			},
-			"request": "launch",
-			"outFiles": [
-				"${workspaceFolder}/out/**/*.js"
-			],
-			"smartStep": true,
-			"skipFiles": [
-				"<node_internals>/**",
-				"**/app/out/vs/**"
-			]
-		},
-		{
-			"name": "Flutter Debug Server",
-			"type": "node",
-			"cwd": "${workspaceFolder}",
-			"program": "${workspaceFolder}/src/debug/flutter_debug_entry.ts",
-			"args": [
-				"--server=4711"
-			],
-			"preLaunchTask": "npm: watch",
-			"presentation": {
-				"hidden": true
-			},
-			"request": "launch",
-			"outFiles": [
-				"${workspaceFolder}/out/**/*.js"
-			],
-			"smartStep": true,
-			"skipFiles": [
-				"<node_internals>/**",
-				"**/app/out/vs/**"
-			]
-		},
-		{
-			"name": "Flutter Test Debug Server",
-			"type": "node",
-			"cwd": "${workspaceFolder}",
-			"program": "${workspaceFolder}/src/debug/flutter_test_debug_entry.ts",
-			"args": [
-				"--server=4712"
 			],
 			"preLaunchTask": "npm: watch",
 			"presentation": {
@@ -136,8 +95,9 @@
 			"name": "Web Debug Server",
 			"type": "node",
 			"cwd": "${workspaceFolder}",
-			"program": "${workspaceFolder}/src/debug/web_debug_entry.ts",
+			"program": "${workspaceFolder}/out/dist/debug.js",
 			"args": [
+				"web",
 				"--server=4713"
 			],
 			"preLaunchTask": "npm: watch",
@@ -158,8 +118,9 @@
 			"name": "Web Test Debug Server",
 			"type": "node",
 			"cwd": "${workspaceFolder}",
-			"program": "${workspaceFolder}/src/debug/web_test_debug_entry.ts",
+			"program": "${workspaceFolder}/out/dist/debug.js",
 			"args": [
+				"web_test",
 				"--server=4714"
 			],
 			"preLaunchTask": "npm: watch",
@@ -177,7 +138,53 @@
 			]
 		},
 		{
-			"name": "Dart Tests (hidden)",
+			"name": "Flutter Debug Server",
+			"type": "node",
+			"cwd": "${workspaceFolder}",
+			"program": "${workspaceFolder}/out/dist/debug.js",
+			"args": [
+				"flutter",
+				"--server=4711"
+			],
+			"preLaunchTask": "npm: watch",
+			"presentation": {
+				"hidden": true
+			},
+			"request": "launch",
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"smartStep": true,
+			"skipFiles": [
+				"<node_internals>/**",
+				"**/app/out/vs/**"
+			]
+		},
+		{
+			"name": "Flutter Test Debug Server",
+			"type": "node",
+			"cwd": "${workspaceFolder}",
+			"program": "${workspaceFolder}/out/dist/debug.js",
+			"args": [
+				"flutter_test",
+				"--server=4712"
+			],
+			"preLaunchTask": "npm: watch",
+			"presentation": {
+				"hidden": true
+			},
+			"request": "launch",
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"smartStep": true,
+			"skipFiles": [
+				"<node_internals>/**",
+				"**/app/out/vs/**"
+			]
+		},
+		{
+			"name": "Dart Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -205,7 +212,7 @@
 			]
 		},
 		{
-			"name": "Dart LSP Tests (hidden)",
+			"name": "Dart LSP Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -234,7 +241,7 @@
 			]
 		},
 		{
-			"name": "Dart Debug Tests (hidden)",
+			"name": "Dart Debug Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -262,7 +269,7 @@
 			]
 		},
 		{
-			"name": "Web Debug Tests (hidden)",
+			"name": "Web Debug Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -290,7 +297,7 @@
 			]
 		},
 		{
-			"name": "Flutter Tests (hidden)",
+			"name": "Flutter Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -318,7 +325,7 @@
 			]
 		},
 		{
-			"name": "Flutter LSP Tests (hidden)",
+			"name": "Flutter LSP Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -347,7 +354,7 @@
 			]
 		},
 		{
-			"name": "Flutter Debug Tests (hidden)",
+			"name": "Flutter Debug Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -375,7 +382,7 @@
 			]
 		},
 		{
-			"name": "Flutter Debug Chrome Tests (hidden)",
+			"name": "Flutter Debug Chrome Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -404,7 +411,7 @@
 			]
 		},
 		{
-			"name": "Flutter Test Debug Tests (hidden)",
+			"name": "Flutter Test Debug Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -432,7 +439,7 @@
 			]
 		},
 		{
-			"name": "Multi Root Tests (hidden)",
+			"name": "Multi Root Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -460,7 +467,7 @@
 			]
 		},
 		{
-			"name": "Multi Project Folder Tests (hidden)",
+			"name": "Multi Project Folder Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -488,7 +495,7 @@
 			]
 		},
 		{
-			"name": "Dart Create Tests Tests (hidden)",
+			"name": "Dart Create Tests Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -516,7 +523,7 @@
 			]
 		},
 		{
-			"name": "Not Activated / Dart Create Tests (hidden)",
+			"name": "Not Activated / Dart Create Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -544,7 +551,7 @@
 			]
 		},
 		{
-			"name": "Flutter Create Tests Tests (hidden)",
+			"name": "Flutter Create Tests Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -572,7 +579,7 @@
 			]
 		},
 		{
-			"name": "Not Activated / Flutter Create Tests (hidden)",
+			"name": "Not Activated / Flutter Create Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -600,7 +607,7 @@
 			]
 		},
 		{
-			"name": "Flutter Bazel Tests (hidden)",
+			"name": "Flutter Bazel Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -628,7 +635,7 @@
 			]
 		},
 		{
-			"name": "Flutter Snap Tests (hidden)",
+			"name": "Flutter Snap Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -656,7 +663,7 @@
 			]
 		},
 		{
-			"name": "Flutter Repository Tests (hidden)",
+			"name": "Flutter Repository Tests",
 			"type": "extensionHost",
 			"runtimeExecutable": "${execPath}",
 			"args": [
@@ -691,10 +698,10 @@
 				"Extension",
 				"Dart Debug Server",
 				"Dart Test Debug Server",
-				"Flutter Debug Server",
-				"Flutter Test Debug Server",
 				"Web Debug Server",
-				"Web Test Debug Server"
+				"Web Test Debug Server",
+				"Flutter Debug Server",
+				"Flutter Test Debug Server"
 			],
 			"presentation": {
 				"order": 1
@@ -702,9 +709,9 @@
 			"stopAll": true
 		},
 		{
-			"name": "Dart Tests",
+			"name": "Dart Tests + DAs",
 			"configurations": [
-				"Dart Tests (hidden)"
+				"Dart Tests"
 			],
 			"presentation": {
 				"order": 3
@@ -712,9 +719,9 @@
 			"stopAll": true
 		},
 		{
-			"name": "Dart LSP Tests",
+			"name": "Dart LSP Tests + DAs",
 			"configurations": [
-				"Dart LSP Tests (hidden)"
+				"Dart LSP Tests"
 			],
 			"presentation": {
 				"order": 3
@@ -724,7 +731,7 @@
 		{
 			"name": "Dart Debug Tests + DAs",
 			"configurations": [
-				"Dart Debug Tests (hidden)",
+				"Dart Debug Tests",
 				"Dart Debug Server",
 				"Dart Test Debug Server"
 			],
@@ -736,7 +743,7 @@
 		{
 			"name": "Web Debug Tests + DAs",
 			"configurations": [
-				"Web Debug Tests (hidden)",
+				"Web Debug Tests",
 				"Web Debug Server",
 				"Web Test Debug Server"
 			],
@@ -746,9 +753,9 @@
 			"stopAll": true
 		},
 		{
-			"name": "Flutter Tests",
+			"name": "Flutter Tests + DAs",
 			"configurations": [
-				"Flutter Tests (hidden)"
+				"Flutter Tests"
 			],
 			"presentation": {
 				"order": 3
@@ -756,9 +763,9 @@
 			"stopAll": true
 		},
 		{
-			"name": "Flutter LSP Tests",
+			"name": "Flutter LSP Tests + DAs",
 			"configurations": [
-				"Flutter LSP Tests (hidden)"
+				"Flutter LSP Tests"
 			],
 			"presentation": {
 				"order": 3
@@ -768,7 +775,7 @@
 		{
 			"name": "Flutter Debug Tests + DAs",
 			"configurations": [
-				"Flutter Debug Tests (hidden)",
+				"Flutter Debug Tests",
 				"Flutter Debug Server"
 			],
 			"presentation": {
@@ -779,7 +786,7 @@
 		{
 			"name": "Flutter Debug Chrome Tests + DAs",
 			"configurations": [
-				"Flutter Debug Chrome Tests (hidden)",
+				"Flutter Debug Chrome Tests",
 				"Flutter Debug Server"
 			],
 			"presentation": {
@@ -790,7 +797,7 @@
 		{
 			"name": "Flutter Test Debug Tests + DAs",
 			"configurations": [
-				"Flutter Test Debug Tests (hidden)",
+				"Flutter Test Debug Tests",
 				"Flutter Test Debug Server"
 			],
 			"presentation": {
@@ -799,9 +806,9 @@
 			"stopAll": true
 		},
 		{
-			"name": "Multi Root Tests",
+			"name": "Multi Root Tests + DAs",
 			"configurations": [
-				"Multi Root Tests (hidden)"
+				"Multi Root Tests"
 			],
 			"presentation": {
 				"order": 3
@@ -809,9 +816,9 @@
 			"stopAll": true
 		},
 		{
-			"name": "Multi Project Folder Tests",
+			"name": "Multi Project Folder Tests + DAs",
 			"configurations": [
-				"Multi Project Folder Tests (hidden)"
+				"Multi Project Folder Tests"
 			],
 			"presentation": {
 				"order": 3
@@ -819,9 +826,9 @@
 			"stopAll": true
 		},
 		{
-			"name": "Dart Create Tests Tests",
+			"name": "Dart Create Tests Tests + DAs",
 			"configurations": [
-				"Dart Create Tests Tests (hidden)"
+				"Dart Create Tests Tests"
 			],
 			"presentation": {
 				"order": 3
@@ -829,9 +836,9 @@
 			"stopAll": true
 		},
 		{
-			"name": "Not Activated / Dart Create Tests",
+			"name": "Not Activated / Dart Create Tests + DAs",
 			"configurations": [
-				"Not Activated / Dart Create Tests (hidden)"
+				"Not Activated / Dart Create Tests"
 			],
 			"presentation": {
 				"order": 3
@@ -839,9 +846,9 @@
 			"stopAll": true
 		},
 		{
-			"name": "Flutter Create Tests Tests",
+			"name": "Flutter Create Tests Tests + DAs",
 			"configurations": [
-				"Flutter Create Tests Tests (hidden)"
+				"Flutter Create Tests Tests"
 			],
 			"presentation": {
 				"order": 3
@@ -849,9 +856,9 @@
 			"stopAll": true
 		},
 		{
-			"name": "Not Activated / Flutter Create Tests",
+			"name": "Not Activated / Flutter Create Tests + DAs",
 			"configurations": [
-				"Not Activated / Flutter Create Tests (hidden)"
+				"Not Activated / Flutter Create Tests"
 			],
 			"presentation": {
 				"order": 3
@@ -859,9 +866,9 @@
 			"stopAll": true
 		},
 		{
-			"name": "Flutter Bazel Tests",
+			"name": "Flutter Bazel Tests + DAs",
 			"configurations": [
-				"Flutter Bazel Tests (hidden)"
+				"Flutter Bazel Tests"
 			],
 			"presentation": {
 				"order": 3
@@ -869,9 +876,9 @@
 			"stopAll": true
 		},
 		{
-			"name": "Flutter Snap Tests",
+			"name": "Flutter Snap Tests + DAs",
 			"configurations": [
-				"Flutter Snap Tests (hidden)"
+				"Flutter Snap Tests"
 			],
 			"presentation": {
 				"order": 3
@@ -879,9 +886,9 @@
 			"stopAll": true
 		},
 		{
-			"name": "Flutter Repository Tests",
+			"name": "Flutter Repository Tests + DAs",
 			"configurations": [
-				"Flutter Repository Tests (hidden)"
+				"Flutter Repository Tests"
 			],
 			"presentation": {
 				"order": 3

--- a/package.json
+++ b/package.json
@@ -1999,7 +1999,7 @@
 		"build-with-instrumentation": "webpack --env.instrumentation --mode development",
 		"watch": "webpack --mode development --watch --info-verbosity verbose",
 		"build-tests": "tsc -p ./",
-		"watch-non-ext": "tsc -p ./ --watch",
+		"watch-non-ext": "tsc -p ./ --watch --extendedDiagnostics",
 		"lint": "tslint --project tsconfig.json 'src/**/*.ts' -t verbose",
 		"test": "npm run build-with-instrumentation && npm run build-tests && npm run instrument && npm run test-only && npm run report_lcov && npm run report_screen",
 		"instrument": "cd out/src && nyc instrument --compact false --in-place . . && cd ../..",

--- a/package.json
+++ b/package.json
@@ -1747,7 +1747,7 @@
 			{
 				"type": "dart",
 				"label": "Dart & Flutter",
-				"program": "./out/src/extension/debug/dart_debug_entry.js",
+				"program": "./out/src/dist/debug.js",
 				"runtime": "node",
 				"languages": [
 					"dart"

--- a/src/debug/dart_debug_entry.ts
+++ b/src/debug/dart_debug_entry.ts
@@ -1,4 +1,0 @@
-import { DebugSession } from "vscode-debugadapter";
-import { DartDebugSession } from "./dart_debug_impl";
-
-DebugSession.run(DartDebugSession);

--- a/src/debug/dart_test_debug_entry.ts
+++ b/src/debug/dart_test_debug_entry.ts
@@ -1,4 +1,0 @@
-import { DebugSession } from "vscode-debugadapter";
-import { DartTestDebugSession } from "./dart_test_debug_impl";
-
-DebugSession.run(DartTestDebugSession);

--- a/src/debug/debug_entry.ts
+++ b/src/debug/debug_entry.ts
@@ -1,0 +1,26 @@
+import { DebugSession } from "vscode-debugadapter";
+import { DartDebugSession } from "./dart_debug_impl";
+import { DartTestDebugSession } from "./dart_test_debug_impl";
+import { FlutterDebugSession } from "./flutter_debug_impl";
+import { FlutterTestDebugSession } from "./flutter_test_debug_impl";
+import { WebDebugSession } from "./web_debug_impl";
+import { WebTestDebugSession } from "./web_test_debug_impl";
+
+const args = process.argv.slice(2);
+const debugType = args.length ? args[0] : undefined;
+
+const debuggers: { [key: string]: any } = {
+	"dart": DartDebugSession,
+	"dart_test": DartTestDebugSession,
+	"flutter": FlutterDebugSession,
+	"flutter_test": FlutterTestDebugSession,
+	"web": WebDebugSession,
+	"web_test": WebTestDebugSession,
+};
+
+const dbg = debugType ? debuggers[debugType] : undefined;
+if (dbg) {
+	DebugSession.run(dbg);
+} else {
+	throw new Error(`Debugger type must be one of ${Object.keys(debuggers).join(', ')} but got ${debugType}`);
+}

--- a/src/debug/flutter_debug_entry.ts
+++ b/src/debug/flutter_debug_entry.ts
@@ -1,4 +1,0 @@
-import { DebugSession } from "vscode-debugadapter";
-import { FlutterDebugSession } from "./flutter_debug_impl";
-
-DebugSession.run(FlutterDebugSession);

--- a/src/debug/flutter_test_debug_entry.ts
+++ b/src/debug/flutter_test_debug_entry.ts
@@ -1,4 +1,0 @@
-import { DebugSession } from "vscode-debugadapter";
-import { FlutterTestDebugSession } from "./flutter_test_debug_impl";
-
-DebugSession.run(FlutterTestDebugSession);

--- a/src/debug/web_debug_entry.ts
+++ b/src/debug/web_debug_entry.ts
@@ -1,4 +1,0 @@
-import { DebugSession } from "vscode-debugadapter";
-import { WebDebugSession } from "./web_debug_impl";
-
-DebugSession.run(WebDebugSession);

--- a/src/debug/web_test_debug_entry.ts
+++ b/src/debug/web_test_debug_entry.ts
@@ -1,4 +1,0 @@
-import { DebugSession } from "vscode-debugadapter";
-import { WebTestDebugSession } from "./web_test_debug_impl";
-
-DebugSession.run(WebTestDebugSession);

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -404,7 +404,7 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 	// Set up debug stuff.
 	const debugProvider = new DebugConfigProvider(logger, workspaceContext, analytics, pubGlobal, flutterDaemon, deviceManager, dartCapabilities, flutterCapabilities);
 	context.subscriptions.push(vs.debug.registerDebugConfigurationProvider("dart", debugProvider));
-	context.subscriptions.push(vs.debug.registerDebugAdapterDescriptorFactory("dart", new DartDebugAdapterDescriptorFactory(context)));
+	context.subscriptions.push(vs.debug.registerDebugAdapterDescriptorFactory("dart", new DartDebugAdapterDescriptorFactory()));
 	// Also the providers for the initial configs.
 	context.subscriptions.push(vs.debug.registerDebugConfigurationProvider("dart", new InitialLaunchJsonDebugConfigProvider(), vs.DebugConfigurationProviderTriggerKind.Initial));
 	context.subscriptions.push(vs.debug.registerDebugConfigurationProvider("dart", new DynamicDebugConfigProvider(), vs.DebugConfigurationProviderTriggerKind.Dynamic));
@@ -632,7 +632,6 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 	return {
 		...new DartExtensionApi(),
 		[internalApiSymbol]: {
-			asAbsolutePath: (p) => context.asAbsolutePath(p),
 			analyzer,
 			analyzerCapabilities: dasClient && dasClient.capabilities,
 			cancelAllAnalysisRequests: () => dasClient && dasClient.cancelAllRequests(),

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -404,7 +404,7 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 	// Set up debug stuff.
 	const debugProvider = new DebugConfigProvider(logger, workspaceContext, analytics, pubGlobal, flutterDaemon, deviceManager, dartCapabilities, flutterCapabilities);
 	context.subscriptions.push(vs.debug.registerDebugConfigurationProvider("dart", debugProvider));
-	context.subscriptions.push(vs.debug.registerDebugAdapterDescriptorFactory("dart", new DartDebugAdapterDescriptorFactory()));
+	context.subscriptions.push(vs.debug.registerDebugAdapterDescriptorFactory("dart", new DartDebugAdapterDescriptorFactory(context)));
 	// Also the providers for the initial configs.
 	context.subscriptions.push(vs.debug.registerDebugConfigurationProvider("dart", new InitialLaunchJsonDebugConfigProvider(), vs.DebugConfigurationProviderTriggerKind.Initial));
 	context.subscriptions.push(vs.debug.registerDebugConfigurationProvider("dart", new DynamicDebugConfigProvider(), vs.DebugConfigurationProviderTriggerKind.Dynamic));

--- a/src/extension/providers/debug_adapter_descriptor_factory.ts
+++ b/src/extension/providers/debug_adapter_descriptor_factory.ts
@@ -1,8 +1,10 @@
-import { DebugAdapterDescriptor, DebugAdapterDescriptorFactory, DebugAdapterExecutable, DebugAdapterServer, DebugSession } from "vscode";
+import { DebugAdapterDescriptor, DebugAdapterDescriptorFactory, DebugAdapterExecutable, DebugAdapterServer, DebugSession, ExtensionContext } from "vscode";
 import { debugAdapterPath } from "../../shared/constants";
 import { getDebugAdapterName, getDebugAdapterPort } from "../../shared/utils/debug";
 
 export class DartDebugAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
+	constructor(private readonly extensionContext: ExtensionContext) { }
+
 	public createDebugAdapterDescriptor(session: DebugSession, executable: DebugAdapterExecutable | undefined): DebugAdapterDescriptor {
 		const debuggerName = getDebugAdapterName(session.configuration.debuggerType);
 
@@ -10,6 +12,6 @@ export class DartDebugAdapterDescriptorFactory implements DebugAdapterDescriptor
 			return new DebugAdapterServer(getDebugAdapterPort(debuggerName));
 		}
 
-		return new DebugAdapterExecutable("node", [debugAdapterPath, debuggerName]);
+		return new DebugAdapterExecutable("node", [this.extensionContext.asAbsolutePath(debugAdapterPath), debuggerName]);
 	}
 }

--- a/src/extension/providers/debug_adapter_descriptor_factory.ts
+++ b/src/extension/providers/debug_adapter_descriptor_factory.ts
@@ -1,17 +1,15 @@
-import { DebugAdapterDescriptor, DebugAdapterDescriptorFactory, DebugAdapterExecutable, DebugAdapterServer, DebugSession, ExtensionContext } from "vscode";
-import { getDebugAdapterPath, getDebugAdapterPort } from "../../shared/utils/debug";
+import { DebugAdapterDescriptor, DebugAdapterDescriptorFactory, DebugAdapterExecutable, DebugAdapterServer, DebugSession } from "vscode";
+import { debugAdapterPath } from "../../shared/constants";
+import { getDebugAdapterName, getDebugAdapterPort } from "../../shared/utils/debug";
 
 export class DartDebugAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
-	constructor(private readonly extensionContext: ExtensionContext) { }
-
 	public createDebugAdapterDescriptor(session: DebugSession, executable: DebugAdapterExecutable | undefined): DebugAdapterDescriptor {
-		const scriptPath = getDebugAdapterPath((p) => this.extensionContext.asAbsolutePath(p), session.configuration.debuggerType);
+		const debuggerName = getDebugAdapterName(session.configuration.debuggerType);
 
 		if (process.env.DART_CODE_USE_DEBUG_SERVERS) {
-			return new DebugAdapterServer(getDebugAdapterPort(scriptPath));
+			return new DebugAdapterServer(getDebugAdapterPort(debuggerName));
 		}
 
-		const args = [scriptPath];
-		return new DebugAdapterExecutable("node", args);
+		return new DebugAdapterExecutable("node", [debugAdapterPath, debuggerName]);
 	}
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 
 export const dartCodeExtensionIdentifier = "Dart-Code.dart-code";
 export const flutterExtensionIdentifier = "Dart-Code.flutter";
+export const debugAdapterPath = 'out/dist/debug.js';
 
 export const isWin = /^win/.test(process.platform);
 export const isMac = process.platform === "darwin";

--- a/src/shared/utils/debug.ts
+++ b/src/shared/utils/debug.ts
@@ -1,47 +1,44 @@
-import * as path from "path";
 import { DebuggerType } from "../enums";
 
-export function getDebugAdapterPath(asAbsolutePath: (path: string) => string, debugType: DebuggerType) {
-	let debuggerScript: string;
+export function getDebugAdapterName(debugType: DebuggerType) {
+	let debuggerName: string;
 	switch (debugType) {
 		case DebuggerType.Flutter:
-			debuggerScript = "flutter_debug_entry";
+			debuggerName = "flutter";
 			break;
 		case DebuggerType.FlutterTest:
-			debuggerScript = "flutter_test_debug_entry";
+			debuggerName = "flutter_test";
 			break;
 		case DebuggerType.Web:
-			debuggerScript = "web_debug_entry";
+			debuggerName = "web";
 			break;
 		case DebuggerType.WebTest:
-			debuggerScript = "web_test_debug_entry"
+			debuggerName = "web_test"
 			break;
 		case DebuggerType.Dart:
-			debuggerScript = "dart_debug_entry";
+			debuggerName = "dart";
 			break;
 		case DebuggerType.PubTest:
-			debuggerScript = "dart_test_debug_entry";
+			debuggerName = "dart_test";
 			break;
 		default:
-			throw new Error("Unknown debugger type");
+			throw new Error(`Unknown debugger type: ${debugType}`);
 	}
 
-	return asAbsolutePath(`./out/src/debug/${debuggerScript}.js`);
+	return debuggerName;
 }
 
-export function getDebugAdapterPort(debuggerScript: string) {
-	// Get filename without extension.
-	debuggerScript = path.basename(debuggerScript).split(".")[0];
-	const debugAdapterScripts = [
-		"flutter_debug_entry",
-		"flutter_test_debug_entry",
-		"web_debug_entry",
-		"web_test_debug_entry",
-		"dart_debug_entry",
-		"dart_test_debug_entry",
+export function getDebugAdapterPort(debuggerName: string) {
+	const debugAdapterNames = [
+		"flutter",
+		"flutter_test",
+		"web",
+		"web_test",
+		"dart",
+		"dart_test",
 	];
-	const index = debugAdapterScripts.indexOf(debuggerScript);
+	const index = debugAdapterNames.indexOf(debuggerName);
 	if (index === -1)
-		throw new Error("Unknown debugger type");
+		throw new Error(`Unknown debugger type: ${debuggerName}`);
 	return 4711 + index;
 }

--- a/src/shared/vscode/interfaces.ts
+++ b/src/shared/vscode/interfaces.ts
@@ -4,7 +4,7 @@ import { AvailableSuggestion, FlutterOutline, Outline } from "../analysis_server
 import { Analyzer } from "../analyzer";
 import { TestStatus, VersionStatus, VmService, VmServiceExtension } from "../enums";
 import { WebClient } from "../fetch";
-import { SpawnedProcess } from "../interfaces";
+import { CustomScript, SpawnedProcess } from "../interfaces";
 import { EmittingLogger } from "../logging";
 import { WorkspaceContext } from "../workspace";
 import { Context } from "./workspace";
@@ -76,7 +76,7 @@ export interface InternalExtensionApi {
 	nextAnalysis: () => Promise<void>;
 	packagesTreeProvider: TreeDataProvider<TreeItem>;
 	pubGlobal: {
-		promptToInstallIfRequired(packageName: string, packageID: string, moreInfoLink?: string, requiredVersion?: string, customActivateScript?: string, autoUpdate?: boolean): Promise<string | undefined>;
+		promptToInstallIfRequired(packageName: string, packageID: string, moreInfoLink?: string, requiredVersion?: string, customActivateScript?: CustomScript, autoUpdate?: boolean): Promise<string | undefined>;
 		checkVersionStatus(packageID: string, installedVersion: string | undefined, requiredVersion?: string): Promise<VersionStatus>;
 		getInstalledVersion(packageName: string, packageID: string): Promise<string | undefined>;
 		uninstall(packageID: string): Promise<void>;

--- a/src/shared/vscode/interfaces.ts
+++ b/src/shared/vscode/interfaces.ts
@@ -20,7 +20,6 @@ export interface DebugCommandHandler {
 }
 
 export interface InternalExtensionApi {
-	asAbsolutePath: (path: string) => string,
 	analyzerCapabilities?: {
 		supportsGetSignature: boolean;
 		isDart2: boolean;

--- a/src/test/dart_debug_client.ts
+++ b/src/test/dart_debug_client.ts
@@ -10,14 +10,14 @@ import { delay, logger, watchPromise, withTimeout } from "./helpers";
 
 const customEventsToForward = ["dart.log", "dart.serviceExtensionAdded", "dart.serviceRegistered", "dart.debuggerUris", "dart.startTerminalProcess", "dart.exposeUrl"];
 
-type DebugClientArgs = { runtime: string, executable: string, port?: undefined } | { runtime?: undefined, executable?: undefined, port: number };
+type DebugClientArgs = { runtime: string, executable: string, args: string[], port?: undefined } | { runtime?: undefined, executable?: undefined, args?: undefined, port: number };
 
 export class DartDebugClient extends DebugClient {
 	private readonly port: number | undefined;
 	private currentSession?: DebugSession;
 
 	constructor(args: DebugClientArgs, private debugCommands: DebugCommandHandler, testProvider: TestResultsProvider | undefined) {
-		super(args.runtime, args.executable, "dart", undefined, true);
+		super(args.runtime, args.executable, args.args, "dart", undefined, true);
 		this.port = args.port;
 
 		// HACK to handle incoming requests..

--- a/src/test/debug_client_ms.ts
+++ b/src/test/debug_client_ms.ts
@@ -39,6 +39,7 @@ export class DebugClient extends ProtocolClient {
 
 	private _runtime: string | undefined;
 	private _executable: string | undefined;
+	private _args: string[] | undefined;
 	private _adapterProcess?: cp.ChildProcess;
 	private _spawnOptions?: cp.SpawnOptionsWithoutStdio;
 	private _enableStderr: boolean;
@@ -65,10 +66,11 @@ export class DebugClient extends ProtocolClient {
 	 *     return dc.hitBreakpoint({ program: 'test.js' }, 'test.js', 15);
 	 * });
 	 */
-	constructor(runtime: string | undefined, executable: string | undefined, debugType: string, spawnOptions?: cp.SpawnOptionsWithoutStdio, enableStderr?: boolean) {
+	constructor(runtime: string | undefined, executable: string | undefined, args: string[] | undefined, debugType: string, spawnOptions?: cp.SpawnOptionsWithoutStdio, enableStderr?: boolean) {
 		super();
 		this._runtime = runtime;
 		this._executable = executable;
+		this._args = args;
 		this._spawnOptions = spawnOptions;
 		this._enableStderr = !!enableStderr;
 		this._debugType = debugType;
@@ -102,7 +104,7 @@ export class DebugClient extends ProtocolClient {
 					resolve();
 				});
 			} else {
-				this._adapterProcess = cp.spawn(this._runtime!, [this._executable!], this._spawnOptions);
+				this._adapterProcess = cp.spawn(this._runtime!, [this._executable!, ...(this._args || [])], this._spawnOptions);
 				const sanitize = (s: string) => s.toString().replace(/\r?\n$/mg, '');
 				this._adapterProcess.stderr!.on('data', (data: string) => {
 					if (this._enableStderr) {

--- a/src/test/debug_helpers.ts
+++ b/src/test/debug_helpers.ts
@@ -40,7 +40,7 @@ export function createDebugClient(debugType: DebuggerType) {
 
 	dc.defaultTimeout = 60000;
 	const thisDc = dc;
-	if (debugAdapterPath.indexOf("_test_") !== -1) {
+	if (debugAdapterName.endsWith("_test")) {
 		// The test runner doesn't quit on the first SIGINT, it prints a message that it's waiting for the
 		// test to finish and then runs cleanup. Since we don't care about this for these tests, we just send
 		// a second request and that'll cause it to quit immediately.

--- a/src/test/debug_helpers.ts
+++ b/src/test/debug_helpers.ts
@@ -2,11 +2,11 @@ import * as assert from "assert";
 import * as path from "path";
 import { DebugConfiguration, Uri } from "vscode";
 import { DebugProtocol } from "vscode-debugprotocol";
-import { dartVMPath, isWin, vmServiceListeningBannerPattern } from "../shared/constants";
+import { dartVMPath, debugAdapterPath, isWin, vmServiceListeningBannerPattern } from "../shared/constants";
 import { DebuggerType, LogCategory } from "../shared/enums";
 import { SpawnedProcess } from "../shared/interfaces";
 import { logProcess } from "../shared/logging";
-import { getDebugAdapterPath, getDebugAdapterPort } from "../shared/utils/debug";
+import { getDebugAdapterName, getDebugAdapterPort } from "../shared/utils/debug";
 import { fsPath } from "../shared/utils/fs";
 import { DartDebugClient } from "./dart_debug_client";
 import { currentTestName, defer, delay, extApi, getLaunchConfiguration, logger, watchPromise, withTimeout } from "./helpers";
@@ -27,12 +27,12 @@ export async function startDebugger(dc: DartDebugClient, script?: Uri | string, 
 }
 
 export function createDebugClient(debugType: DebuggerType) {
-	const debugAdapterPath = getDebugAdapterPath((p) => extApi.asAbsolutePath(p), debugType);
-	const debugAdapterPort = getDebugAdapterPort(debugAdapterPath);
+	const debugAdapterName = getDebugAdapterName(debugType);
+	const debugAdapterPort = getDebugAdapterPort(debugAdapterName);
 
 	const dc = process.env.DART_CODE_USE_DEBUG_SERVERS
 		? new DartDebugClient({ port: debugAdapterPort }, extApi.debugCommands, extApi.testTreeProvider)
-		: new DartDebugClient({ runtime: "node", executable: debugAdapterPath }, extApi.debugCommands, extApi.testTreeProvider);
+		: new DartDebugClient({ runtime: "node", executable: debugAdapterPath, args: [debugAdapterName] }, extApi.debugCommands, extApi.testTreeProvider);
 
 	dc.defaultTimeout = 60000;
 	const thisDc = dc;

--- a/src/test/debug_helpers.ts
+++ b/src/test/debug_helpers.ts
@@ -9,7 +9,7 @@ import { logProcess } from "../shared/logging";
 import { getDebugAdapterName, getDebugAdapterPort } from "../shared/utils/debug";
 import { fsPath } from "../shared/utils/fs";
 import { DartDebugClient } from "./dart_debug_client";
-import { currentTestName, defer, delay, extApi, getLaunchConfiguration, logger, watchPromise, withTimeout } from "./helpers";
+import { currentTestName, defer, delay, ext, extApi, getLaunchConfiguration, logger, watchPromise, withTimeout } from "./helpers";
 
 export const flutterTestDeviceId = process.env.FLUTTER_TEST_DEVICE_ID || "flutter-tester";
 export const flutterTestDeviceIsWeb = flutterTestDeviceId === "chrome" || flutterTestDeviceId === "web-server";
@@ -29,12 +29,14 @@ export async function startDebugger(dc: DartDebugClient, script?: Uri | string, 
 export function createDebugClient(debugType: DebuggerType) {
 	const debugAdapterName = getDebugAdapterName(debugType);
 	const debugAdapterPort = getDebugAdapterPort(debugAdapterName);
+	const debuggerExecutablePath = path.join(fsPath(ext.extensionUri), debugAdapterPath);
+	const debuggerArgs = [debugAdapterName];
 
 	// TODO: Change this to go through DartDebugAdapterDescriptorFactory to ensure we don't have tests that pass
 	// if we've broken the real implementation.
 	const dc = process.env.DART_CODE_USE_DEBUG_SERVERS
 		? new DartDebugClient({ port: debugAdapterPort }, extApi.debugCommands, extApi.testTreeProvider)
-		: new DartDebugClient({ runtime: "node", executable: debugAdapterPath, args: [debugAdapterName] }, extApi.debugCommands, extApi.testTreeProvider);
+		: new DartDebugClient({ runtime: "node", executable: debuggerExecutablePath, args: debuggerArgs }, extApi.debugCommands, extApi.testTreeProvider);
 
 	dc.defaultTimeout = 60000;
 	const thisDc = dc;

--- a/src/test/debug_helpers.ts
+++ b/src/test/debug_helpers.ts
@@ -30,6 +30,8 @@ export function createDebugClient(debugType: DebuggerType) {
 	const debugAdapterName = getDebugAdapterName(debugType);
 	const debugAdapterPort = getDebugAdapterPort(debugAdapterName);
 
+	// TODO: Change this to go through DartDebugAdapterDescriptorFactory to ensure we don't have tests that pass
+	// if we've broken the real implementation.
 	const dc = process.env.DART_CODE_USE_DEBUG_SERVERS
 		? new DartDebugClient({ port: debugAdapterPort }, extApi.debugCommands, extApi.testTreeProvider)
 		: new DartDebugClient({ runtime: "node", executable: debugAdapterPath, args: [debugAdapterName] }, extApi.debugCommands, extApi.testTreeProvider);

--- a/src/tool/generate_launch_configs.ts
+++ b/src/tool/generate_launch_configs.ts
@@ -35,19 +35,20 @@ async function main() {
 		"version": "0.1.0",
 		"configurations": [
 			getExtensionConfig(),
+			getDebuggableExtensionConfig(),
 			getGenerateLaunchConfigConfig(),
 			...debugAdapters.map((name) => getDebugServerConfig(name)),
 			...testConfigs.map(getTestsConfig),
 		],
 		"compounds": [
 			{
-				"name": "Extension + DAs",
+				"name": "Extension (Debuggable) + DAs",
 				"configurations": [
-					"Extension",
+					"Extension (Debuggable)",
 					...debugAdapters.map((name) => getDebugServerConfigName(name))
 				],
 				"presentation": {
-					"order": 1
+					"order": 0
 				},
 				"stopAll": true,
 			},
@@ -108,9 +109,9 @@ function titleCase(input: string) {
 	return `${input[0].toUpperCase()}${input.slice(1)}`;
 }
 
-function getExtensionConfig() {
+function getDebuggableExtensionConfig() {
 	return Object.assign({
-		"name": "Extension",
+		"name": "Extension (Debuggable)",
 		"type": "extensionHost",
 		"runtimeExecutable": "${execPath}",
 		"args": [
@@ -122,6 +123,21 @@ function getExtensionConfig() {
 		"preLaunchTask": "npm: watch",
 		"presentation": {
 			"hidden": true,
+		}
+	}, template);
+}
+
+function getExtensionConfig() {
+	return Object.assign({
+		"name": "Extension",
+		"type": "extensionHost",
+		"runtimeExecutable": "${execPath}",
+		"args": [
+			"--extensionDevelopmentPath=${workspaceFolder}"
+		],
+		"preLaunchTask": "npm: watch",
+		"presentation": {
+			"order": 0,
 		}
 	}, template);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,10 @@
 		"strict": true
 	},
 	"exclude": [
+		".vscode-test",
 		"node_modules",
-		".vscode-test"
+		"out",
+		"src/extension",
+		"src/debug",
 	]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,10 @@ module.exports = env => {
 	 */
 	const config = {
 		devtool: "source-map",
-		entry: "./src/extension/extension.ts",
+		entry: {
+			extension: "./src/extension/extension.ts",
+			debug: "./src/debug/debug_entry.ts"
+		},
 		// https://webpack.js.org/configuration/externals/
 		externals: {
 			vscode: "commonjs vscode",
@@ -39,7 +42,6 @@ module.exports = env => {
 		},
 		output: {
 			devtoolModuleFilenameTemplate: "../../[resource-path]",
-			filename: "extension.js",
 			libraryTarget: "commonjs2",
 			path: path.resolve(__dirname, "out/dist"),
 		},


### PR DESCRIPTION
When running in-process these were all packed, but we lost that when running out-of-process. This packs into a single debug adapter that takes an argument for the debugger name (to avoid having many entry points all being built with webpack that are mostly the same).

