### PR TITLE
Capture logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -240,13 +240,18 @@
 				"category": "Dart"
 			},
 			{
-				"command": "dart.startLoggingViaPicker",
+				"command": "dart.startLogging",
 				"title": "Capture Logs",
 				"category": "Dart"
 			},
 			{
 				"command": "dart.startLoggingAnalysisServer",
 				"title": "Capture Analysis Server Logs",
+				"category": "Dart"
+			},
+			{
+				"command": "dart.startLoggingDebugging",
+				"title": "Capture Debugging Logs",
 				"category": "Dart"
 			},
 			{
@@ -561,11 +566,15 @@
 					"command": "dart.createProject"
 				},
 				{
-					"command": "dart.startLoggingViaPicker",
+					"command": "dart.startLogging",
 					"when": "dart-code:dartProjectLoaded"
 				},
 				{
 					"command": "dart.startLoggingAnalysisServer",
+					"when": "dart-code:dartProjectLoaded"
+				},
+				{
+					"command": "dart.startLoggingDebugging",
 					"when": "dart-code:dartProjectLoaded"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -240,8 +240,18 @@
 				"category": "Dart"
 			},
 			{
-				"command": "dart.startLogging",
+				"command": "dart.startLoggingViaPicker",
 				"title": "Capture Logs",
+				"category": "Dart"
+			},
+			{
+				"command": "dart.startLoggingAnalysisServer",
+				"title": "Capture Analysis Server Logs",
+				"category": "Dart"
+			},
+			{
+				"command": "dart.startLoggingExtensionOnly",
+				"title": "Capture Extension Logs",
 				"category": "Dart"
 			},
 			{
@@ -551,7 +561,15 @@
 					"command": "dart.createProject"
 				},
 				{
-					"command": "dart.startLogging",
+					"command": "dart.startLoggingViaPicker",
+					"when": "dart-code:dartProjectLoaded"
+				},
+				{
+					"command": "dart.startLoggingAnalysisServer",
+					"when": "dart-code:dartProjectLoaded"
+				},
+				{
+					"command": "dart.startLoggingExtensionOnly",
 					"when": "dart-code:dartProjectLoaded"
 				},
 				{

--- a/src/extension/utils/log.ts
+++ b/src/extension/utils/log.ts
@@ -22,6 +22,20 @@ export const userSelectableLogCategories: { [key: string]: LogCategory } = {
 	"Web Daemon": LogCategory.WebDaemon,
 };
 
+export const analysisServerLogCategories = [
+	LogCategory.Analyzer,
+	LogCategory.CommandProcesses,
+];
+
+export const extensionsLogCategories = [
+	LogCategory.CommandProcesses,
+	LogCategory.DevTools,
+	LogCategory.FlutterDaemon,
+];
+
+export const debuggingLogCategories = Object.values(userSelectableLogCategories)
+	.filter((c) => c !== LogCategory.Analyzer);
+
 const logHeader: string[] = [];
 export function clearLogHeader() {
 	logHeader.length = 0;

--- a/src/test/dart/commands/capture_log.test.ts
+++ b/src/test/dart/commands/capture_log.test.ts
@@ -6,7 +6,7 @@ import { LogCategory } from "../../../shared/enums";
 import { fsPath } from "../../../shared/utils/fs";
 import { activate, logger, sb, waitForResult } from "../../helpers";
 
-describe("capture logs command", () => {
+describe.only("capture logs command", () => {
 	beforeEach("activate", () => activate());
 
 	async function configureLog(...logCategories: LogCategory[]) {
@@ -18,7 +18,7 @@ describe("capture logs command", () => {
 			showQuickPick.resolves(undefined);
 
 		// Start the logging but don't await it (it doesn't complete until we stop the logging!).
-		const loggingCommand = vs.commands.executeCommand("dart.startLogging") as Thenable<string>;
+		const loggingCommand = vs.commands.executeCommand("dart.startLoggingViaPicker") as Thenable<string>;
 
 		// Wait until the command has called for the filename and options (otherwise we'll send our log before
 		// the logger is set up because the above call is async).

--- a/src/test/test_projects/hello_world/pubspec.yaml
+++ b/src/test/test_projects/hello_world/pubspec.yaml
@@ -15,15 +15,3 @@ dependencies:
 
 dev_dependencies:
   test: '>=0.12.34'
-         # test
- # test
- # test
- # test
- # test
- # test
- # test
- # test
- # test
- # test
- # test
- # test

--- a/src/test/test_projects/hello_world/pubspec.yaml
+++ b/src/test/test_projects/hello_world/pubspec.yaml
@@ -23,3 +23,7 @@ dev_dependencies:
  # test
  # test
  # test
+ # test
+ # test
+ # test
+ # test


### PR DESCRIPTION
Splits the _Capture Logs_ command into multiple commands:

* **Capture Logs**: Selectable capture categories via a picker, as before.
* **Capture Analysis Server Logs**: Only captures _Analyzer_ and _CommandProcess._
* **Capture Debugging Logs**: Captures everything except _Analyzer._
* **Capture Extension Logs**: Captures only _CommandProcess, DevTools,_ and _FlutterDaemon._

Includes tests.

Fixes #2789.