### PR TITLE
Add support for Flutter integration tests

### DIFF
--- a/src/debug/debug_entry.ts
+++ b/src/debug/debug_entry.ts
@@ -2,6 +2,7 @@ import { DebugSession } from "vscode-debugadapter";
 import { DartDebugSession } from "./dart_debug_impl";
 import { DartTestDebugSession } from "./dart_test_debug_impl";
 import { FlutterDebugSession } from "./flutter_debug_impl";
+import { FlutterIntegrationTestDebugSession } from "./flutter_integration_test_debug_impl";
 import { FlutterTestDebugSession } from "./flutter_test_debug_impl";
 import { WebDebugSession } from "./web_debug_impl";
 import { WebTestDebugSession } from "./web_test_debug_impl";
@@ -13,6 +14,7 @@ const debuggers: { [key: string]: any } = {
 	"dart": DartDebugSession,
 	"dart_test": DartTestDebugSession,
 	"flutter": FlutterDebugSession,
+	"flutter_integration_test": FlutterIntegrationTestDebugSession,
 	"flutter_test": FlutterTestDebugSession,
 	"web": WebDebugSession,
 	"web_test": WebTestDebugSession,

--- a/src/debug/flutter_integration_test_debug_impl.ts
+++ b/src/debug/flutter_integration_test_debug_impl.ts
@@ -1,0 +1,49 @@
+import path = require("path");
+import { TerminatedEvent } from "vscode-debugadapter";
+import { DebugProtocol } from "vscode-debugprotocol";
+import { flutterPath } from "../shared/constants";
+import { FlutterLaunchRequestArguments } from "../shared/debug/interfaces";
+import { LogCategory } from "../shared/enums";
+import { safeSpawn } from "../shared/processes";
+import { DartDebugSession } from "./dart_debug_impl";
+
+export class FlutterIntegrationTestDebugSession extends DartDebugSession {
+	constructor() {
+		super();
+
+		this.allowWriteServiceInfo = false;
+		this.parseVmServiceUriFromStdOut = false;
+		this.logCategory = LogCategory.FlutterTest;
+	}
+
+	protected async attachRequest(response: DebugProtocol.AttachResponse, args: any): Promise<void> {
+		return this.launchRequest(response, args);
+	}
+
+	protected spawnProcess(args: FlutterLaunchRequestArguments): any {
+		// TODO: Do we support this?
+		const isAttach = args.request === "attach";
+		this.allowTerminatingVmServicePid = !isAttach;
+
+		if (!args.flutterDriverScript || !args.program) {
+			this.logToUser("Unable to launch Flutter integration test. flutterDriverScript and program required.");
+			this.sendEvent(new TerminatedEvent());
+			return;
+		}
+
+		// TODO: Debug arguments and Flutter drive additional args.
+		const appArgs = ["drive", "--driver", args.flutterDriverScript, "--target", args.program];
+		const flutterBinPath = path.join(args.flutterSdkPath, flutterPath);
+
+		this.log(`Spawning ${flutterBinPath} with args ${JSON.stringify(appArgs)}`);
+		if (args.cwd)
+			this.log(`..  in ${args.cwd}`);
+		// TODO: Flutter global args?
+		const process = safeSpawn(args.cwd, flutterBinPath, appArgs, { envOverrides: args.env, toolEnv: args.toolEnv });
+
+		this.log(`    PID: ${process.pid}`);
+
+		return process;
+	}
+
+}

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -109,6 +109,12 @@ export function isTestFileOrFolder(path: string): boolean {
 	return !!path && (isTestFile(path) || isTestFolder(path));
 }
 
+export function isIntegrationTestFile(file: string): boolean {
+	return !!file && isDartFile(file)
+		&& (isInsideFolderNamed(file, "integration_test"))
+		&& file.toLowerCase().endsWith("_test.dart");
+}
+
 export function isTestFile(file: string): boolean {
 	// To be a test, you must be _test.dart AND inside a test folder.
 	// https://github.com/Dart-Code/Dart-Code/issues/1165
@@ -155,7 +161,7 @@ export function isInsideFolderNamed(file: string, folderName: string): boolean {
 export function isValidEntryFile(file: string | undefined) {
 	return file && isDartFile(file) &&
 		(
-			isTestFile(file)
+			isTestFile(file) || isIntegrationTestFile(file)
 			|| isInsideFolderNamed(file, "bin") || isInsideFolderNamed(file, "tool") || isInsideFolderNamed(file, "test_driver")
 			|| file.endsWith(`lib${path.sep}main.dart`)
 		);

--- a/src/shared/debug/interfaces.ts
+++ b/src/shared/debug/interfaces.ts
@@ -40,6 +40,7 @@ export interface FlutterLaunchRequestArguments extends DartLaunchRequestArgument
 	forceFlutterVerboseMode?: boolean;
 	flutterTrackWidgetCreation?: boolean;
 	flutterDisableVmServiceExperimental?: boolean;
+	flutterDriverScript?: string;
 	flutterSdkPath: string;
 	globalFlutterArgs?: string[];
 	workspaceConfig?: WorkspaceConfig;

--- a/src/shared/enums.ts
+++ b/src/shared/enums.ts
@@ -3,6 +3,7 @@ export enum DebuggerType {
 	PubTest,
 	Flutter,
 	FlutterTest,
+	FlutterIntegrationTest,
 	Web,
 	WebTest,
 }

--- a/src/shared/utils/debug.ts
+++ b/src/shared/utils/debug.ts
@@ -9,6 +9,9 @@ export function getDebugAdapterName(debugType: DebuggerType) {
 		case DebuggerType.FlutterTest:
 			debuggerName = "flutter_test";
 			break;
+		case DebuggerType.FlutterIntegrationTest:
+			debuggerName = "flutter_integration_test";
+			break;
 		case DebuggerType.Web:
 			debuggerName = "web";
 			break;

--- a/src/test/test_projects/flutter_hello_world/.gitignore
+++ b/src/test/test_projects/flutter_hello_world/.gitignore
@@ -1,4 +1,6 @@
 .idea/
+.flutter-plugins
+.flutter-plugins-dependencies
 .metadata
 *.iml
 android/

--- a/src/test/test_projects/flutter_hello_world/.gitignore
+++ b/src/test/test_projects/flutter_hello_world/.gitignore
@@ -7,3 +7,4 @@ example/.gitignore
 example/test/widget_test.dart
 ios/
 README.md
+windows/

--- a/src/test/test_projects/flutter_hello_world/integration_test/app_test.dart
+++ b/src/test/test_projects/flutter_hello_world/integration_test/app_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hello_world/main.dart' as app;
+import 'package:hello_world/counter.dart' as app;
 import 'package:integration_test/integration_test.dart';
 
 void main() {

--- a/src/test/test_projects/flutter_hello_world/integration_test/app_test.dart
+++ b/src/test/test_projects/flutter_hello_world/integration_test/app_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hello_world/main.dart' as app;
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    app.main();
+
+    // Trigger a frame.
+    await tester.pumpAndSettle();
+
+    // Verify that our counter starts at 0.
+    expect(find.text('0'), findsOneWidget);
+    expect(find.text('1'), findsNothing);
+
+    // Tap the '+' icon and trigger a frame.
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pump();
+
+    // Verify that our counter has incremented.
+    expect(find.text('0'), findsNothing);
+    expect(find.text('1'), findsOneWidget);
+  });
+}

--- a/src/test/test_projects/flutter_hello_world/integration_test/driver.dart
+++ b/src/test/test_projects/flutter_hello_world/integration_test/driver.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();

--- a/src/test/test_projects/flutter_hello_world/pubspec.yaml
+++ b/src/test/test_projects/flutter_hello_world/pubspec.yaml
@@ -19,6 +19,7 @@ dev_dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
+  integration_test: ^1.0.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
This PR adds support for integration testing but I have some questions.

- Should debugging be supported?
  - If so, how do we get the VM service URL?
- Does Flutter drive support JSON output so we can put the results in the test tree?
- Should we support `attach` (Flutter drive does have `use-existing-app`)?