### PR TITLE
Extract devtools links from flutter structured errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1523,6 +1523,12 @@
 						"type": "string"
 					}
 				},
+				"dart.showInspectorNotificationsForWidgetErrors": {
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "Whether to show notifications for widget errors that offer Inspect Widget links. This requires that the `dart.shareDevToolsWithFlutter` setting is also enabled.",
+					"scope": "window"
+				},
 				"dart.hotReloadProgress": {
 					"enum": [
 						"notification",

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -73,6 +73,7 @@ export class DartDebugSession extends DebugSession {
 	public debugExternalLibraries = false;
 	public showDartDeveloperLogs = true;
 	public useFlutterStructuredErrors = false;
+	public useInspectorNotificationsForWidgetErrors = false;
 	public evaluateGettersInDebugViews = false;
 	protected evaluateToStringInDebugViews = false;
 	protected readonly dartCapabilities = DartCapabilities.empty;
@@ -275,7 +276,8 @@ export class DartDebugSession extends DebugSession {
 		this.sendLogsToClient = !!args.sendLogsToClient;
 		this.showDartDeveloperLogs = args.showDartDeveloperLogs;
 		this.toolEnv = args.toolEnv;
-		this.useFlutterStructuredErrors = args.useFlutterStructuredErrors;
+		this.useFlutterStructuredErrors = !!args.useFlutterStructuredErrors;
+		this.useInspectorNotificationsForWidgetErrors = !!args.useInspectorNotificationsForWidgetErrors;
 	}
 
 	protected async attachRequest(response: DebugProtocol.AttachResponse, args: DartAttachRequestArguments): Promise<void> {

--- a/src/extension/commands/debug.ts
+++ b/src/extension/commands/debug.ts
@@ -1,9 +1,9 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as vs from "vscode";
-import { devToolsPages, doNotAskAgainAction, isInFlutterDebugModeDebugSessionContext, isInFlutterProfileModeDebugSessionContext } from "../../shared/constants";
+import { devToolsPages, doNotAskAgainAction, isInFlutterDebugModeDebugSessionContext, isInFlutterProfileModeDebugSessionContext, widgetInspectorPage } from "../../shared/constants";
 import { DebuggerType, DebugOption, debugOptionNames, LogSeverity, VmServiceExtension } from "../../shared/enums";
-import { DartWorkspaceContext, DevToolsPage, Logger, LogMessage } from "../../shared/interfaces";
+import { DartWorkspaceContext, DevToolsPage, Logger, LogMessage, WidgetErrorInspectData } from "../../shared/interfaces";
 import { flatMap, PromiseCompleter } from "../../shared/utils";
 import { findProjectFolders, fsPath } from "../../shared/utils/fs";
 import { showDevToolsNotificationIfAppropriate } from "../../shared/vscode/user_prompts";
@@ -54,6 +54,7 @@ export class DebugCommands {
 	public readonly onDebugSessionVmServiceAvailable = this.onDebugSessionVmServiceAvailableEmitter.event;
 	public readonly vmServices: VmServiceExtensions;
 	public readonly devTools: DevToolsManager;
+	private suppressFlutterWidgetErrors = false;
 
 	constructor(private readonly logger: Logger, private context: Context, workspaceContext: DartWorkspaceContext, private readonly analytics: Analytics, pubGlobal: PubGlobal) {
 		this.vmServices = new VmServiceExtensions(logger, this.sendServiceSetting);
@@ -121,11 +122,10 @@ export class DebugCommands {
 
 			// Only show a notification if we were not triggered automatically.
 			const notify = !options || options.triggeredAutomatically !== true;
-			const reuseWindows = config.devToolsReuseWindows;
 			const page = options?.page;
 
 			if (session.vmServiceUri) {
-				return this.devTools.spawnForSession(session as DartDebugSessionInformation & { vmServiceUri: string }, { embed: config.embedDevTools, reuseWindows, notify, page });
+				return this.devTools.spawnForSession(session as DartDebugSessionInformation & { vmServiceUri: string }, { notify, page });
 			} else if (session.session.configuration.noDebug) {
 				vs.window.showInformationMessage("You must start your app with debugging in order to use DevTools.");
 			} else {
@@ -549,6 +549,34 @@ export class DebugCommands {
 				await new Promise((resolve) => setTimeout(resolve, 400));
 			}
 			session.progress[e.body.progressID]?.complete();
+		} else if (e.event === "dart.flutter.widgetErrorInspectData") {
+			if (this.suppressFlutterWidgetErrors || !config.showInspectorNotificationsForWidgetErrors)
+				return;
+
+			const data = e.body as WidgetErrorInspectData;
+			if (data.devToolsUrl !== (await this.devTools.devtoolsUrl))
+				return;
+
+			// To avoid spam, when we show this dialog we will set a flag that prevents any more
+			// of these types of dialogs until it is dismissed or 5 seconds have passed.
+			this.suppressFlutterWidgetErrors = true;
+			const timer = setTimeout(() => this.suppressFlutterWidgetErrors = false, 5000);
+
+			const inspectAction = `Inspect Widget`;
+			const choice = await vs.window.showWarningMessage(data.errorDescription, inspectAction, doNotAskAgainAction);
+			if (choice === inspectAction && session.vmServiceUri) {
+				this.devTools.spawnForSession(
+					session as DartDebugSessionInformation & { vmServiceUri: string },
+					{
+						inspectorRef: data.inspectorReference,
+						page: widgetInspectorPage,
+					},
+				);
+			} else if (choice === doNotAskAgainAction) {
+				config.setShowInspectorNotificationsForWidgetErrors(false);
+			}
+			clearTimeout(timer);
+			this.suppressFlutterWidgetErrors = false;
 		}
 	}
 

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -104,6 +104,7 @@ class Config {
 	get shareDevToolsWithFlutter(): boolean { return this.getConfig<boolean>("shareDevToolsWithFlutter", true); }
 	get showDartPadSampleCodeLens(): boolean { return this.getConfig<boolean>("showDartPadSampleCodeLens", true); }
 	get showDevToolsDebugToolBarButtons(): boolean { return this.getConfig<boolean>("showDevToolsDebugToolBarButtons", true); }
+	get showInspectorNotificationsForWidgetErrors(): boolean { return this.getConfig<boolean>("showInspectorNotificationsForWidgetErrors", true); }
 	get showIgnoreQuickFixes(): boolean { return this.getConfig<boolean>("showIgnoreQuickFixes", true); }
 	get showMainCodeLens(): boolean { return this.getConfig<boolean>("showMainCodeLens", true); }
 	get showSkippedTests(): boolean { return this.getConfig<boolean>("showSkippedTests", true); }
@@ -134,6 +135,7 @@ class Config {
 	public setGlobalFlutterSdkPath(value: string): Thenable<void> { return this.setConfig("flutterSdkPath", value, ConfigurationTarget.Global); }
 	public setPreviewLsp(value: boolean): Thenable<void> { return this.setConfig("previewLsp", value, ConfigurationTarget.Global); }
 	public setOpenDevTools(value: "never" | "flutter" | "always" | undefined): Thenable<void> { return this.setConfig("openDevTools", value, ConfigurationTarget.Global); }
+	public setShowInspectorNotificationsForWidgetErrors(value: boolean): Thenable<void> { return this.setConfig("showInspectorNotificationsForWidgetErrors", value, ConfigurationTarget.Global); }
 	public setShowSkippedTests(value: boolean): Thenable<void> { return this.setConfig("showSkippedTests", value, ConfigurationTarget.Global); }
 	public setSdkPath(value: string | undefined): Thenable<void> { return this.setConfig("sdkPath", value, ConfigurationTarget.Workspace); }
 	public setWarnWhenEditingFilesOutsideWorkspace(value: boolean): Thenable<void> { return this.setConfig("warnWhenEditingFilesOutsideWorkspace", value, ConfigurationTarget.Global); }

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -463,6 +463,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			debugConfig.flutterSdkPath = this.wsContext.sdks.flutter;
 			debugConfig.globalFlutterArgs = getGlobalFlutterArgs();
 			debugConfig.useFlutterStructuredErrors = conf.flutterStructuredErrors;
+			debugConfig.useInspectorNotificationsForWidgetErrors = config.showInspectorNotificationsForWidgetErrors;
 			debugConfig.debugExtensionBackendProtocol = config.debugExtensionBackendProtocol;
 
 			const additionalArgs = isTest

--- a/src/extension/sdk/dev_tools/manager.ts
+++ b/src/extension/sdk/dev_tools/manager.ts
@@ -154,9 +154,10 @@ export class DevToolsManager implements vs.Disposable {
 		if (!url)
 			return;
 
-		// If the launched versin of DevTools doesn't support embedding, remove the flag.
-		if (!this.capabilities.supportsEmbedFlag)
-			options.embed = false;
+		if (options.embed === undefined)
+			options.embed = this.capabilities.supportsEmbedFlag && config.embedDevTools;
+		if (options.reuseWindows === undefined)
+			options.reuseWindows = config.devToolsReuseWindows;
 
 		// When we're running embedded and were asked to open without a page, we should prompt for a page (plus give an option
 		// to open non-embedded view).
@@ -246,6 +247,7 @@ export class DevToolsManager implements vs.Disposable {
 		const queryParams: { [key: string]: string | undefined } = {
 			hide: "debugger",
 			ide: "VSCode",
+			inspectorRef: options.inspectorRef,
 			theme: config.useDevToolsDarkTheme && !options.embed ? "dark" : undefined,
 		};
 
@@ -260,7 +262,7 @@ export class DevToolsManager implements vs.Disposable {
 			queryParams.embed = "true";
 		const fullUrl = await this.buildDevToolsUrl(queryParams, session, url);
 		if (options.embed)
-			// TODO: What should really we do it we don't have a page?
+			// TODO: What should we do if we don't have a page?
 			this.launchInEmbeddedWebView(fullUrl, session, options.page ?? devToolsPages[0]);
 		else
 			await envUtils.openInBrowser(fullUrl.toString(), this.logger);
@@ -476,8 +478,9 @@ export interface ServerStartedNotification {
 }
 
 interface DevToolsOptions {
-	embed: boolean;
+	embed?: boolean;
 	reuseWindows?: boolean;
 	notify?: boolean;
 	page?: DevToolsPage;
+	inspectorRef?: string;
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -136,9 +136,10 @@ export const runFlutterCreateDotPrompt = (platformType: string) => `You must run
 export const runFlutterCreateDotAction = "Run 'flutter create .'";
 export const cancelAction = "Cancel";
 
+export const widgetInspectorPage: DevToolsPage = { pageId: "inspector", commandId: "dart.openDevToolsInspector", title: "Widget Inspector" };
 export const devToolsPages: DevToolsPage[] = [
 	// First entry is the default page.
-	{ pageId: "inspector", commandId: "dart.openDevToolsInspector", title: "Widget Inspector" },
+	widgetInspectorPage,
 	{ pageId: "cpu-profiler", commandId: "dart.openDevToolsCpuProfiler", legacyPageId: "performance", title: "CPU Profiler" },
 	{ pageId: "memory", commandId: "dart.openDevToolsMemory", title: "Memory" },
 	{ pageId: "performance", commandId: "dart.openDevToolsPerformance", legacyPageId: "timeline", title: "Performance" },

--- a/src/shared/debug/interfaces.ts
+++ b/src/shared/debug/interfaces.ts
@@ -11,7 +11,8 @@ export interface DartSharedArgs {
 	sendLogsToClient?: boolean;
 	showDartDeveloperLogs: boolean;
 	toolEnv?: { [key: string]: string | undefined };
-	useFlutterStructuredErrors: boolean;
+	useFlutterStructuredErrors?: boolean;
+	useInspectorNotificationsForWidgetErrors?: boolean;
 	debugExtensionBackendProtocol: "sse" | "ws";
 }
 

--- a/src/shared/flutter/structured_errors.ts
+++ b/src/shared/flutter/structured_errors.ts
@@ -12,6 +12,7 @@ export interface DiagnosticsNode {
 	properties: DiagnosticsNode[];
 	children: DiagnosticsNode[];
 	style: DiagnosticsNodeStyle;
+	value?: string;
 }
 
 // If we have per-type properties, handle them like this.
@@ -21,8 +22,10 @@ export interface DiagnosticsNode {
 
 export enum DiagnosticsNodeType {
 	ErrorDescription = "ErrorDescription",
+	ErrorSummary = "ErrorSummary",
 	ErrorSpacer = "ErrorSpacer",
 	DiagnosticsStackTrace = "DiagnosticsStackTrace",
+	DevToolsDeepLinkProperty = "DevToolsDeepLinkProperty",
 }
 
 export enum DiagnosticsNodeLevel {

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -181,3 +181,9 @@ export interface DevToolsPage {
 	legacyPageId?: string;
 	title: string;
 }
+
+export interface WidgetErrorInspectData {
+	errorDescription: string;
+	devToolsUrl: string;
+	inspectorReference: string;
+}


### PR DESCRIPTION
- [x] Rebase over #3086
- [x] Replace link in console output with a not saying to look for the notification
- [x] Ensure we only display one notification at a time
- [x] See if we can improve the regex to be less reliant on the exact text