### PR TITLE
Stop Flutter UI guidelines being tilted for certain fonts

### DIFF
--- a/src/extension/decorations/flutter_ui_guides_decorations.ts
+++ b/src/extension/decorations/flutter_ui_guides_decorations.ts
@@ -113,9 +113,9 @@ export abstract class FlutterUiGuideDecorations implements vs.Disposable {
 					before: {
 						color,
 						contentText: tabAdjustedDecorationString.join(""),
+						fontStyle: "normal",
 						margin: "0 3px 0 -3px",
 						width: "0",
-						fontStyle: "normal",
 					},
 				},
 			});

--- a/src/extension/decorations/flutter_ui_guides_decorations.ts
+++ b/src/extension/decorations/flutter_ui_guides_decorations.ts
@@ -115,6 +115,7 @@ export abstract class FlutterUiGuideDecorations implements vs.Disposable {
 						contentText: tabAdjustedDecorationString.join(""),
 						margin: "0 3px 0 -3px",
 						width: "0",
+						fontStyle: "normal",
 					},
 				},
 			});


### PR DESCRIPTION
Fixes the tilting, but there may be a visual artifact due to the guidelines vertically overlapping (see included screenshot).

![image](https://user-images.githubusercontent.com/18527642/95744041-a5b42980-0c8a-11eb-982e-7a99bfe57c59.png)

Fixes #2239.