### PR TITLE
Specified type in dart snippet

### DIFF
--- a/snippets/dart.json
+++ b/snippets/dart.json
@@ -54,7 +54,7 @@
 			"prefix": "for",
 			"description": "Insert a for loop.",
 			"body": [
-				"for (var i = 0; i < ${1:count}; i++) {",
+				"for (int i = 0; i < ${1:count}; i++) {",
 				"  $0",
 				"}"
 			]


### PR DESCRIPTION
It is a [better practice](https://dart-lang.github.io/linter/lints/always_specify_types.html) to specify type annotations.