### PR TITLE
Add support for creating other Flutter project templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
 		"workspaceContains:flutter.create",
 		"onCommand:flutter.createProject",
 		"onCommand:flutter.createProject.module",
+		"onCommand:flutter.createProject.package",
+		"onCommand:flutter.createProject.plugin",
 		"onCommand:dart.createProject",
 		"onCommand:_dart.flutter.createSampleProject",
 		"onCommand:flutter.doctor",
@@ -90,6 +92,16 @@
 			{
 				"command": "flutter.createProject.module",
 				"title": "New Module Project",
+				"category": "Flutter"
+			},
+			{
+				"command": "flutter.createProject.package",
+				"title": "New Package Project",
+				"category": "Flutter"
+			},
+			{
+				"command": "flutter.createProject.plugin",
+				"title": "New Plugin Project",
 				"category": "Flutter"
 			},
 			{
@@ -575,6 +587,12 @@
 				},
 				{
 					"command": "flutter.createProject.module"
+				},
+				{
+					"command": "flutter.createProject.package"
+				},
+				{
+					"command": "flutter.createProject.plugin"
 				},
 				{
 					"command": "dart.createProject"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"workspaceContains:flutter.sh.create",
 		"workspaceContains:flutter.create",
 		"onCommand:flutter.createProject",
+		"onCommand:flutter.createProject.module",
 		"onCommand:dart.createProject",
 		"onCommand:_dart.flutter.createSampleProject",
 		"onCommand:flutter.doctor",
@@ -83,7 +84,12 @@
 		"commands": [
 			{
 				"command": "flutter.createProject",
-				"title": "New Project",
+				"title": "New Application Project",
+				"category": "Flutter"
+			},
+			{
+				"command": "flutter.createProject.module",
+				"title": "New Module Project",
 				"category": "Flutter"
 			},
 			{
@@ -566,6 +572,9 @@
 			"commandPalette": [
 				{
 					"command": "flutter.createProject"
+				},
+				{
+					"command": "flutter.createProject.module"
 				},
 				{
 					"command": "dart.createProject"

--- a/src/extension/commands/sdk.ts
+++ b/src/extension/commands/sdk.ts
@@ -70,6 +70,8 @@ export class SdkCommands {
 		context.subscriptions.push(vs.commands.registerCommand("flutter.upgrade", this.flutterUpgrade, this));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.createProject", this.createFlutterProject, this));
 		context.subscriptions.push(vs.commands.registerCommand("flutter.createProject.module", () => this.createFlutterProject("module"), this));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.createProject.package", () => this.createFlutterProject("package"), this));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.createProject.plugin", () => this.createFlutterProject("plugin"), this));
 		context.subscriptions.push(vs.commands.registerCommand("_dart.flutter.createSampleProject", this.createFlutterSampleProject, this));
 		context.subscriptions.push(vs.commands.registerCommand("dart.createProject", this.createDartProject, this));
 		context.subscriptions.push(vs.commands.registerCommand("_dart.create", this.dartCreate, this));

--- a/src/extension/commands/sdk.ts
+++ b/src/extension/commands/sdk.ts
@@ -7,7 +7,7 @@ import { DartCapabilities } from "../../shared/capabilities/dart";
 import { FlutterCapabilities } from "../../shared/capabilities/flutter";
 import { dartVMPath, DART_STAGEHAND_PROJECT_TRIGGER_FILE, flutterPath, FLUTTER_CREATE_PROJECT_TRIGGER_FILE, pubPath } from "../../shared/constants";
 import { LogCategory } from "../../shared/enums";
-import { CustomScript, DartSdks, DartWorkspaceContext, Logger, SpawnedProcess, StagehandTemplate } from "../../shared/interfaces";
+import { CustomScript, DartSdks, DartWorkspaceContext, FlutterCreateTriggerData, Logger, SpawnedProcess, StagehandTemplate } from "../../shared/interfaces";
 import { logProcess } from "../../shared/logging";
 import { flatMap, PromiseCompleter, uniq, usingCustomScript } from "../../shared/utils";
 import { sortBy } from "../../shared/utils/array";
@@ -221,7 +221,7 @@ export class SdkCommands {
 		await util.promptToReloadExtension();
 	}
 
-	private async flutterCreate(projectPath: string | undefined, projectName?: string, sampleID?: string) {
+	private async flutterCreate(projectPath: string | undefined, projectName?: string, triggerData?: FlutterCreateTriggerData) {
 		if (!projectPath) {
 			projectPath = await getFolderToRunCommandIn(this.logger, `Select the folder to run "flutter create" in`, undefined, true);
 			if (!projectPath)
@@ -248,9 +248,9 @@ export class SdkCommands {
 			args.push("--android-language");
 			args.push(config.flutterCreateAndroidLanguage);
 		}
-		if (sampleID) {
+		if (triggerData?.sample) {
 			args.push("--sample");
-			args.push(sampleID);
+			args.push(triggerData.sample);
 			args.push("--overwrite");
 		}
 		args.push(".");

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -68,7 +68,8 @@ export interface StagehandTemplate {
 }
 
 export interface FlutterCreateTriggerData {
-	readonly sample: string;
+	readonly sample?: string;
+	readonly template?: string;
 }
 
 export interface Logger {

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -67,6 +67,10 @@ export interface StagehandTemplate {
 	readonly entrypoint: string;
 }
 
+export interface FlutterCreateTriggerData {
+	readonly sample: string;
+}
+
 export interface Logger {
 	info(message: string, category?: LogCategory): void;
 	warn(message: SomeError, category?: LogCategory): void;

--- a/src/shared/utils/projects.ts
+++ b/src/shared/utils/projects.ts
@@ -1,8 +1,16 @@
 import * as fs from "fs";
 import * as path from "path";
+import { FLUTTER_CREATE_PROJECT_TRIGGER_FILE } from "../constants";
+import { FlutterCreateTriggerData } from "../interfaces";
 
 export function writeDartSdkSettingIntoProject(dartSdkPath: string, projectFolder: string): void {
 	writeSettingIntoProject(projectFolder, { "dart.sdkPath": dartSdkPath });
+}
+
+export function writeFlutterTriggerFile(folderPath: string, triggerData: FlutterCreateTriggerData | undefined) {
+	const jsonString = triggerData ? JSON.stringify(triggerData) : "";
+
+	fs.writeFileSync(path.join(folderPath, FLUTTER_CREATE_PROJECT_TRIGGER_FILE), jsonString);
 }
 
 export function writeFlutterSdkSettingIntoProject(flutterSdkPath: string, projectFolder: string): void {

--- a/src/shared/vscode/flutter_samples.ts
+++ b/src/shared/vscode/flutter_samples.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as vs from "vscode";
 import { FlutterCapabilities } from "../capabilities/flutter";
 import { dartCodeExtensionIdentifier, FLUTTER_CREATE_PROJECT_TRIGGER_FILE } from "../constants";
+import { FlutterCreateTriggerData } from "../interfaces";
 import { getRandomInt, mkDirRecursive } from "../utils/fs";
 import { writeFlutterSdkSettingIntoProject } from "../utils/projects";
 
@@ -20,8 +21,9 @@ export function createFlutterSampleInTempFolder(flutterCapabilities: FlutterCapa
 	// Create the empty folder so we can open it.
 	mkDirRecursive(tempSamplePath);
 
-	// Create a temp dart file to force extension to load when we open this folder.
-	fs.writeFileSync(path.join(tempSamplePath, FLUTTER_CREATE_PROJECT_TRIGGER_FILE), sampleID);
+	const triggerData: FlutterCreateTriggerData = { sample: sampleID };
+	fs.writeFileSync(path.join(tempSamplePath, FLUTTER_CREATE_PROJECT_TRIGGER_FILE), JSON.stringify(triggerData));
+
 	// If we're using a custom SDK, we need to apply it to the new project too.
 	if (flutterSdkOverride)
 		writeFlutterSdkSettingIntoProject(flutterSdkOverride, tempSamplePath);

--- a/src/shared/vscode/flutter_samples.ts
+++ b/src/shared/vscode/flutter_samples.ts
@@ -1,12 +1,11 @@
-import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as vs from "vscode";
 import { FlutterCapabilities } from "../capabilities/flutter";
-import { dartCodeExtensionIdentifier, FLUTTER_CREATE_PROJECT_TRIGGER_FILE } from "../constants";
+import { dartCodeExtensionIdentifier } from "../constants";
 import { FlutterCreateTriggerData } from "../interfaces";
 import { getRandomInt, mkDirRecursive } from "../utils/fs";
-import { writeFlutterSdkSettingIntoProject } from "../utils/projects";
+import { writeFlutterSdkSettingIntoProject, writeFlutterTriggerFile } from "../utils/projects";
 
 export function createFlutterSampleInTempFolder(flutterCapabilities: FlutterCapabilities, sampleID: string, flutterSdkOverride?: string): vs.Uri | undefined {
 	// Ensure we're on at least Flutter v1 so we know creating samples works.
@@ -22,7 +21,7 @@ export function createFlutterSampleInTempFolder(flutterCapabilities: FlutterCapa
 	mkDirRecursive(tempSamplePath);
 
 	const triggerData: FlutterCreateTriggerData = { sample: sampleID };
-	fs.writeFileSync(path.join(tempSamplePath, FLUTTER_CREATE_PROJECT_TRIGGER_FILE), JSON.stringify(triggerData));
+	writeFlutterTriggerFile(tempSamplePath, triggerData);
 
 	// If we're using a custom SDK, we need to apply it to the new project too.
 	if (flutterSdkOverride)

--- a/src/test/flutter_create_tests/extension.test.ts
+++ b/src/test/flutter_create_tests/extension.test.ts
@@ -6,7 +6,7 @@ import { fsPath } from "../../shared/utils/fs";
 describe("test environment", () => {
 	it("has opened the correct folder", () => {
 		const wfs = vs.workspace.workspaceFolders || [];
-		assert.equal(wfs.length, 3);
+		assert.equal(wfs.length, 5);
 		assert.ok(
 			fsPath(wfs[0].uri).endsWith(path.sep + "flutter_create_basic"),
 			`${fsPath(wfs[0].uri)} doesn't end with ${path.sep}flutter_create_basic`,
@@ -18,6 +18,14 @@ describe("test environment", () => {
 		assert.ok(
 			fsPath(wfs[2].uri).endsWith(path.sep + "flutter_create_module"),
 			`${fsPath(wfs[2].uri)} doesn't end with ${path.sep}flutter_create_module`,
+		);
+		assert.ok(
+			fsPath(wfs[3].uri).endsWith(path.sep + "flutter_create_package"),
+			`${fsPath(wfs[3].uri)} doesn't end with ${path.sep}flutter_create_package`,
+		);
+		assert.ok(
+			fsPath(wfs[4].uri).endsWith(path.sep + "flutter_create_plugin"),
+			`${fsPath(wfs[4].uri)} doesn't end with ${path.sep}flutter_create_plugin`,
 		);
 	});
 });

--- a/src/test/flutter_create_tests/extension.test.ts
+++ b/src/test/flutter_create_tests/extension.test.ts
@@ -6,7 +6,7 @@ import { fsPath } from "../../shared/utils/fs";
 describe("test environment", () => {
 	it("has opened the correct folder", () => {
 		const wfs = vs.workspace.workspaceFolders || [];
-		assert.equal(wfs.length, 2);
+		assert.equal(wfs.length, 3);
 		assert.ok(
 			fsPath(wfs[0].uri).endsWith(path.sep + "flutter_create_basic"),
 			`${fsPath(wfs[0].uri)} doesn't end with ${path.sep}flutter_create_basic`,
@@ -14,6 +14,10 @@ describe("test environment", () => {
 		assert.ok(
 			fsPath(wfs[1].uri).endsWith(path.sep + "flutter_create_sample"),
 			`${fsPath(wfs[1].uri)} doesn't end with ${path.sep}flutter_create_sample`,
+		);
+		assert.ok(
+			fsPath(wfs[2].uri).endsWith(path.sep + "flutter_create_module"),
+			`${fsPath(wfs[2].uri)} doesn't end with ${path.sep}flutter_create_module`,
 		);
 	});
 });

--- a/src/test/flutter_create_tests/flutter_create.test.ts
+++ b/src/test/flutter_create_tests/flutter_create.test.ts
@@ -70,6 +70,45 @@ describe("flutter", () => {
 			assert.fail(`Did not find "${expectedString}'" in the file (${pubspecFile}):\n\n${contents}`);
 	});
 
+	it("created a package project", async () => {
+		const packageProjectFolder = fsPath(vs.workspace.workspaceFolders![3].uri);
+		const expectedString = "description: A new Flutter package project";
+		const pubspecFile = path.join(packageProjectFolder, "pubspec.yaml");
+		// Creating the project may be a little slow, so allow up to 60 seconds for it.
+		logger.info("Waiting for file to exist", LogCategory.CI);
+		await waitForResult(() => fs.existsSync(pubspecFile), "pubspec.yaml did not exist", 100000);
+		// Wait for up to 10 seconds for the content to match, as the file may be updated after creation.
+		logger.info("Waiting for content match", LogCategory.CI);
+		await waitForResult(() => {
+			const contents = fs.readFileSync(pubspecFile);
+			return contents.indexOf(expectedString) !== -1;
+		}, undefined, 10000, false); // Don't throw on failure, as we have a better assert below that can include the contents.
+
+		const contents = fs.readFileSync(pubspecFile);
+		if (contents.indexOf(expectedString) === -1)
+			assert.fail(`Did not find "${expectedString}'" in the file (${pubspecFile}):\n\n${contents}`);
+	});
+
+	it("created a plugin project", async () => {
+		const pluginProjectFolder = fsPath(vs.workspace.workspaceFolders![4].uri);
+		// Flutter below is lowercased in the created project; consequently, this test may fail if it gets fixed by Flutter in the future.
+		const expectedString = "description: A new flutter plugin project";
+		const pubspecFile = path.join(pluginProjectFolder, "pubspec.yaml");
+		// Creating the project may be a little slow, so allow up to 60 seconds for it.
+		logger.info("Waiting for file to exist", LogCategory.CI);
+		await waitForResult(() => fs.existsSync(pubspecFile), "pubspec.yaml did not exist", 100000);
+		// Wait for up to 10 seconds for the content to match, as the file may be updated after creation.
+		logger.info("Waiting for content match", LogCategory.CI);
+		await waitForResult(() => {
+			const contents = fs.readFileSync(pubspecFile);
+			return contents.indexOf(expectedString) !== -1;
+		}, undefined, 10000, false); // Don't throw on failure, as we have a better assert below that can include the contents.
+
+		const contents = fs.readFileSync(pubspecFile);
+		if (contents.indexOf(expectedString) === -1)
+			assert.fail(`Did not find "${expectedString}'" in the file (${pubspecFile}):\n\n${contents}`);
+	});
+
 	it("triggered Flutter mode", () => {
 		const ext = vs.extensions.getExtension(dartCodeExtensionIdentifier);
 		assert.ok(ext);

--- a/src/test/flutter_create_tests/flutter_create.test.ts
+++ b/src/test/flutter_create_tests/flutter_create.test.ts
@@ -14,106 +14,63 @@ describe("flutter", () => {
 
 	it("created a basic default project", async () => {
 		const basicProjectFolder = fsPath(vs.workspace.workspaceFolders![0].uri);
-		const expectedString = "title: 'Flutter Demo'";
-		const mainFile = path.join(basicProjectFolder, "lib", "main.dart");
-		// Creating the sample may be a little slow, so allow up to 60 seconds for it.
-		logger.info("Waiting for file to exist", LogCategory.CI);
-		await waitForResult(() => fs.existsSync(mainFile), "lib/main.dart did not exist", 100000);
-		// Wait for up to 10 seconds for the content to match, as the file may be updated after creation.
-		logger.info("Waiting for content match", LogCategory.CI);
-		await waitForResult(() => {
-			const contents = fs.readFileSync(mainFile);
-			return contents.indexOf(expectedString) !== -1;
-		}, undefined, 10000, false); // Don't throw on failure, as we have a better assert below that can include the contents.
+		const pubspecFile = path.join(basicProjectFolder, "lib", "main.dart");
 
-		const contents = fs.readFileSync(mainFile);
-		if (contents.indexOf(expectedString) === -1)
-			assert.fail(`Did not find "${expectedString}'" in the sample file:\n\n${contents}`);
+		await projectFileContainsExpectedString(pubspecFile, "title: 'Flutter Demo'");
 	});
 
 	it("created a sample project", async () => {
 		const sampleProjectFolder = fsPath(vs.workspace.workspaceFolders![1].uri);
-		// const expectedString = "Flutter code sample for material.IconButton.1";
-		const expectedString = "This sample shows an `IconButton` that";
-		const mainFile = path.join(sampleProjectFolder, "lib", "main.dart");
-		// Creating the sample may be a little slow, so allow up to 60 seconds for it.
-		logger.info("Waiting for file to exist", LogCategory.CI);
-		await waitForResult(() => fs.existsSync(mainFile), "lib/main.dart did not exist", 100000);
-		// Wait for up to 10 seconds for the content to match, as the file may be updated after creation.
-		logger.info("Waiting for content match", LogCategory.CI);
-		await waitForResult(() => {
-			const contents = fs.readFileSync(mainFile);
-			return contents.indexOf(expectedString) !== -1;
-		}, undefined, 10000, false); // Don't throw on failure, as we have a better assert below that can include the contents.
+		const pubspecFile = path.join(sampleProjectFolder, "lib", "main.dart");
 
-		const contents = fs.readFileSync(mainFile);
-		if (contents.indexOf(expectedString) === -1)
-			assert.fail(`Did not find "${expectedString}'" in the sample file (${mainFile}):\n\n${contents}`);
+		await projectFileContainsExpectedString(pubspecFile, "This sample shows an `IconButton` that");
 	});
 
 	it("created a module project", async () => {
 		const moduleProjectFolder = fsPath(vs.workspace.workspaceFolders![2].uri);
-		const expectedString = "description: A new flutter module project";
 		const pubspecFile = path.join(moduleProjectFolder, "pubspec.yaml");
-		// Creating the project may be a little slow, so allow up to 60 seconds for it.
-		logger.info("Waiting for file to exist", LogCategory.CI);
-		await waitForResult(() => fs.existsSync(pubspecFile), "pubspec.yaml did not exist", 100000);
-		// Wait for up to 10 seconds for the content to match, as the file may be updated after creation.
-		logger.info("Waiting for content match", LogCategory.CI);
-		await waitForResult(() => {
-			const contents = fs.readFileSync(pubspecFile);
-			return contents.indexOf(expectedString) !== -1;
-		}, undefined, 10000, false); // Don't throw on failure, as we have a better assert below that can include the contents.
 
-		const contents = fs.readFileSync(pubspecFile);
-		if (contents.indexOf(expectedString) === -1)
-			assert.fail(`Did not find "${expectedString}'" in the file (${pubspecFile}):\n\n${contents}`);
+		await projectFileContainsExpectedString(pubspecFile, "description: A new flutter module project");
 	});
 
 	it("created a package project", async () => {
 		const packageProjectFolder = fsPath(vs.workspace.workspaceFolders![3].uri);
-		const expectedString = "description: A new Flutter package project";
 		const pubspecFile = path.join(packageProjectFolder, "pubspec.yaml");
-		// Creating the project may be a little slow, so allow up to 60 seconds for it.
-		logger.info("Waiting for file to exist", LogCategory.CI);
-		await waitForResult(() => fs.existsSync(pubspecFile), "pubspec.yaml did not exist", 100000);
-		// Wait for up to 10 seconds for the content to match, as the file may be updated after creation.
-		logger.info("Waiting for content match", LogCategory.CI);
-		await waitForResult(() => {
-			const contents = fs.readFileSync(pubspecFile);
-			return contents.indexOf(expectedString) !== -1;
-		}, undefined, 10000, false); // Don't throw on failure, as we have a better assert below that can include the contents.
 
-		const contents = fs.readFileSync(pubspecFile);
-		if (contents.indexOf(expectedString) === -1)
-			assert.fail(`Did not find "${expectedString}'" in the file (${pubspecFile}):\n\n${contents}`);
+		await projectFileContainsExpectedString(pubspecFile, "description: A new Flutter package project");
 	});
 
 	it("created a plugin project", async () => {
 		const pluginProjectFolder = fsPath(vs.workspace.workspaceFolders![4].uri);
-		// Flutter below is lowercased in the created project; consequently, this test may fail if it gets fixed by Flutter in the future.
-		const expectedString = "description: A new flutter plugin project";
 		const pubspecFile = path.join(pluginProjectFolder, "pubspec.yaml");
-		// Creating the project may be a little slow, so allow up to 60 seconds for it.
-		logger.info("Waiting for file to exist", LogCategory.CI);
-		await waitForResult(() => fs.existsSync(pubspecFile), "pubspec.yaml did not exist", 100000);
-		// Wait for up to 10 seconds for the content to match, as the file may be updated after creation.
-		logger.info("Waiting for content match", LogCategory.CI);
-		await waitForResult(() => {
-			const contents = fs.readFileSync(pubspecFile);
-			return contents.indexOf(expectedString) !== -1;
-		}, undefined, 10000, false); // Don't throw on failure, as we have a better assert below that can include the contents.
 
-		const contents = fs.readFileSync(pubspecFile);
-		if (contents.indexOf(expectedString) === -1)
-			assert.fail(`Did not find "${expectedString}'" in the file (${pubspecFile}):\n\n${contents}`);
+		await projectFileContainsExpectedString(pubspecFile, "description: A new flutter plugin project");
 	});
 
 	it("triggered Flutter mode", () => {
 		const ext = vs.extensions.getExtension(dartCodeExtensionIdentifier);
 		assert.ok(ext);
 		assert.ok(ext.isActive);
+
 		const api: InternalExtensionApi = ext.exports[internalApiSymbol];
 		assert.equal(api.workspaceContext.hasAnyFlutterProjects, true);
 	});
+
 });
+
+async function projectFileContainsExpectedString(fileToCheck: string, expectedString: string): Promise<void> {
+	// Creating the project may be a little slow, so allow up to 60 seconds for it.
+	logger.info("Waiting for file to exist", LogCategory.CI);
+	await waitForResult(() => fs.existsSync(fileToCheck), `${fileToCheck} did not exist`, 100000);
+
+	// Wait for up to 10 seconds for the content to match, as the file may be updated after creation.
+	logger.info("Waiting for content match", LogCategory.CI);
+	await waitForResult(() => {
+		const contents = fs.readFileSync(fileToCheck);
+		return contents.indexOf(expectedString) !== -1;
+	}, undefined, 10000, false); // Don't throw on failure as we have a better assert below that can include the contents.
+
+	const contents = fs.readFileSync(fileToCheck);
+	if (contents.indexOf(expectedString) === -1)
+		assert.fail(`Did not find "${expectedString}'" in the file (${fileToCheck}):\n\n${contents}`);
+}

--- a/src/test/flutter_create_tests/flutter_create.test.ts
+++ b/src/test/flutter_create_tests/flutter_create.test.ts
@@ -51,6 +51,25 @@ describe("flutter", () => {
 			assert.fail(`Did not find "${expectedString}'" in the sample file (${mainFile}):\n\n${contents}`);
 	});
 
+	it("created a module project", async () => {
+		const moduleProjectFolder = fsPath(vs.workspace.workspaceFolders![2].uri);
+		const expectedString = "description: A new flutter module project";
+		const pubspecFile = path.join(moduleProjectFolder, "pubspec.yaml");
+		// Creating the project may be a little slow, so allow up to 60 seconds for it.
+		logger.info("Waiting for file to exist", LogCategory.CI);
+		await waitForResult(() => fs.existsSync(pubspecFile), "pubspec.yaml did not exist", 100000);
+		// Wait for up to 10 seconds for the content to match, as the file may be updated after creation.
+		logger.info("Waiting for content match", LogCategory.CI);
+		await waitForResult(() => {
+			const contents = fs.readFileSync(pubspecFile);
+			return contents.indexOf(expectedString) !== -1;
+		}, undefined, 10000, false); // Don't throw on failure, as we have a better assert below that can include the contents.
+
+		const contents = fs.readFileSync(pubspecFile);
+		if (contents.indexOf(expectedString) === -1)
+			assert.fail(`Did not find "${expectedString}'" in the file (${pubspecFile}):\n\n${contents}`);
+	});
+
 	it("triggered Flutter mode", () => {
 		const ext = vs.extensions.getExtension(dartCodeExtensionIdentifier);
 		assert.ok(ext);

--- a/src/test/not_activated/flutter_create/extension.test.ts
+++ b/src/test/not_activated/flutter_create/extension.test.ts
@@ -30,7 +30,7 @@ describe("extension", () => {
 // Other tests must go in their own folders and be listed in test_all/launch.json individually.
 
 describe("command", () => {
-	it("Flutter: New Project can be invoked and creates trigger file", async () => {
+	it("Flutter: New Application Project can be invoked and creates trigger file", async () => {
 		attachLoggingWhenExtensionAvailable();
 
 		const showOpenDialog = sb.stub(vs.window, "showOpenDialog");
@@ -54,6 +54,39 @@ describe("command", () => {
 		assert.ok(showOpenDialog.calledOnce);
 		assert.ok(openFolder.calledOnce);
 		assert.ok(fs.existsSync(path.join(tempFolder, "my_test_flutter_proj", FLUTTER_CREATE_PROJECT_TRIGGER_FILE)));
+	});
+
+	it("Flutter: New Module Project can be invoked and creates trigger file", async () => {
+		attachLoggingWhenExtensionAvailable();
+
+		const showOpenDialog = sb.stub(vs.window, "showOpenDialog");
+		const tempFolder = getRandomTempFolder();
+		showOpenDialog.resolves([vs.Uri.file(tempFolder)]);
+
+		const showInputBox = sb.stub(vs.window, "showInputBox");
+		showInputBox.resolves("my_test_flutter_proj");
+
+		// Create some folders in the temp folder to check the default name is correctly incremented.
+		fs.mkdirSync(path.join(tempFolder, "flutter_application_1"));
+		fs.mkdirSync(path.join(tempFolder, "flutter_application_2"));
+
+		// Intercept executeCommand for openFolder so we don't spawn a new instance of Code!
+		const executeCommand = sb.stub(vs.commands, "executeCommand").callThrough();
+		const openFolder = executeCommand.withArgs("vscode.openFolder", sinon.match.any).resolves();
+		const projectFolderUri: string | undefined = await vs.commands.executeCommand("flutter.createProject.module");
+
+		assert.ok(projectFolderUri);
+		assert.ok(showInputBox.calledOnceWith(sinon.match.has("value", "flutter_application_3")));
+		assert.ok(showOpenDialog.calledOnce);
+		assert.ok(openFolder.calledOnce);
+
+		const triggerFile = path.join(fsPath(projectFolderUri), FLUTTER_CREATE_PROJECT_TRIGGER_FILE);
+		assert.ok(fs.existsSync(triggerFile));
+
+		const jsonString: string | undefined = fs.readFileSync(triggerFile).toString().trim();
+		const json = jsonString ? JSON.parse(jsonString) as FlutterCreateTriggerData : undefined;
+
+		assert.equal(json?.template === "module", true);
 	});
 
 	it("Flutter: Create Sample Project can be invoked and creates trigger file", async () => {

--- a/src/test/not_activated/flutter_create/extension.test.ts
+++ b/src/test/not_activated/flutter_create/extension.test.ts
@@ -89,6 +89,72 @@ describe("command", () => {
 		assert.equal(json?.template === "module", true);
 	});
 
+	it("Flutter: New Package Project can be invoked and creates trigger file", async () => {
+		attachLoggingWhenExtensionAvailable();
+
+		const showOpenDialog = sb.stub(vs.window, "showOpenDialog");
+		const tempFolder = getRandomTempFolder();
+		showOpenDialog.resolves([vs.Uri.file(tempFolder)]);
+
+		const showInputBox = sb.stub(vs.window, "showInputBox");
+		showInputBox.resolves("my_test_flutter_proj");
+
+		// Create some folders in the temp folder to check the default name is correctly incremented.
+		fs.mkdirSync(path.join(tempFolder, "flutter_application_1"));
+		fs.mkdirSync(path.join(tempFolder, "flutter_application_2"));
+
+		// Intercept executeCommand for openFolder so we don't spawn a new instance of Code!
+		const executeCommand = sb.stub(vs.commands, "executeCommand").callThrough();
+		const openFolder = executeCommand.withArgs("vscode.openFolder", sinon.match.any).resolves();
+		const projectFolderUri: string | undefined = await vs.commands.executeCommand("flutter.createProject.package");
+
+		assert.ok(projectFolderUri);
+		assert.ok(showInputBox.calledOnceWith(sinon.match.has("value", "flutter_application_3")));
+		assert.ok(showOpenDialog.calledOnce);
+		assert.ok(openFolder.calledOnce);
+
+		const triggerFile = path.join(fsPath(projectFolderUri), FLUTTER_CREATE_PROJECT_TRIGGER_FILE);
+		assert.ok(fs.existsSync(triggerFile));
+
+		const jsonString: string | undefined = fs.readFileSync(triggerFile).toString().trim();
+		const json = jsonString ? JSON.parse(jsonString) as FlutterCreateTriggerData : undefined;
+
+		assert.equal(json?.template === "package", true);
+	});
+
+	it("Flutter: New Plugin Project can be invoked and creates trigger file", async () => {
+		attachLoggingWhenExtensionAvailable();
+
+		const showOpenDialog = sb.stub(vs.window, "showOpenDialog");
+		const tempFolder = getRandomTempFolder();
+		showOpenDialog.resolves([vs.Uri.file(tempFolder)]);
+
+		const showInputBox = sb.stub(vs.window, "showInputBox");
+		showInputBox.resolves("my_test_flutter_proj");
+
+		// Create some folders in the temp folder to check the default name is correctly incremented.
+		fs.mkdirSync(path.join(tempFolder, "flutter_application_1"));
+		fs.mkdirSync(path.join(tempFolder, "flutter_application_2"));
+
+		// Intercept executeCommand for openFolder so we don't spawn a new instance of Code!
+		const executeCommand = sb.stub(vs.commands, "executeCommand").callThrough();
+		const openFolder = executeCommand.withArgs("vscode.openFolder", sinon.match.any).resolves();
+		const projectFolderUri: string | undefined = await vs.commands.executeCommand("flutter.createProject.plugin");
+
+		assert.ok(projectFolderUri);
+		assert.ok(showInputBox.calledOnceWith(sinon.match.has("value", "flutter_application_3")));
+		assert.ok(showOpenDialog.calledOnce);
+		assert.ok(openFolder.calledOnce);
+
+		const triggerFile = path.join(fsPath(projectFolderUri), FLUTTER_CREATE_PROJECT_TRIGGER_FILE);
+		assert.ok(fs.existsSync(triggerFile));
+
+		const jsonString: string | undefined = fs.readFileSync(triggerFile).toString().trim();
+		const json = jsonString ? JSON.parse(jsonString) as FlutterCreateTriggerData : undefined;
+
+		assert.equal(json?.template === "plugin", true);
+	});
+
 	it("Flutter: Create Sample Project can be invoked and creates trigger file", async () => {
 		const showQuickPick = sb.stub(vs.window, "showQuickPick");
 		type SnippetOption = vs.QuickPickItem & { snippet: FlutterSampleSnippet };

--- a/src/test/not_activated/flutter_create/extension.test.ts
+++ b/src/test/not_activated/flutter_create/extension.test.ts
@@ -57,102 +57,15 @@ describe("command", () => {
 	});
 
 	it("Flutter: New Module Project can be invoked and creates trigger file", async () => {
-		attachLoggingWhenExtensionAvailable();
-
-		const showOpenDialog = sb.stub(vs.window, "showOpenDialog");
-		const tempFolder = getRandomTempFolder();
-		showOpenDialog.resolves([vs.Uri.file(tempFolder)]);
-
-		const showInputBox = sb.stub(vs.window, "showInputBox");
-		showInputBox.resolves("my_test_flutter_proj");
-
-		// Create some folders in the temp folder to check the default name is correctly incremented.
-		fs.mkdirSync(path.join(tempFolder, "flutter_application_1"));
-		fs.mkdirSync(path.join(tempFolder, "flutter_application_2"));
-
-		// Intercept executeCommand for openFolder so we don't spawn a new instance of Code!
-		const executeCommand = sb.stub(vs.commands, "executeCommand").callThrough();
-		const openFolder = executeCommand.withArgs("vscode.openFolder", sinon.match.any).resolves();
-		const projectFolderUri: string | undefined = await vs.commands.executeCommand("flutter.createProject.module");
-
-		assert.ok(projectFolderUri);
-		assert.ok(showInputBox.calledOnceWith(sinon.match.has("value", "flutter_application_3")));
-		assert.ok(showOpenDialog.calledOnce);
-		assert.ok(openFolder.calledOnce);
-
-		const triggerFile = path.join(fsPath(projectFolderUri), FLUTTER_CREATE_PROJECT_TRIGGER_FILE);
-		assert.ok(fs.existsSync(triggerFile));
-
-		const jsonString: string | undefined = fs.readFileSync(triggerFile).toString().trim();
-		const json = jsonString ? JSON.parse(jsonString) as FlutterCreateTriggerData : undefined;
-
-		assert.equal(json?.template === "module", true);
+		await projectContainsExpectedTemplate("flutter.createProject.module", "module");
 	});
 
 	it("Flutter: New Package Project can be invoked and creates trigger file", async () => {
-		attachLoggingWhenExtensionAvailable();
-
-		const showOpenDialog = sb.stub(vs.window, "showOpenDialog");
-		const tempFolder = getRandomTempFolder();
-		showOpenDialog.resolves([vs.Uri.file(tempFolder)]);
-
-		const showInputBox = sb.stub(vs.window, "showInputBox");
-		showInputBox.resolves("my_test_flutter_proj");
-
-		// Create some folders in the temp folder to check the default name is correctly incremented.
-		fs.mkdirSync(path.join(tempFolder, "flutter_application_1"));
-		fs.mkdirSync(path.join(tempFolder, "flutter_application_2"));
-
-		// Intercept executeCommand for openFolder so we don't spawn a new instance of Code!
-		const executeCommand = sb.stub(vs.commands, "executeCommand").callThrough();
-		const openFolder = executeCommand.withArgs("vscode.openFolder", sinon.match.any).resolves();
-		const projectFolderUri: string | undefined = await vs.commands.executeCommand("flutter.createProject.package");
-
-		assert.ok(projectFolderUri);
-		assert.ok(showInputBox.calledOnceWith(sinon.match.has("value", "flutter_application_3")));
-		assert.ok(showOpenDialog.calledOnce);
-		assert.ok(openFolder.calledOnce);
-
-		const triggerFile = path.join(fsPath(projectFolderUri), FLUTTER_CREATE_PROJECT_TRIGGER_FILE);
-		assert.ok(fs.existsSync(triggerFile));
-
-		const jsonString: string | undefined = fs.readFileSync(triggerFile).toString().trim();
-		const json = jsonString ? JSON.parse(jsonString) as FlutterCreateTriggerData : undefined;
-
-		assert.equal(json?.template === "package", true);
+		await projectContainsExpectedTemplate("flutter.createProject.package", "package");
 	});
 
 	it("Flutter: New Plugin Project can be invoked and creates trigger file", async () => {
-		attachLoggingWhenExtensionAvailable();
-
-		const showOpenDialog = sb.stub(vs.window, "showOpenDialog");
-		const tempFolder = getRandomTempFolder();
-		showOpenDialog.resolves([vs.Uri.file(tempFolder)]);
-
-		const showInputBox = sb.stub(vs.window, "showInputBox");
-		showInputBox.resolves("my_test_flutter_proj");
-
-		// Create some folders in the temp folder to check the default name is correctly incremented.
-		fs.mkdirSync(path.join(tempFolder, "flutter_application_1"));
-		fs.mkdirSync(path.join(tempFolder, "flutter_application_2"));
-
-		// Intercept executeCommand for openFolder so we don't spawn a new instance of Code!
-		const executeCommand = sb.stub(vs.commands, "executeCommand").callThrough();
-		const openFolder = executeCommand.withArgs("vscode.openFolder", sinon.match.any).resolves();
-		const projectFolderUri: string | undefined = await vs.commands.executeCommand("flutter.createProject.plugin");
-
-		assert.ok(projectFolderUri);
-		assert.ok(showInputBox.calledOnceWith(sinon.match.has("value", "flutter_application_3")));
-		assert.ok(showOpenDialog.calledOnce);
-		assert.ok(openFolder.calledOnce);
-
-		const triggerFile = path.join(fsPath(projectFolderUri), FLUTTER_CREATE_PROJECT_TRIGGER_FILE);
-		assert.ok(fs.existsSync(triggerFile));
-
-		const jsonString: string | undefined = fs.readFileSync(triggerFile).toString().trim();
-		const json = jsonString ? JSON.parse(jsonString) as FlutterCreateTriggerData : undefined;
-
-		assert.equal(json?.template === "plugin", true);
+		await projectContainsExpectedTemplate("flutter.createProject.plugin", "plugin");
 	});
 
 	it("Flutter: Create Sample Project can be invoked and creates trigger file", async () => {
@@ -164,7 +77,6 @@ describe("command", () => {
 		// Intercept executeCommand for openFolder so we don't spawn a new instance of Code!
 		const executeCommand = sb.stub(vs.commands, "executeCommand").callThrough();
 		const openFolder = executeCommand.withArgs("vscode.openFolder", sinon.match.any).resolves();
-
 		const sampleFolderUri: string | undefined = await vs.commands.executeCommand("_dart.flutter.createSampleProject");
 
 		assert.ok(sampleFolderUri);
@@ -181,3 +93,36 @@ describe("command", () => {
 		// assert.equal(recordedSampleId, "material.IconButton.1");
 	});
 });
+
+async function projectContainsExpectedTemplate(commandToExecute: string, expectedTemplate: string): Promise<void> {
+	attachLoggingWhenExtensionAvailable();
+
+	const showOpenDialog = sb.stub(vs.window, "showOpenDialog");
+	const tempFolder = getRandomTempFolder();
+	showOpenDialog.resolves([vs.Uri.file(tempFolder)]);
+
+	const showInputBox = sb.stub(vs.window, "showInputBox");
+	showInputBox.resolves("my_test_flutter_proj");
+
+	// Create some folders in the temp folder to check the default name is correctly incremented.
+	fs.mkdirSync(path.join(tempFolder, "flutter_application_1"));
+	fs.mkdirSync(path.join(tempFolder, "flutter_application_2"));
+
+	// Intercept executeCommand for openFolder so we don't spawn a new instance of Code!
+	const executeCommand = sb.stub(vs.commands, "executeCommand").callThrough();
+	const openFolder = executeCommand.withArgs("vscode.openFolder", sinon.match.any).resolves();
+	const projectFolderUri: string | undefined = await vs.commands.executeCommand(commandToExecute);
+
+	assert.ok(projectFolderUri);
+	assert.ok(showInputBox.calledOnceWith(sinon.match.has("value", "flutter_application_3")));
+	assert.ok(showOpenDialog.calledOnce);
+	assert.ok(openFolder.calledOnce);
+
+	const triggerFile = path.join(fsPath(projectFolderUri), FLUTTER_CREATE_PROJECT_TRIGGER_FILE);
+	assert.ok(fs.existsSync(triggerFile));
+
+	const jsonString: string | undefined = fs.readFileSync(triggerFile).toString().trim();
+	const json = jsonString ? JSON.parse(jsonString) as FlutterCreateTriggerData : undefined;
+
+	assert.equal(json?.template === expectedTemplate, true);
+}

--- a/src/test/not_activated/flutter_create/extension.test.ts
+++ b/src/test/not_activated/flutter_create/extension.test.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import * as sinon from "sinon";
 import * as vs from "vscode";
 import { FLUTTER_CREATE_PROJECT_TRIGGER_FILE } from "../../../shared/constants";
+import { FlutterCreateTriggerData } from "../../../shared/interfaces";
 import { fsPath } from "../../../shared/utils/fs";
 import { FlutterSampleSnippet } from "../../../shared/vscode/interfaces";
 import { attachLoggingWhenExtensionAvailable, ext, getRandomTempFolder, sb } from "../../helpers";
@@ -72,9 +73,12 @@ describe("command", () => {
 		assert.ok(openFolder.calledOnce);
 		const triggerFile = path.join(fsPath(sampleFolderUri), FLUTTER_CREATE_PROJECT_TRIGGER_FILE);
 		assert.ok(fs.existsSync(triggerFile));
-		const recordedSampleId = fs.readFileSync(triggerFile).toString().trim();
+
+		const jsonString: string | undefined = fs.readFileSync(triggerFile).toString().trim();
+		const json = jsonString ? JSON.parse(jsonString) as FlutterCreateTriggerData : undefined;
+
 		// TODO: Remove next line and uncomment the following one after the next stable Flutter release (the one after v1.2).
-		assert.equal(recordedSampleId === "material.IconButton" || recordedSampleId === "material.IconButton.1", true);
+		assert.equal(json?.sample === "material.IconButton" || json?.sample === "material.IconButton.1", true);
 		// assert.equal(recordedSampleId, "material.IconButton.1");
 	});
 });

--- a/src/test/test_projects/flutter_create_module/flutter.create
+++ b/src/test/test_projects/flutter_create_module/flutter.create
@@ -1,0 +1,3 @@
+{
+	"template": "module"
+}

--- a/src/test/test_projects/flutter_create_package/flutter.create
+++ b/src/test/test_projects/flutter_create_package/flutter.create
@@ -1,0 +1,3 @@
+{
+	"template": "package"
+}

--- a/src/test/test_projects/flutter_create_plugin/flutter.create
+++ b/src/test/test_projects/flutter_create_plugin/flutter.create
@@ -1,0 +1,3 @@
+{
+	"template": "plugin"
+}

--- a/src/test/test_projects/flutter_create_sample/flutter.create
+++ b/src/test/test_projects/flutter_create_sample/flutter.create
@@ -1,1 +1,3 @@
-material.IconButton.1
+{
+	"sample": "material.IconButton.1"
+}

--- a/src/test/test_projects/flutter_create_tests.code-workspace
+++ b/src/test/test_projects/flutter_create_tests.code-workspace
@@ -8,7 +8,13 @@
 		},
 		{
 			"path": "flutter_create_module"
-		}
+		},
+		{
+			"path": "flutter_create_package"
+		},
+		{
+			"path": "flutter_create_plugin"
+		},
 	],
 	"settings": {
 		"files.insertFinalNewline": true

--- a/src/test/test_projects/flutter_create_tests.code-workspace
+++ b/src/test/test_projects/flutter_create_tests.code-workspace
@@ -5,6 +5,9 @@
 		},
 		{
 			"path": "flutter_create_sample"
+		},
+		{
+			"path": "flutter_create_module"
 		}
 	],
 	"settings": {


### PR DESCRIPTION
This currently only implements the `module` template; if it looks good, then there will additional commits implementing the `plugin` and `package` templates.

Fixes #2963.