### PR TITLE
Add new test commands/settings

### DIFF
--- a/media/commands/test-clear-dark.svg
+++ b/media/commands/test-clear-dark.svg
@@ -1,0 +1,4 @@
+
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+	<path d="M10 12.6l.7.7 1.6-1.6 1.6 1.6.8-.7L13 11l1.7-1.6-.8-.8-1.6 1.7-1.6-1.7-.7.8 1.6 1.6-1.6 1.6zM1 4h14V3H1v1zm0 3h14V6H1v1zm8 2.5V9H1v1h8v-.5zM9 13v-1H1v1h8z" fill="#c5c5c5" />
+</svg>

--- a/media/commands/test-clear-light.svg
+++ b/media/commands/test-clear-light.svg
@@ -1,0 +1,4 @@
+
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+	<path d="M10 12.6l.7.7 1.6-1.6 1.6 1.6.8-.7L13 11l1.7-1.6-.8-.8-1.6 1.7-1.6-1.7-.7.8 1.6 1.6-1.6 1.6zM1 4h14V3H1v1zm0 3h14V6H1v1zm8 2.5V9H1v1h8v-.5zM9 13v-1H1v1h8z" fill="#424242"/>
+</svg>

--- a/media/commands/test-run-failed.svg
+++ b/media/commands/test-run-failed.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" fill="red" />
+	<path d="M0 12v12l10 -6Z" fill="green" />
+</svg>

--- a/media/commands/test-run-failed.svg
+++ b/media/commands/test-run-failed.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
     <path d="M0 0h24v24H0z" fill="none"/>
     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z" fill="red" />
-	<path d="M0 12v12l10 -6Z" fill="green" />
+	<path fill-rule="evenodd" clip-rule="evenodd" d="M4 2v12.48l8.915-6.24L4 2zm7.18 6.24l-6.185 4.328V3.912l6.186 4.328z" transform="translate(-3, 6)" stroke-width="1.5" stroke="#c5c5c5"/>
 </svg>

--- a/media/commands/test-run-skipped.svg
+++ b/media/commands/test-run-skipped.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
     <path d="M0 0h24v24H0z" fill="none"/>
     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 14H9V8h2v8zm4 0h-2V8h2v8z" fill="yellow" />
-	<path d="M0 12v12l10 -6Z" fill="green" />
+	<path fill-rule="evenodd" clip-rule="evenodd" d="M4 2v12.48l8.915-6.24L4 2zm7.18 6.24l-6.185 4.328V3.912l6.186 4.328z" transform="translate(-3, 6)" stroke-width="1.5" stroke="#c5c5c5"/>
 </svg>
 
 

--- a/media/commands/test-run-skipped.svg
+++ b/media/commands/test-run-skipped.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 14H9V8h2v8zm4 0h-2V8h2v8z" fill="yellow" />
+	<path d="M0 12v12l10 -6Z" fill="green" />
+</svg>
+
+

