### PR TITLE
Add a setting to easily set Flutter's web renderer in user/workspace settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1638,13 +1638,12 @@
 				},
 				"dart.flutterWebRenderer": {
 					"enum": [
-						"default",
+						"auto",
 						"html",
-						"canvaskit",
-						"auto"
+						"canvaskit"
 					],
-					"default": "default",
-					"markdownDescription": "- `default` - use Flutter's default value.\n- `html` - always use the HTML renderer. This renderer uses a combination of HTML, CSS, SVG, 2D Canvas, and WebGL.\n- `canvaskit` - always use the CanvasKit renderer. This renderer uses WebGL and WebAssembly to render graphics.\n- `auto` - use the HTML renderer on mobile devices, and CanvasKit on desktop devices.",
+					"default": "auto",
+					"markdownDescription": "- `auto` - allow Flutter to pick the best renderer based on the users device.\n- `html` - always use the HTML renderer. This renderer uses a combination of HTML, CSS, SVG, 2D Canvas, and WebGL.\n- `canvaskit` - always use the CanvasKit renderer. This renderer uses WebGL and WebAssembly to render graphics.",
 					"scope": "window"
 				},
 				"dart.analyzerAdditionalArgs": {

--- a/package.json
+++ b/package.json
@@ -1636,6 +1636,17 @@
 					"description": "Whether to show the Flutter Outline tree in the sidebar.",
 					"scope": "window"
 				},
+				"dart.flutterWebRenderer": {
+					"enum": [
+						"default",
+						"html",
+						"canvaskit",
+						"auto"
+					],
+					"default": "default",
+					"markdownDescription": "- `default` - use Flutter's default value.\n- `html` - always use the HTML renderer. This renderer uses a combination of HTML, CSS, SVG, 2D Canvas, and WebGL.\n- `canvaskit` - always use the CanvasKit renderer. This renderer uses WebGL and WebAssembly to render graphics.\n- `auto` - use the HTML renderer on mobile devices, and CanvasKit on desktop devices.",
+					"scope": "window"
+				},
 				"dart.analyzerAdditionalArgs": {
 					"type": "array",
 					"default": [],

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -85,7 +85,7 @@ class Config {
 	get flutterSdkPaths(): string[] { return this.getConfig<string[]>("flutterSdkPaths", []).map(resolvePaths); }
 	get flutterSelectDeviceWhenConnected(): boolean { return this.getConfig<boolean>("flutterSelectDeviceWhenConnected", true); }
 	get flutterTestLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("flutterTestLogFile", null))); }
-	get flutterWebRenderer(): "default" | "auto" | "html" | "canvaskit" { return this.getConfig<"default" | "auto" | "html" | "canvaskit">("flutterWebRenderer", "default"); }
+	get flutterWebRenderer(): "auto" | "html" | "canvaskit" { return this.getConfig<"auto" | "html" | "canvaskit">("flutterWebRenderer", "auto"); }
 	get hotReloadProgress(): "notification" | "statusBar" { return this.getConfig<"notification" | "statusBar">("hotReloadProgress", "notification"); }
 	get maxLogLineLength(): number { return this.getConfig<number>("maxLogLineLength", 2000); }
 	get notifyAnalyzerErrors(): boolean { return this.getConfig<boolean>("notifyAnalyzerErrors", true); }

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -85,6 +85,7 @@ class Config {
 	get flutterSdkPaths(): string[] { return this.getConfig<string[]>("flutterSdkPaths", []).map(resolvePaths); }
 	get flutterSelectDeviceWhenConnected(): boolean { return this.getConfig<boolean>("flutterSelectDeviceWhenConnected", true); }
 	get flutterTestLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("flutterTestLogFile", null))); }
+	get flutterWebRenderer(): "default" | "auto" | "html" | "canvaskit" { return this.getConfig<"default" | "auto" | "html" | "canvaskit">("flutterWebRenderer", "default"); }
 	get hotReloadProgress(): "notification" | "statusBar" { return this.getConfig<"notification" | "statusBar">("hotReloadProgress", "notification"); }
 	get maxLogLineLength(): number { return this.getConfig<number>("maxLogLineLength", 2000); }
 	get notifyAnalyzerErrors(): boolean { return this.getConfig<boolean>("notifyAnalyzerErrors", true); }

--- a/src/extension/dart/dart_task_provider.ts
+++ b/src/extension/dart/dart_task_provider.ts
@@ -69,6 +69,8 @@ export abstract class BaseTaskProvider implements vs.TaskProvider {
 			definition.args = (definition.args ?? []).concat((await options?.runtimeArgs()) ?? []);
 		}
 
