### PR TITLE
Pass --run-skipped when running a test from the test tree/code-lens

### DIFF
--- a/src/extension/commands/test.ts
+++ b/src/extension/commands/test.ts
@@ -39,13 +39,13 @@ abstract class TestCommands implements vs.Disposable {
 		this.disposables.push(vs.commands.registerCommand("_dart.startDebuggingTestFromOutline", (test: TestOutlineInfo, launchTemplate: any | undefined) =>
 			vs.debug.startDebugging(
 				vs.workspace.getWorkspaceFolder(vs.Uri.file(test.file)),
-				getLaunchConfig(false, test.file, [test.fullName], test.isGroup, launchTemplate),
+				getLaunchConfig(false, test.file, [test.fullName], test.isGroup, !test.isGroup, launchTemplate),
 			)
 		));
 		this.disposables.push(vs.commands.registerCommand("_dart.startWithoutDebuggingTestFromOutline", (test: TestOutlineInfo, launchTemplate: any | undefined) =>
 			vs.debug.startDebugging(
 				vs.workspace.getWorkspaceFolder(vs.Uri.file(test.file)),
-				getLaunchConfig(true, test.file, [test.fullName], test.isGroup, launchTemplate),
+				getLaunchConfig(true, test.file, [test.fullName], test.isGroup, !test.isGroup, launchTemplate),
 			)
 		));
 	}

--- a/src/extension/views/test_view.ts
+++ b/src/extension/views/test_view.ts
@@ -29,8 +29,8 @@ export class TestResultsProvider implements vs.Disposable, vs.TreeDataProvider<T
 		this.disposables.push(vs.debug.onDidTerminateDebugSession((session) => this.handleDebugSessionEnd(session)));
 		this.disposables.push(vs.commands.registerCommand("_dart.toggleSkippedTestVisibilityOff", () => config.setShowSkippedTests(false)));
 		this.disposables.push(vs.commands.registerCommand("_dart.toggleSkippedTestVisibilityOn", () => config.setShowSkippedTests(true)));
-		this.disposables.push(vs.commands.registerCommand("dart.startDebuggingTest", (treeNode: SuiteNode | GroupNode | TestNode) => this.runTests(treeNode, this.getTestNames(treeNode), true, false)));
-		this.disposables.push(vs.commands.registerCommand("dart.startWithoutDebuggingTest", (treeNode: SuiteNode | GroupNode | TestNode) => this.runTests(treeNode, this.getTestNames(treeNode), false, false)));
+		this.disposables.push(vs.commands.registerCommand("dart.startDebuggingTest", (treeNode: SuiteNode | GroupNode | TestNode) => this.runTests(treeNode, this.getTestNames(treeNode), true, false, treeNode instanceof TestNode)));
+		this.disposables.push(vs.commands.registerCommand("dart.startWithoutDebuggingTest", (treeNode: SuiteNode | GroupNode | TestNode) => this.runTests(treeNode, this.getTestNames(treeNode), false, false, treeNode instanceof TestNode)));
 		this.disposables.push(vs.commands.registerCommand("dart.startDebuggingSkippedTests", (treeNode: SuiteNode | GroupNode | TestNode) => this.runTests(treeNode, this.getTestNames(treeNode, TestStatus.Skipped), true, false, true)));
 		this.disposables.push(vs.commands.registerCommand("dart.startWithoutDebuggingSkippedTests", (treeNode: SuiteNode | GroupNode | TestNode) => this.runTests(treeNode, this.getTestNames(treeNode, TestStatus.Skipped), false, false, true)));
 		this.disposables.push(vs.commands.registerCommand("dart.startDebuggingFailedTests", (treeNode: SuiteNode | GroupNode | TestNode) => this.runTests(treeNode, this.getTestNames(treeNode, TestStatus.Failed), true, false)));


### PR DESCRIPTION
Fixes incorrect parameters being passed to `getLaunchConfig`.
Fixes #3097.