--- a/package.json
+++ b/package.json
@@ -178,12 +178,14 @@
 			{
 				"command": "dart.runAllSkippedTestsWithoutDebugging",
 				"title": "Run All Skipped Tests",
-				"category": "Dart"
+				"category": "Dart",
+				"icon": "./media/commands/test-run-skipped.svg"
 			},
 			{
 				"command": "dart.runAllFailedTestsWithoutDebugging",
 				"title": "Run All Failed Tests",
-				"category": "Dart"
+				"category": "Dart",
+				"icon": "./media/commands/test-run-failed.svg"
 			},
 			{
 				"command": "dart.rerunLastDebugSession",
@@ -1156,6 +1158,16 @@
 				{
 					"when": "view == dartFlutterOutline && dart-code:widgetSupports:refactor.flutter.removeWidget",
 					"command": "_flutter.outline.refactor.flutter.removeWidget"
+				},
+				{
+					"when": "view == dartTestTree",
+					"command": "dart.runAllFailedTestsWithoutDebugging",
+					"group": "navigation@1"
+				},
+				{
+					"when": "view == dartTestTree",
+					"command": "dart.runAllSkippedTestsWithoutDebugging",
+					"group": "navigation@2"
 				},
 				{
 					"when": "view == dartTestTree",

--- a/package.json
+++ b/package.json
@@ -223,7 +223,11 @@
 			{
 				"command": "dart.clearTestResults",
 				"title": "Clear Test Results",
-				"category": "Dart"
+				"category": "Dart",
+				"icon": {
+					"dark": "./media/commands/test-clear-dark.svg",
+					"light": "./media/commands/test-clear-light.svg"
+				}
 			},
 			{
 				"command": "dart.goToTests",
@@ -1152,6 +1156,11 @@
 				{
 					"when": "view == dartFlutterOutline && dart-code:widgetSupports:refactor.flutter.removeWidget",
 					"command": "_flutter.outline.refactor.flutter.removeWidget"
+				},
+				{
+					"when": "view == dartTestTree",
+					"command": "dart.clearTestResults",
+					"group": "navigation@3"
 				}
 			],
 			"view/item/context": [

--- a/package.json
+++ b/package.json
@@ -584,6 +584,14 @@
 				"command": "_flutter.outline.refactor.flutter.removeWidget",
 				"title": "Remove this widget",
 				"category": "Flutter"
+			},
+			{
+				"command": "_dart.toggleSkippedTestVisibilityOn",
+				"title": "Show skipped tests"
+			},
+			{
+				"command": "_dart.toggleSkippedTestVisibilityOff",
+				"title": "Hide skipped tests"
 			}
 		],
 		"keybindings": [
@@ -1173,6 +1181,14 @@
 					"when": "view == dartTestTree",
 					"command": "dart.clearTestResults",
 					"group": "navigation@3"
+				},
+				{
+					"when": "view == dartTestTree && config.dart.showSkippedTests",
+					"command": "_dart.toggleSkippedTestVisibilityOff"
+				},
+				{
+					"when": "view == dartTestTree && !config.dart.showSkippedTests",
+					"command": "_dart.toggleSkippedTestVisibilityOn"
 				}
 			],
 			"view/item/context": [
@@ -1413,6 +1429,12 @@
 					"default": true,
 					"markdownDescription": "Whether to show logs from the `dart:developer` `log()` function in the debug console.",
 					"scope": "resource"
+				},
+				"dart.showSkippedTests": {
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "Whether to show skipped tests in the test tree.",
+					"scope": "window"
 				},
 				"dart.flutterStructuredErrors": {
 					"type": "boolean",

--- a/package.json
+++ b/package.json
@@ -173,7 +173,8 @@
 			{
 				"command": "dart.runAllTestsWithoutDebugging",
 				"title": "Run All Tests",
-				"category": "Dart"
+				"category": "Dart",
+				"icon": "$(play)"
 			},
 			{
 				"command": "dart.runAllSkippedTestsWithoutDebugging",
@@ -1169,18 +1170,23 @@
 				},
 				{
 					"when": "view == dartTestTree",
-					"command": "dart.runAllFailedTestsWithoutDebugging",
+					"command": "dart.runAllTestsWithoutDebugging",
 					"group": "navigation@1"
 				},
 				{
 					"when": "view == dartTestTree",
-					"command": "dart.runAllSkippedTestsWithoutDebugging",
+					"command": "dart.runAllFailedTestsWithoutDebugging",
 					"group": "navigation@2"
 				},
 				{
 					"when": "view == dartTestTree",
-					"command": "dart.clearTestResults",
+					"command": "dart.runAllSkippedTestsWithoutDebugging",
 					"group": "navigation@3"
+				},
+				{
+					"when": "view == dartTestTree",
+					"command": "dart.clearTestResults",
+					"group": "navigation@4"
 				},
 				{
 					"when": "view == dartTestTree && config.dart.showSkippedTests",

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -105,6 +105,7 @@ class Config {
 	get showDevToolsDebugToolBarButtons(): boolean { return this.getConfig<boolean>("showDevToolsDebugToolBarButtons", true); }
 	get showIgnoreQuickFixes(): boolean { return this.getConfig<boolean>("showIgnoreQuickFixes", true); }
 	get showMainCodeLens(): boolean { return this.getConfig<boolean>("showMainCodeLens", true); }
+	get showSkippedTests(): boolean { return this.getConfig<boolean>("showSkippedTests", true); }
 	get showTestCodeLens(): boolean { return this.getConfig<boolean>("showTestCodeLens", true); }
 	get showTodos(): boolean { return this.getConfig<boolean>("showTodos", true); }
 	get triggerSignatureHelpAutomatically(): boolean { return this.getConfig<boolean>("triggerSignatureHelpAutomatically", false); }
@@ -132,6 +133,7 @@ class Config {
 	public setGlobalFlutterSdkPath(value: string): Thenable<void> { return this.setConfig("flutterSdkPath", value, ConfigurationTarget.Global); }
 	public setPreviewLsp(value: boolean): Thenable<void> { return this.setConfig("previewLsp", value, ConfigurationTarget.Global); }
 	public setOpenDevTools(value: "never" | "flutter" | "always" | undefined): Thenable<void> { return this.setConfig("openDevTools", value, ConfigurationTarget.Global); }
+	public setShowSkippedTests(value: boolean): Thenable<void> { return this.setConfig("showSkippedTests", value, ConfigurationTarget.Global); }
 	public setSdkPath(value: string | undefined): Thenable<void> { return this.setConfig("sdkPath", value, ConfigurationTarget.Workspace); }
 	public setWarnWhenEditingFilesOutsideWorkspace(value: boolean): Thenable<void> { return this.setConfig("warnWhenEditingFilesOutsideWorkspace", value, ConfigurationTarget.Global); }
 	public setWarnWhenEditingFilesInPubCache(value: boolean): Thenable<void> { return this.setConfig("warnWhenEditingFilesInPubCache", value, ConfigurationTarget.Global); }

--- a/src/extension/views/test_view.ts
+++ b/src/extension/views/test_view.ts
@@ -10,6 +10,7 @@ import { brightRed, yellow } from "../../shared/utils/colors";
 import { fsPath, getRandomInt } from "../../shared/utils/fs";
 import { getLaunchConfig } from "../../shared/utils/test";
 import { extensionPath } from "../../shared/vscode/extension_utils";
+import { config } from "../config";
 import { writeToPseudoTerminal } from "../utils/vscode/terminals";
 
 type SuiteList = [SuiteNode, string[]];
@@ -25,6 +26,8 @@ export class TestResultsProvider implements vs.Disposable, vs.TreeDataProvider<T
 
 		this.disposables.push(vs.debug.onDidReceiveDebugSessionCustomEvent((e) => this.handleDebugSessionCustomEvent(e)));
 		this.disposables.push(vs.debug.onDidTerminateDebugSession((session) => this.handleDebugSessionEnd(session)));
+		this.disposables.push(vs.commands.registerCommand("_dart.toggleSkippedTestVisibilityOff", () => config.setShowSkippedTests(false)));
+		this.disposables.push(vs.commands.registerCommand("_dart.toggleSkippedTestVisibilityOn", () => config.setShowSkippedTests(true)));
 		this.disposables.push(vs.commands.registerCommand("dart.startDebuggingTest", (treeNode: SuiteNode | GroupNode | TestNode) => this.runTests(treeNode, this.getTestNames(treeNode), true, false)));
 		this.disposables.push(vs.commands.registerCommand("dart.startWithoutDebuggingTest", (treeNode: SuiteNode | GroupNode | TestNode) => this.runTests(treeNode, this.getTestNames(treeNode), false, false)));
 		this.disposables.push(vs.commands.registerCommand("dart.startDebuggingSkippedTests", (treeNode: SuiteNode | GroupNode | TestNode) => this.runTests(treeNode, this.getTestNames(treeNode, TestStatus.Skipped), true, false, true)));

--- a/src/extension/views/test_view.ts
+++ b/src/extension/views/test_view.ts
@@ -98,7 +98,7 @@ export class TestResultsProvider implements vs.Disposable, vs.TreeDataProvider<T
 			{
 				cancellable: true,
 				location: vs.ProgressLocation.Notification,
-				title: `Running ${onlyOfType.toString().toLowerCase()} tests`,
+				title: `Running ${TestStatus[onlyOfType].toString().toLowerCase()} tests`,
 			},
 			async (progress, token) => {
 				progress.report({ increment: 1 });

--- a/src/shared/test/coordindator.ts
+++ b/src/shared/test/coordindator.ts
@@ -87,7 +87,6 @@ export class TestSessionCoordindator implements IAmDisposable {
 
 	private handleSuiteNotification(suitePath: string, evt: SuiteNotification) {
 		const [suite, didCreate] = this.data.getOrCreateSuite(evt.suite.path);
-		suite.node.clearStatuses();
 		suite.node.appendStatus(TestStatus.Waiting);
 		this.data.updateNode(suite.node);
 		this.data.updateNode();
@@ -209,7 +208,6 @@ export class TestSessionCoordindator implements IAmDisposable {
 		if (!existingGroup || hasChangedParent)
 			groupNode.parent.groups.push(groupNode);
 
-		groupNode.clearStatuses();
 		groupNode.appendStatus(TestStatus.Running);
 		this.data.updateNode(groupNode);
 		this.data.updateNode(groupNode.parent);

--- a/src/shared/test/test_model.ts
+++ b/src/shared/test/test_model.ts
@@ -12,8 +12,8 @@ enum TestSortOrder {
 	Bottom, // Skips
 }
 
-function getTestSortOrder(status: TestStatus): TestSortOrder {
-	if (status === TestStatus.Failed)
+function getTestSortOrder(statuses: Set<TestStatus>): TestSortOrder {
+	if (statuses.has(TestStatus.Failed))
 		return TestSortOrder.Top;
 	// https://github.com/Dart-Code/Dart-Code/issues/1125
 	// if (status === TestStatus.Skipped)
@@ -65,7 +65,7 @@ export abstract class TestContainerNode extends TreeNode {
 		this.statuses.add(status);
 		this.updateHighestPriorityStatus();
 
-		this._sort = getTestSortOrder(this._highestStatus);
+		this._sort = getTestSortOrder(this.statuses);
 	}
 
 	public clearStatuses() {
@@ -197,7 +197,7 @@ export class TestNode extends TreeNode {
 			this.isPotentiallyDeleted = false;
 		}
 
-		this._sort = getTestSortOrder(this.status);
+		this._sort = getTestSortOrder(new Set<TestStatus>([this.status]));
 	}
 }
 


### PR DESCRIPTION
This is progress towards #3038 and #3050 but will need rebasing over @BootBlock's PR.

Still needs:

- [x] The `dart.showSkippedTests` setting to actually affect rendering (but not the model)
- [x] Refreshing the test tree whenever the `dart.showSkippedTests` setting changes
- [x] Merge the `dart.runAllSkippedTestsWithoutDebugging` command definition cleanly and ensure the same IDs have been used
- [x] ~Improve test icons~ #3094

(Fixes #3038 and fixes #3050 once complete.)