### PR TITLE
Fix typo in Coordindator naming

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -10,7 +10,7 @@ import { DartWorkspaceContext, FlutterSdks, FlutterWorkspaceContext, IAmDisposab
 import { captureLogs, EmittingLogger, logToConsole, RingLog } from "../shared/logging";
 import { PubApi } from "../shared/pub/api";
 import { internalApiSymbol } from "../shared/symbols";
-import { TestSessionCoordindator } from "../shared/test/coordindator";
+import { TestSessionCoordinator } from "../shared/test/coordinator";
 import { TestTreeModel, TreeNode } from "../shared/test/test_model";
 import { disposeAll, uniq } from "../shared/utils";
 import { fsPath, isWithinPath } from "../shared/utils/fs";
@@ -428,7 +428,7 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 	util.logTime("All other stuff before debugger..");
 
 	const testTreeModel = new TestTreeModel(config);
-	const testCoordinator = new TestSessionCoordindator(logger, testTreeModel);
+	const testCoordinator = new TestSessionCoordinator(logger, testTreeModel);
 	const analyzerCommands = new AnalyzerCommands(context, logger, analyzer, analytics);
 
 	// Set up debug stuff.

--- a/src/extension/views/test_view.ts
+++ b/src/extension/views/test_view.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import * as vs from "vscode";
 import { DART_TEST_CONTAINER_NODE_WITH_FAILURES_CONTEXT, DART_TEST_CONTAINER_NODE_WITH_SKIPS_CONTEXT, DART_TEST_GROUP_NODE_CONTEXT, DART_TEST_SUITE_NODE_CONTEXT, DART_TEST_TEST_NODE_CONTEXT } from "../../shared/constants";
 import { TestStatus } from "../../shared/enums";
-import { TestSessionCoordindator } from "../../shared/test/coordindator";
+import { TestSessionCoordinator } from "../../shared/test/coordinator";
 import { GroupNode, SuiteNode, TestContainerNode, TestNode, TestTreeModel, TreeNode } from "../../shared/test/test_model";
 import { ErrorNotification, PrintNotification } from "../../shared/test_protocol";
 import { disposeAll } from "../../shared/utils";
@@ -21,7 +21,7 @@ export class TestResultsProvider implements vs.Disposable, vs.TreeDataProvider<T
 	public readonly onDidChangeTreeData: vs.Event<TreeNode | undefined> = this.onDidChangeTreeDataEmitter.event;
 	private currentTestTerminal: [vs.Terminal, vs.EventEmitter<string>] | undefined;
 
-	constructor(private readonly data: TestTreeModel, private readonly coordindator: TestSessionCoordindator) {
+	constructor(private readonly data: TestTreeModel, private readonly coordinator: TestSessionCoordinator) {
 		this.disposables.push(data.onDidChangeTreeData.listen((node) => this.onDidChangeTreeDataEmitter.fire(node)));
 		this.disposables.push(vs.workspace.onDidChangeConfiguration((e) => this.handleConfigChange(e)));
 
@@ -76,11 +76,11 @@ export class TestResultsProvider implements vs.Disposable, vs.TreeDataProvider<T
 	}
 
 	public handleDebugSessionCustomEvent(e: { session: vs.DebugSession; event: string; body?: any; }) {
-		this.coordindator.handleDebugSessionCustomEvent(e);
+		this.coordinator.handleDebugSessionCustomEvent(e);
 	}
 
 	public handleDebugSessionEnd(session: vs.DebugSession) {
-		this.coordindator.handleDebugSessionEnd(session.id);
+		this.coordinator.handleDebugSessionEnd(session.id);
 	}
 
 	private async runAllSkippedTests(): Promise<void> {

--- a/src/shared/test/coordinator.ts
+++ b/src/shared/test/coordinator.ts
@@ -6,7 +6,7 @@ import { disposeAll, uriToFilePath } from "../utils";
 import { GroupNode, SuiteData, SuiteNode, TestNode, TestTreeModel, TreeNode } from "./test_model";
 
 /// Handles results from a test debug session and provides them to the test model.
-export class TestSessionCoordindator implements IAmDisposable {
+export class TestSessionCoordinator implements IAmDisposable {
 	private disposables: IAmDisposable[] = [];
 
 	private onDidStartTestsEmitter: EventEmitter<TreeNode> = new EventEmitter<TreeNode>();

--- a/src/shared/vscode/interfaces.ts
+++ b/src/shared/vscode/interfaces.ts
@@ -8,7 +8,7 @@ import { VersionStatus, VmService, VmServiceExtension } from "../enums";
 import { WebClient } from "../fetch";
 import { CustomScript, SpawnedProcess } from "../interfaces";
 import { EmittingLogger } from "../logging";
-import { TestSessionCoordindator } from "../test/coordindator";
+import { TestSessionCoordinator } from "../test/coordinator";
 import { TestTreeModel, TreeNode } from "../test/test_model";
 import { WorkspaceContext } from "../workspace";
 import { Context } from "./workspace";
@@ -70,7 +70,7 @@ export interface InternalExtensionApi {
 	renameProvider: RenameProvider | undefined;
 	safeToolSpawn: (workingDirectory: string | undefined, binPath: string, args: string[], envOverrides?: { [key: string]: string | undefined }) => SpawnedProcess;
 	testTreeProvider: TreeDataProvider<TreeNode>;
-	testCoordinator: TestSessionCoordindator;
+	testCoordinator: TestSessionCoordinator;
 	testTreeModel: TestTreeModel;
 	webClient: WebClient;
 	workspaceContext: WorkspaceContext;

--- a/src/test/dart_debug_client.ts
+++ b/src/test/dart_debug_client.ts
@@ -3,7 +3,7 @@ import * as assert from "assert";
 import { Writable } from "stream";
 import { DebugSession, DebugSessionCustomEvent, window } from "vscode";
 import { DebugProtocol } from "vscode-debugprotocol";
-import { TestSessionCoordindator } from "../shared/test/coordindator";
+import { TestSessionCoordinator } from "../shared/test/coordinator";
 import { Notification, Test, TestDoneNotification, TestStartNotification } from "../shared/test_protocol";
 import { waitFor } from "../shared/utils/promises";
 import { DebugCommandHandler } from "../shared/vscode/interfaces";
@@ -19,7 +19,7 @@ export class DartDebugClient extends DebugClient {
 	private currentSession?: DebugSession;
 	public hasStarted = false;
 
-	constructor(args: DebugClientArgs, private debugCommands: DebugCommandHandler, testCoordinator: TestSessionCoordindator | undefined) {
+	constructor(args: DebugClientArgs, private debugCommands: DebugCommandHandler, testCoordinator: TestSessionCoordinator | undefined) {
 		super(args.runtime, args.executable, args.args, "dart", undefined, true);
 		this.port = args.port;
 


### PR DESCRIPTION
Fixes all instances of `coordindator` appearing rather than `coordinator`.