### PR TITLE
Add option to re-run only failed tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,6 +220,16 @@
 				"category": "Dart"
 			},
 			{
+				"command": "dart.startDebuggingFailedTests",
+				"title": "Debug Failed",
+				"category": "Dart"
+			},
+			{
+				"command": "dart.startWithoutDebuggingFailedTests",
+				"title": "Run Failed",
+				"category": "Dart"
+			},
+			{
 				"command": "dart.sortMembers",
 				"title": "Sort Members",
 				"category": "Dart"
@@ -609,6 +619,14 @@
 				},
 				{
 					"command": "dart.startWithoutDebuggingTest",
+					"when": "false"
+				},
+				{
+					"command": "dart.startDebuggingFailedTests",
+					"when": "false"
+				},
+				{
+					"command": "dart.startWithoutDebuggingFailedTests",
 					"when": "false"
 				},
 				{
@@ -1056,7 +1074,17 @@
 				{
 					"when": "dart-code:dartProjectLoaded && viewItem == dart-code:testSuiteNode",
 					"command": "dart.startWithoutDebuggingTest",
-					"group": "4.5_exec@1"
+					"group": "4.5_exec@2"
+				},
+				{
+					"when": "dart-code:dartProjectLoaded && viewItem == dart-code:testSuiteNode",
+					"command": "dart.startDebuggingFailedTests",
+					"group": "4.5_exec@3"
+				},
+				{
+					"when": "dart-code:dartProjectLoaded && viewItem == dart-code:testSuiteNode",
+					"command": "dart.startWithoutDebuggingFailedTests",
+					"group": "4.5_exec@4"
 				},
 				{
 					"when": "dart-code:dartProjectLoaded && viewItem == dart-code:testGroupNode",
@@ -1066,7 +1094,7 @@
 				{
 					"when": "dart-code:dartProjectLoaded && viewItem == dart-code:testGroupNode",
 					"command": "dart.startWithoutDebuggingTest",
-					"group": "4.5_exec@1"
+					"group": "4.5_exec@2"
 				},
 				{
 					"when": "dart-code:dartProjectLoaded && viewItem == dart-code:testTestNode",
@@ -1076,7 +1104,7 @@
 				{
 					"when": "dart-code:dartProjectLoaded && viewItem == dart-code:testTestNode",
 					"command": "dart.startWithoutDebuggingTest",
-					"group": "4.5_exec@1"
+					"group": "4.5_exec@2"
 				}
 			]
 		},

--- a/package.json
+++ b/package.json
@@ -158,6 +158,11 @@
 				"category": "Dart"
 			},
 			{
+				"command": "dart.runAllFailedTestsWithoutDebugging",
+				"title": "Re-Run All Failed Tests",
+				"category": "Dart"
+			},
+			{
 				"command": "dart.rerunLastDebugSession",
 				"title": "Rerun Last Debug Session",
 				"category": "Dart"
@@ -575,6 +580,10 @@
 				},
 				{
 					"command": "dart.runAllTestsWithoutDebugging",
+					"when": "dart-code:dartProjectLoaded"
+				},
+				{
+					"command": "dart.runAllFailedTestsWithoutDebugging",
 					"when": "dart-code:dartProjectLoaded"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -1076,22 +1076,22 @@
 					"command": "_flutter.outline.refactor.flutter.removeWidget"
 				},
 				{
-					"when": "dart-code:dartProjectLoaded && viewItem == dart-code:testSuiteNode",
+					"when": "dart-code:dartProjectLoaded && viewItem =~ /^dart-code:testSuiteNode/",
 					"command": "dart.startDebuggingTest",
 					"group": "4.5_exec@1"
 				},
 				{
-					"when": "dart-code:dartProjectLoaded && viewItem == dart-code:testSuiteNode",
+					"when": "dart-code:dartProjectLoaded && viewItem =~ /^dart-code:testSuiteNode/",
 					"command": "dart.startWithoutDebuggingTest",
 					"group": "4.5_exec@2"
 				},
 				{
-					"when": "dart-code:dartProjectLoaded && viewItem == dart-code:testSuiteNode",
+					"when": "dart-code:dartProjectLoaded && viewItem == dart-code:testSuiteNodeWithFailures",
 					"command": "dart.startDebuggingFailedTests",
 					"group": "4.5_exec@3"
 				},
 				{
-					"when": "dart-code:dartProjectLoaded && viewItem == dart-code:testSuiteNode",
+					"when": "dart-code:dartProjectLoaded && viewItem == dart-code:testSuiteNodeWithFailures",
 					"command": "dart.startWithoutDebuggingFailedTests",
 					"group": "4.5_exec@4"
 				},

