### PR TITLE
Tweaks to Flutter initialization

### DIFF
--- a/src/extension/sdk/flutter.ts
+++ b/src/extension/sdk/flutter.ts
@@ -1,0 +1,37 @@
+import { ProgressLocation, window } from "vscode";
+import { initializingFlutterMessage, noAction, yesAction } from "../../shared/constants";
+import { LogCategory } from "../../shared/enums";
+import { Logger } from "../../shared/interfaces";
+import { logProcess } from "../../shared/logging";
+import { safeToolSpawn } from "../utils/processes";
+
+export async function initializeFlutterSdk(logger: Logger, flutterScript: string, promptText?: string): Promise<void> {
+	const selectedItem = promptText ? await window.showInformationMessage(promptText, yesAction, noAction) : yesAction;
+	if (selectedItem === yesAction) {
+		logger.info(`Flutter is not initialized, running 'flutter config --machine'...`);
+		await window.withProgress(
+			{
+				location: ProgressLocation.Notification,
+				title: initializingFlutterMessage,
+			},
+			async (progress, cancellationToken) => {
+				const proc = safeToolSpawn(undefined, flutterScript, ["config", "--machine"]);
+				cancellationToken.onCancellationRequested((e) => {
+					logger.info(`User canceled!`);
+					proc.kill();
+				});
+				logProcess(logger, LogCategory.CommandProcesses, proc);
+				return new Promise((resolve, reject) => proc.on("exit", (code) => {
+					if (code) {
+						logger.error(`Failed to initialize Flutter: Process exited with code ${code}.`);
+						window.showErrorMessage(`Failed to initialize Flutter: Process exited with code ${code}.`);
+						reject();
+					}
+					else
+						resolve();
+				}))
+			},
+		);
+		logger.info(`Flutter initialized!`);
+	}
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -73,7 +73,7 @@ export const skipThisSurveyAction = "Skip This Survey";
 export const modifyingFilesOutsideWorkspaceInfoUrl = "https://dartcode.org/docs/modifying-files-outside-workspace/";
 
 export const initializeSnapPrompt = "The Flutter snap is installed but not initialized. Would you like to initialize it now? This may take a few minutes.";
-export const initializingSnapMessage = "Initializing Flutter snap…";
+export const initializingFlutterMessage = "Initializing Flutter…";
 
 // Minutes.
 export const fiveMinutesInMs = 1000 * 60 * 5;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -72,8 +72,8 @@ export const skipThisSurveyAction = "Skip This Survey";
 
 export const modifyingFilesOutsideWorkspaceInfoUrl = "https://dartcode.org/docs/modifying-files-outside-workspace/";
 
-export const initializeSnapPrompt = "The Flutter snap is installed but not initialized. Would you like to initialize it now? This may take a few minutes.";
-export const initializingFlutterMessage = "Initializing Flutter…";
+export const initializeSnapPrompt = "The Flutter snap is installed but not initialized. Would you like to initialize it now?";
+export const initializingFlutterMessage = "Initializing Flutter. This may take a few minutes.";
 
 // Minutes.
 export const fiveMinutesInMs = 1000 * 60 * 5;


### PR DESCRIPTION
If Flutter is missing the `version` file or `bin/cache/dart-sdk`, this will show an "initializing..." notification (same as Snap support already did) and delay activation until that's done. This prevents some weird edge cases (including #2638) where we might initialize badly.

@MarcusTomlinson this shouldn't change anything for snap (and the CI tests still pass), it's mostly just making some of its code reusable - but FYI! (I'll likely make a beta build including this in the next few days).