### PR TITLE
Prefilled project name

### DIFF
--- a/src/test/not_activated/dart_create/extension.test.ts
+++ b/src/test/not_activated/dart_create/extension.test.ts
@@ -36,12 +36,16 @@ describe("command", () => {
 		const templateName = "console-full";
 		const templateEntrypoint = "bin/__projectName__.dart";
 
-		const showInputBox = sb.stub(vs.window, "showInputBox");
-		showInputBox.resolves(projectName);
-
 		const showOpenDialog = sb.stub(vs.window, "showOpenDialog");
 		const tempFolder = getRandomTempFolder();
 		showOpenDialog.resolves([vs.Uri.file(tempFolder)]);
+
+		const showInputBox = sb.stub(vs.window, "showInputBox");
+		showInputBox.resolves(projectName);
+
+		// Create some folders in the temp folder to check the default name is correctly incremented.
+		fs.mkdirSync(path.join(tempFolder, "dart_application_1"));
+		fs.mkdirSync(path.join(tempFolder, "dart_application_2"));
 
 		const showQuickPick = sb.stub(vs.window, "showQuickPick");
 		type SnippetOption = vs.QuickPickItem & { template: StagehandTemplate };
@@ -53,6 +57,7 @@ describe("command", () => {
 
 		await vs.commands.executeCommand("dart.createProject");
 
+		assert.ok(showInputBox.calledOnceWith(sinon.match.has("value", "dart_application_3")));
 		assert.ok(showQuickPick.calledOnce);
 		assert.ok(openFolder.calledOnce);
 		const triggerFile = path.join(tempFolder, projectName, DART_STAGEHAND_PROJECT_TRIGGER_FILE);

--- a/src/test/not_activated/flutter_create/extension.test.ts
+++ b/src/test/not_activated/flutter_create/extension.test.ts
@@ -32,12 +32,16 @@ describe("command", () => {
 	it("Flutter: New Project can be invoked and creates trigger file", async () => {
 		attachLoggingWhenExtensionAvailable();
 
-		const showInputBox = sb.stub(vs.window, "showInputBox");
-		showInputBox.resolves("my_test_flutter_proj");
-
 		const showOpenDialog = sb.stub(vs.window, "showOpenDialog");
 		const tempFolder = getRandomTempFolder();
 		showOpenDialog.resolves([vs.Uri.file(tempFolder)]);
+
+		const showInputBox = sb.stub(vs.window, "showInputBox");
+		showInputBox.resolves("my_test_flutter_proj");
+
+		// Create some folders in the temp folder to check the default name is correctly incremented.
+		fs.mkdirSync(path.join(tempFolder, "flutter_application_1"));
+		fs.mkdirSync(path.join(tempFolder, "flutter_application_2"));
 
 		// Intercept executeCommand for openFolder so we don't spawn a new instance of Code!
 		const executeCommand = sb.stub(vs.commands, "executeCommand").callThrough();
@@ -45,7 +49,7 @@ describe("command", () => {
 
 		await vs.commands.executeCommand("flutter.createProject");
 
-		assert.ok(showInputBox.calledOnce);
+		assert.ok(showInputBox.calledOnceWith(sinon.match.has("value", "flutter_application_3")));
 		assert.ok(showOpenDialog.calledOnce);
 		assert.ok(openFolder.calledOnce);
 		assert.ok(fs.existsSync(path.join(tempFolder, "my_test_flutter_proj", FLUTTER_CREATE_PROJECT_TRIGGER_FILE)));


### PR DESCRIPTION
- Pre-fills name upon creating a new project. Project name determination only occurs for the initial, pre-filled name suggestion and will not apply if a different name is entered entirely.

- Displays an in-place error during (user input) project naming should a directory with the specified name already exist. This negates the user needing to reinvoke the create-project command to begin creating a project again.

- Optimises out multiple `fsPath`() calls.