--- a/src/extension/commands/test.ts
+++ b/src/extension/commands/test.ts
@@ -39,13 +39,13 @@ abstract class TestCommands implements vs.Disposable {
 		this.disposables.push(vs.commands.registerCommand("_dart.startDebuggingTestFromOutline", (test: TestOutlineInfo, launchTemplate: any | undefined) => {
 			vs.debug.startDebugging(
 				vs.workspace.getWorkspaceFolder(vs.Uri.file(test.file)),
-				getLaunchConfig(false, test.file, test.fullName, test.isGroup, launchTemplate),
+				getLaunchConfig(false, test.file, [test.fullName], test.isGroup, launchTemplate),
 			);
 		}));
 		this.disposables.push(vs.commands.registerCommand("_dart.startWithoutDebuggingTestFromOutline", (test: TestOutlineInfo, launchTemplate: any | undefined) => {
 			vs.debug.startDebugging(
 				vs.workspace.getWorkspaceFolder(vs.Uri.file(test.file)),
-				getLaunchConfig(true, test.file, test.fullName, test.isGroup, launchTemplate),
+				getLaunchConfig(true, test.file, [test.fullName], test.isGroup, launchTemplate),
 			);
 		}));
 	}

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -294,7 +294,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		debugConfig.cwd = forceWindowsDriveLetterToUppercase(debugConfig.cwd);
 
 		// If we're launching (not attaching) then check there are no errors before we launch.
-		if (!isAttachRequest && debugConfig.cwd && config.promptToRunIfErrors) {
+		if (!isAttachRequest && debugConfig.cwd && config.promptToRunIfErrors && !debugConfig.suppressPromptOnErrors) {
 			logger.info("Checking for errors before launching");
 			const isDartError = (d: vs.Diagnostic) => d.source === "dart" && d.severity === vs.DiagnosticSeverity.Error;
 			const dartErrors = vs.languages

--- a/src/extension/views/test_view.ts
+++ b/src/extension/views/test_view.ts
@@ -700,6 +700,10 @@ export class SuiteTreeItem extends TestItemTreeItem {
 			? DART_TEST_SUITE_NODE_WITH_FAILURES_CONTEXT
 			: DART_TEST_SUITE_NODE_CONTEXT;
 	}
+
+	get status(): TestStatus {
+		return super.status;
+	}
 }
 
 class GroupTreeItem extends TestItemTreeItem {

--- a/src/extension/views/test_view.ts
+++ b/src/extension/views/test_view.ts
@@ -44,10 +44,7 @@ export class TestResultsProvider implements vs.Disposable, vs.TreeDataProvider<T
 		// since we don't have the necessary information to know the test was renamed.
 		if (isRunningWholeSuite && suitePath && path.isAbsolute(suitePath)) {
 			const suite = suites[fsPath(suitePath)];
-			// If we didn't find the suite, we may be running the whole lot, so
-			// we should mark everything from all suites as potentially deleted.
-			const suitesBeingRun = suite ? [suite] : Object.values(suites);
-			for (const suite of suitesBeingRun) {
+			if (suite) {
 				suite.getAllGroups().forEach((g) => g.isPotentiallyDeleted = true);
 				suite.getAllTests().forEach((t) => t.isPotentiallyDeleted = true);
 			}

--- a/src/extension/views/test_view.ts
+++ b/src/extension/views/test_view.ts
@@ -102,7 +102,7 @@ export class TestResultsProvider implements vs.Disposable, vs.TreeDataProvider<T
 		}));
 	}
 