+		this.injectArgs(definition);
+
 		// We *must* return a new Task here, otherwise the task cannot be customised
 		// in task.json.
 		// https://github.com/microsoft/vscode/issues/58836#issuecomment-696620105
@@ -88,6 +90,9 @@ export abstract class BaseTaskProvider implements vs.TaskProvider {
 		newTask.isBackground = task.isBackground || (options?.isBackground ?? false);
 
 		return newTask;
+	}
+
+	protected injectArgs(_: DartTaskDefinition): void | Promise<void> {
 	}
 
 	private getOptions(def: DartTaskDefinition): DartTaskOptions | undefined {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -361,7 +361,7 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 
 	// Task handlers.
 	context.subscriptions.push(vs.tasks.registerTaskProvider(DartTaskProvider.type, new DartTaskProvider(logger, context, sdks, dartCapabilities)));
-	context.subscriptions.push(vs.tasks.registerTaskProvider(FlutterTaskProvider.type, new FlutterTaskProvider(logger, context, sdks)));
+	context.subscriptions.push(vs.tasks.registerTaskProvider(FlutterTaskProvider.type, new FlutterTaskProvider(logger, context, sdks, flutterCapabilities)));
 
 	// Snippets are language-specific
 	context.subscriptions.push(vs.languages.registerCompletionItemProvider(DART_MODE, new SnippetCompletionItemProvider("snippets/dart.json", () => true)));

--- a/src/extension/flutter/flutter_task_provider.ts
+++ b/src/extension/flutter/flutter_task_provider.ts
@@ -4,6 +4,7 @@ import { FlutterCapabilities } from "../../shared/capabilities/flutter";
 import { getFutterWebRendererArg } from "../../shared/flutter/utils";
 import { DartSdks, Logger } from "../../shared/interfaces";
 import { notUndefined } from "../../shared/utils";
+import { arrayStartsWith } from "../../shared/utils/array";
 import { getDartWorkspaceFolders } from "../../shared/vscode/utils";
 import { config } from "../config";
 import { BaseTaskProvider, DartTaskDefinition } from "../dart/dart_task_provider";
@@ -51,7 +52,7 @@ export class FlutterTaskProvider extends BaseTaskProvider {
 
 		if (definition.command === "flutter") {
 			// Inject web-renderer if required.
-			const isWebBuild = definition.args.length >= 2 && definition.args[0] === "build" && definition.args[1] === "web";
+			const isWebBuild = arrayStartsWith(definition.args, ["build", "web"]);
 			if (isWebBuild) {
 				const rendererArg = getFutterWebRendererArg(this.flutterCapabilities, config.flutterWebRenderer, definition.args);
 				if (rendererArg)

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -9,6 +9,7 @@ import { CHROME_OS_VM_SERVICE_PORT, debugAnywayAction, HAS_LAST_DEBUG_CONFIG, HA
 import { FlutterLaunchRequestArguments } from "../../shared/debug/interfaces";
 import { DebuggerType, VmServiceExtension } from "../../shared/enums";
 import { Device } from "../../shared/flutter/daemon_interfaces";
+import { getFutterWebRendererArg } from "../../shared/flutter/utils";
 import { IFlutterDaemon, Logger } from "../../shared/interfaces";
 import { TestTreeModel } from "../../shared/test/test_model";
 import { filenameSafe } from "../../shared/utils";
@@ -458,6 +459,9 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			debugConfig.useFlutterStructuredErrors = conf.flutterStructuredErrors;
 			debugConfig.debugExtensionBackendProtocol = config.debugExtensionBackendProtocol;
 			debugConfig.args = conf.flutterAdditionalArgs.concat(isTest ? conf.flutterTestAdditionalArgs : []).concat(debugConfig.args);
+			const rendererArg = getFutterWebRendererArg(this.flutterCapabilities, config.flutterWebRenderer, debugConfig.args);
+			if (rendererArg)
+				debugConfig.args.push(rendererArg);
 			debugConfig.forceFlutterVerboseMode = isLogging;
 			debugConfig.flutterTrackWidgetCreation =
 				// Use from the launch.json if configured.

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -459,9 +459,6 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			debugConfig.useFlutterStructuredErrors = conf.flutterStructuredErrors;
 			debugConfig.debugExtensionBackendProtocol = config.debugExtensionBackendProtocol;
 			debugConfig.args = conf.flutterAdditionalArgs.concat(isTest ? conf.flutterTestAdditionalArgs : []).concat(debugConfig.args);
-			const rendererArg = getFutterWebRendererArg(this.flutterCapabilities, config.flutterWebRenderer, debugConfig.args);
-			if (rendererArg)
-				debugConfig.args.push(rendererArg);
 			debugConfig.forceFlutterVerboseMode = isLogging;
 			debugConfig.flutterTrackWidgetCreation =
 				// Use from the launch.json if configured.
@@ -477,6 +474,11 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			if (!debugConfig.deviceId && device) {
 				debugConfig.deviceId = device.id;
 				debugConfig.deviceName = `${deviceManager ? deviceManager.labelForDevice(device) : device.name} (${device.platform})`;
+			}
+			if (debugConfig?.deviceId?.startsWith("web")) {
+				const rendererArg = getFutterWebRendererArg(this.flutterCapabilities, config.flutterWebRenderer, debugConfig.args);
+				if (rendererArg)
+					debugConfig.args.push(rendererArg);
 			}
 			debugConfig.showMemoryUsage =
 				debugConfig.showMemoryUsage || debugConfig.showMemoryUsage === false

--- a/src/shared/capabilities/flutter.ts
+++ b/src/shared/capabilities/flutter.ts
@@ -17,7 +17,6 @@ export class FlutterCapabilities {
 	get supportsExposeUrl() { return versionIsAtLeast(this.version, "1.18.0-5"); }
 	get supportsDartDefine() { return versionIsAtLeast(this.version, "1.17.0"); }
 	get supportsRestartDebounce() { return versionIsAtLeast(this.version, "1.21.0-0"); }
-	// TODO: Confirm this version.
 	get supportsWebRendererOption() { return versionIsAtLeast(this.version, "1.25.0-0"); }
 	// TODO: Update these (along with Dart) when supported.
 	get webSupportsEvaluation() { return false; }

--- a/src/shared/capabilities/flutter.ts
+++ b/src/shared/capabilities/flutter.ts
@@ -17,6 +17,8 @@ export class FlutterCapabilities {
 	get supportsExposeUrl() { return versionIsAtLeast(this.version, "1.18.0-5"); }
 	get supportsDartDefine() { return versionIsAtLeast(this.version, "1.17.0"); }
 	get supportsRestartDebounce() { return versionIsAtLeast(this.version, "1.21.0-0"); }
+	// TODO: Confirm this version.
+	get supportsWebRendererOption() { return versionIsAtLeast(this.version, "1.25.0-0"); }
 	// TODO: Update these (along with Dart) when supported.
 	get webSupportsEvaluation() { return false; }
 	get webSupportsDebugging() { return true; }

--- a/src/shared/flutter/utils.ts
+++ b/src/shared/flutter/utils.ts
@@ -7,7 +7,7 @@ export function getFutterWebRendererArg(flutterCapabilities: FlutterCapabilities
 	if (!renderer || renderer === "default")
 		return;
 
-	const alreadyHasArg = existingArgs?.find((a) => a.startsWith("--web-renderer"));
+	const alreadyHasArg = existingArgs?.find((a) => a.startsWith("--web-renderer=") || a === "--web-renderer");
 	if (alreadyHasArg)
 		return;
 

--- a/src/shared/flutter/utils.ts
+++ b/src/shared/flutter/utils.ts
@@ -1,0 +1,15 @@
+import { FlutterCapabilities } from "../capabilities/flutter";
+
+export function getFutterWebRendererArg(flutterCapabilities: FlutterCapabilities, renderer: "default" | "auto" | "html" | "canvaskit", existingArgs: string[] | undefined) {
+	if (!flutterCapabilities.supportsWebRendererOption)
+		return;
+
+	if (!renderer || renderer === "default")
+		return;
+
+	const alreadyHasArg = existingArgs?.find((a) => a.startsWith("--web-renderer"));
+	if (alreadyHasArg)
+		return;
+
+	return `--web-renderer=${renderer}`;
+}


### PR DESCRIPTION
This adds a setting to easily set the web renderer at the User Setting or Workspace Setting level. It will be injected into `flutter run` commands (launched via the debugger) and `flutter build web` tasks (from the Flutter task contributions) unless they already have this in their `args`.

![Screenshot 2020-12-10 at 12 23 11](https://user-images.githubusercontent.com/1078012/101771889-872faa80-3ae2-11eb-8fbd-813a064cbc35.png)

## TODO:

- [x] Confirm which version of Flutter we should pass this for (currently set to >= `v1.25.0-0`)
- [x] Decide whether we need both `default` and `auto` or if we could fold them together (eg. only have `auto` and always pass it, or only have `default` and leave `auto` as something Flutter does when using its default)
- [ ] Add a link to docs describing the renderers in more detail?

Fixes #2999.