-	private runAllFailedTests() {
+	private async runAllFailedTests(): Promise<void> {
 		const topLevelNodes = this.getChildren() || [];
 		const suitesWithFailures = topLevelNodes
 			.filter((node) => node instanceof SuiteTreeItem && node.hasFailures)
@@ -111,7 +111,7 @@ export class TestResultsProvider implements vs.Disposable, vs.TreeDataProvider<T
 			return;
 
 		const percentProgressPerTest = 99 / suitesWithFailures.map((swf) => swf[1].length).reduce((a, b) => a + b);
-		vs.window.withProgress(
+		await vs.window.withProgress(
 			{
 				cancellable: true,
 				location: vs.ProgressLocation.Notification,

--- a/src/extension/views/test_view.ts
+++ b/src/extension/views/test_view.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import * as vs from "vscode";
-import { DART_TEST_GROUP_NODE_CONTEXT, DART_TEST_SUITE_NODE_CONTEXT, DART_TEST_TEST_NODE_CONTEXT } from "../../shared/constants";
+import { DART_TEST_GROUP_NODE_CONTEXT, DART_TEST_SUITE_NODE_CONTEXT, DART_TEST_SUITE_NODE_WITH_FAILURES_CONTEXT, DART_TEST_TEST_NODE_CONTEXT } from "../../shared/constants";
 import { TestStatus } from "../../shared/enums";
 import { Logger } from "../../shared/interfaces";
 import { ErrorNotification, Group, GroupNotification, Notification, PrintNotification, Suite, SuiteNotification, Test, TestDoneNotification, TestStartNotification } from "../../shared/test_protocol";
@@ -692,6 +692,13 @@ export class SuiteTreeItem extends TestItemTreeItem {
 			...this.groups.filter((g) => !g.isPhantomGroup && !g.hidden),
 			...this.tests.filter((t) => !t.hidden),
 		];
+	}
+
+	set status(status: TestStatus) {
+		super.status = status;
+		this.contextValue = this.hasFailures
+			? DART_TEST_SUITE_NODE_WITH_FAILURES_CONTEXT
+			: DART_TEST_SUITE_NODE_CONTEXT;
 	}
 }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -33,6 +33,7 @@ export const FLUTTER_DOWNLOAD_URL = "https://flutter.dev/setup/";
 export const IS_LSP_CONTEXT = "dart-code:isLsp";
 
 export const DART_TEST_SUITE_NODE_CONTEXT = "dart-code:testSuiteNode";
+export const DART_TEST_SUITE_NODE_WITH_FAILURES_CONTEXT = "dart-code:testSuiteNodeWithFailures";
 export const DART_TEST_GROUP_NODE_CONTEXT = "dart-code:testGroupNode";
 export const DART_TEST_TEST_NODE_CONTEXT = "dart-code:testTestNode";
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import * as semver from "semver";
 import { flutterExecutableName, isWin } from "./constants";
 import { LogCategory } from "./enums";
-import { CustomScript, Logger, SomeError } from "./interfaces";
+import { CustomScript, IAmDisposable, Logger, SomeError } from "./interfaces";
 
 export function uniq<T>(array: T[]): T[] {
 	return array.filter((value, index) => array.indexOf(value) === index);
@@ -205,4 +205,14 @@ export function generateTestNameFromFileName(input: string) {
 
 export function escapeDartString(input: string) {
 	return input.replace(/(['"\\])/g, "\\$1");
+}
+
+export function disposeAll(disposables: IAmDisposable[]) {
+	for (const d of disposables) {
+		try {
+			d.dispose();
+		} catch (e) {
+			console.warn(e);
+		}
+	}
 }

--- a/src/test/dart_debug/debug/dart_test.test.ts
+++ b/src/test/dart_debug/debug/dart_test.test.ts
@@ -4,7 +4,7 @@ import { DebuggerType, TestStatus } from "../../../shared/enums";
 import { fsPath } from "../../../shared/utils/fs";
 import { DasTestOutlineInfo, TestOutlineVisitor } from "../../../shared/utils/outline_das";
 import { LspTestOutlineInfo, LspTestOutlineVisitor } from "../../../shared/utils/outline_lsp";
-import { makeRegexForTest } from "../../../shared/utils/test";
+import { makeRegexForTests } from "../../../shared/utils/test";
 import { DartDebugClient } from "../../dart_debug_client";
 import { createDebugClient, waitAllThrowIfTerminates } from "../../debug_helpers";
 import { activate, extApi, getExpectedResults, getLaunchConfiguration, getPackages, helloWorldTestBrokenFile, helloWorldTestDupeNameFile, helloWorldTestMainFile, helloWorldTestSkipFile, helloWorldTestTreeFile, logger, makeTextTree, openFile, positionOf } from "../../helpers";
@@ -204,7 +204,7 @@ describe("dart test debugger", () => {
 			// Run the test.
 			await runWithoutDebugging(
 				helloWorldTestTreeFile,
-				["--name", makeRegexForTest(test.fullName, test.isGroup)],
+				["--name", makeRegexForTests([test.fullName], test.isGroup)],
 				// Ensure the output contained the test name as a sanity check
 				// that it ran. Because some tests have variables added to the
 				// end, just stop at the $ to avoid failing on them.
@@ -249,12 +249,12 @@ describe("dart test debugger", () => {
 				await editor.edit((e) => e.insert(doc.positionAt(0), "// These\n// are\n// inserted\n// lines.\n\n"));
 			// Re-run each test.
 			for (const test of visitor.tests.filter((t) => !t.isGroup)) {
-				await runWithoutDebugging(helloWorldTestDupeNameFile, ["--name", makeRegexForTest(test.fullName, test.isGroup)]);
+				await runWithoutDebugging(helloWorldTestDupeNameFile, ["--name", makeRegexForTests([test.fullName], test.isGroup)]);
 				await checkResults(`After running ${numRuns++} tests (most recently the test: ${test.fullName})`);
 			}
 			// Re-run each group.
 			for (const group of visitor.tests.filter((t) => t.isGroup)) {
-				await runWithoutDebugging(helloWorldTestDupeNameFile, ["--name", makeRegexForTest(group.fullName, group.isGroup)]);
+				await runWithoutDebugging(helloWorldTestDupeNameFile, ["--name", makeRegexForTests([group.fullName], group.isGroup)]);
 				await checkResults(`After running ${numRuns++} groups (most recently the group: ${group.fullName})`);
 			}
 		}

--- a/src/test/dart_debug/debug/dart_test.test.ts
+++ b/src/test/dart_debug/debug/dart_test.test.ts
@@ -7,7 +7,7 @@ import { LspTestOutlineInfo, LspTestOutlineVisitor } from "../../../shared/utils
 import { makeRegexForTests } from "../../../shared/utils/test";
 import { DartDebugClient } from "../../dart_debug_client";
 import { createDebugClient, waitAllThrowIfTerminates } from "../../debug_helpers";
-import { activate, delay, extApi, getExpectedResults, getLaunchConfiguration, getPackages, helloWorldTestBrokenFile, helloWorldTestDupeNameFile, helloWorldTestMainFile, helloWorldTestSkipFile, helloWorldTestTreeFile, logger, makeTextTree, openFile, positionOf } from "../../helpers";
+import { activate, extApi, getExpectedResults, getLaunchConfiguration, getPackages, helloWorldTestBrokenFile, helloWorldTestDupeNameFile, helloWorldTestMainFile, helloWorldTestSkipFile, helloWorldTestTreeFile, logger, makeTextTree, openFile, positionOf } from "../../helpers";
 
 describe("dart test debugger", () => {
 	// We have tests that require external packages.
@@ -275,7 +275,6 @@ describe("dart test debugger", () => {
 
 		// Now re-run only failed tests.
 		await vs.commands.executeCommand("dart.runAllFailedTestsWithoutDebugging");
-		await delay(5000); // TODO: Find a way for this to wait for the tree to update reliably.
 
 		for (const file of testFiles) {
 			await openFile(file);

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -1050,7 +1050,7 @@ export async function makeTextTree(parent: vs.TreeItem | vs.Uri | undefined, pro
 		// fabricate one here that can be compared in the test. Note: For simplity we always use
 		// forward slashes in these names, since the comparison is against hard-coded comments
 		// in the file that can only be on way.
-		const expectedLabel = item.contextValue === DART_TEST_SUITE_NODE_CONTEXT
+		const expectedLabel = item.contextValue?.startsWith(DART_TEST_SUITE_NODE_CONTEXT)
 			? path.relative(
 				fsPath(vs.workspace.getWorkspaceFolder(item.resourceUri!)!.uri),
 				fsPath(item.resourceUri!),

--- a/src/test/test_projects/hello_world/test/broken_test.dart
+++ b/src/test/test_projects/hello_world/test/broken_test.dart
@@ -1,5 +1,15 @@
 import "package:test/test.dart";
 
+// This comment is extracted by the test and compared to a text representation
+// built from the tree provider in the test. It must be maintained to match
+// the results from the tests below.
+// == EXPECTED RESULTS ==
+// test/broken_test.dart [1/2 passed, {duration}ms] (fail.svg)
+//     might fail [1/2 passed, {duration}ms] (fail.svg)
+//         today [{duration}ms] (fail.svg)
+//         not today [{duration}ms] (pass.svg)
+// == /EXPECTED RESULTS ==
+
 void main() {
   group("might fail", () {
     test("today", () {


### PR DESCRIPTION
- [x] Ability to run failed tests for a single suite
- [x] Command to re-run failed tests for all suites
- [x] Hide context menu entry for nodes without failed tests
- [x] Tests

Fixes #2357.