### PR TITLE
Add the ability to "Run all Skipped Tests" for Dart projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,6 +180,15 @@
 				}
 			},
 			{
+				"command": "dart.runAllSkippedTestsWithoutDebugging",
+				"title": "Run All Skipped Tests",
+				"category": "Dart",
+				"icon": {
+					"dark": "./media/commands/test-run-skipped-dark.svg",
+					"light": "./media/commands/test-run-skipped-light.svg"
+				}
+			},
+			{
 				"command": "dart.runAllFailedTestsWithoutDebugging",
 				"title": "Run All Failed Tests",
 				"category": "Dart",
@@ -262,6 +271,16 @@
 			{
 				"command": "dart.startWithoutDebuggingTest",
 				"title": "Run Without Debugging",
+				"category": "Dart"
+			},
+			{
+				"command": "dart.startDebuggingSkippedTests",
+				"title": "Debug Skipped",
+				"category": "Dart"
+			},
+			{
+				"command": "dart.startWithoutDebuggingSkippedTests",
+				"title": "Run Skipped",
 				"category": "Dart"
 			},
 			{
@@ -674,6 +693,10 @@
 					"when": "dart-code:dartProjectLoaded"
 				},
 				{
+					"command": "dart.runAllSkippedTestsWithoutDebugging",
+					"when": "dart-code:dartProjectLoaded"
+				},
+				{
 					"command": "dart.runAllFailedTestsWithoutDebugging",
 					"when": "dart-code:dartProjectLoaded"
 				},
@@ -727,6 +750,14 @@
 				},
 				{
 					"command": "dart.startWithoutDebuggingTest",
+					"when": "false"
+				},
+				{
+					"command": "dart.startDebuggingSkippedTests",
+					"when": "false"
+				},
+				{
+					"command": "dart.startWithoutDebuggingSkippedTests",
 					"when": "false"
 				},
 				{
@@ -1168,6 +1199,11 @@
 				},
 				{
 					"when": "view == dartTestTree",
+					"command": "dart.runAllSkippedTestsWithoutDebugging",
+					"group": "navigation@3"
+				},
+				{
+					"when": "view == dartTestTree",
 					"command": "dart.clearTestResults",
 					"group": "navigation@4"
 				},
@@ -1230,6 +1266,16 @@
 					"group": "4.5_exec@4"
 				},
 				{
+					"when": "dart-code:dartProjectLoaded && viewItem =~ /dart-code:testContainerNodeWithSkips/ && viewItem =~ /dart-code:isInDartTestSuite/",
+					"command": "dart.startDebuggingSkippedTests",
+					"group": "4.5_exec@5"
+				},
+				{
+					"when": "dart-code:dartProjectLoaded && viewItem =~ /dart-code:testContainerNodeWithSkips/ && viewItem =~ /dart-code:isInDartTestSuite/",
+					"command": "dart.startWithoutDebuggingSkippedTests",
+					"group": "4.5_exec@6"
+				},
+				{
 					"when": "dart-code:dartProjectLoaded && viewItem =~ /dart-code:testGroupNode/",
 					"command": "dart.startDebuggingTest",
 					"group": "4.5_exec@1"
@@ -1240,12 +1286,12 @@
 					"group": "4.5_exec@2"
 				},
 				{
-					"when": "dart-code:dartProjectLoaded && viewItem == dart-code:testTestNode",
+					"when": "dart-code:dartProjectLoaded && viewItem =~ /dart-code:testTestNode/",
 					"command": "dart.startDebuggingTest",
 					"group": "4.5_exec@1"
 				},
 				{
-					"when": "dart-code:dartProjectLoaded && viewItem == dart-code:testTestNode",
+					"when": "dart-code:dartProjectLoaded && viewItem =~ /dart-code:testTestNode/",
 					"command": "dart.startWithoutDebuggingTest",
 					"group": "4.5_exec@2"
 				}

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -427,7 +427,7 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 
 	util.logTime("All other stuff before debugger..");
 
-	const testTreeModel = new TestTreeModel(config);
+	const testTreeModel = new TestTreeModel(config, util.isPathInsideFlutterProject);
 	const testCoordinator = new TestSessionCoordinator(logger, testTreeModel);
 	const analyzerCommands = new AnalyzerCommands(context, logger, analyzer, analytics);
 

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -27,6 +27,14 @@ export function isInsideFlutterProject(uri?: Uri): boolean {
 		return isFlutterWorkspaceFolder(workspace.getWorkspaceFolder(uri));
 }
 
+export function isPathInsideFlutterProject(path: string): boolean {
+	const projectRoot = locateBestProjectRoot(path);
+	if (!projectRoot)
+		return false;
+
+	return isFlutterProjectFolder(projectRoot);
+}
+
 export function isFlutterProjectFolder(folder?: string): boolean {
 	return referencesFlutterSdk(folder);
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -42,6 +42,8 @@ export const DART_TEST_CONTAINER_NODE_WITH_SKIPS_CONTEXT = "dart-code:testContai
 export const DART_TEST_CONTAINER_NODE_WITH_FAILURES_CONTEXT = "dart-code:testContainerNodeWithFailures";
 export const DART_TEST_GROUP_NODE_CONTEXT = "dart-code:testGroupNode";
 export const DART_TEST_TEST_NODE_CONTEXT = "dart-code:testTestNode";
+export const IS_IN_FLUTTER_TEST_SUITE_CONTEXT = "dart-code:isInFlutterTestSuite";
+export const IS_IN_DART_TEST_SUITE_CONTEXT = "dart-code:isInDartTestSuite";
 
 export const DART_DEP_PROJECT_NODE_CONTEXT = "dart-code:depProjectNode";
 export const DART_DEP_PACKAGE_NODE_CONTEXT = "dart-code:depPackageNode";

--- a/src/shared/test/test_model.ts
+++ b/src/shared/test/test_model.ts
@@ -209,7 +209,7 @@ export class TestTreeModel {
 	// TODO: Make private?
 	public readonly suites: { [key: string]: SuiteData } = {};
 
-	public constructor(private readonly config: { showSkippedTests: boolean }) { }
+	public constructor(private readonly config: { showSkippedTests: boolean }, private readonly isPathInsideFlutterProject: (path: string) => boolean) { }
 
 	public flagSuiteStart(suitePath: string, isRunningWholeSuite: boolean): void {
 		this.isNewTestRun = true;
@@ -245,7 +245,7 @@ export class TestTreeModel {
 	public getOrCreateSuite(suitePath: string): [SuiteData, boolean] {
 		let suite = this.suites[suitePath];
 		if (!suite) {
-			suite = new SuiteData(suitePath);
+			suite = new SuiteData(suitePath, this.isPathInsideFlutterProject(suitePath));
 			this.suites[suitePath] = suite;
 			return [suite, true];
 		}
@@ -315,12 +315,10 @@ export class TestTreeModel {
 
 export class SuiteData {
 	public get currentRunNumber() { return this.node.suiteRunNumber; }
-	public readonly path: string;
 	public readonly node: SuiteNode;
 	private readonly groups: { [key: string]: GroupNode } = {};
 	private readonly tests: { [key: string]: TestNode } = {};
-	constructor(suitePath: string) {
-		this.path = suitePath;
+	constructor(public readonly path: string, public readonly isFlutterSuite: boolean) {
 		this.node = new SuiteNode(this);
 	}
 

--- a/src/shared/utils/test.ts
+++ b/src/shared/utils/test.ts
@@ -2,12 +2,15 @@ import * as path from "path";
 import { escapeRegExp } from "../../shared/utils";
 import { OpenedFileInformation } from "../interfaces";
 
-export function getLaunchConfig(noDebug: boolean, path: string, testNames: string[] | undefined, isGroup: boolean, template?: any | undefined) {
+export function getLaunchConfig(noDebug: boolean, path: string, testNames: string[] | undefined, isGroup: boolean, runSkippedTests?: boolean, template?: any | undefined) {
 	const templateArgs = template?.args || [];
 	const testNameArgs = testNames
 		? ["--name", makeRegexForTests(testNames, isGroup)]
 		: [];
 	const args = templateArgs.concat(testNameArgs);
+
+	if (runSkippedTests)
+		args.push("--run-skipped");
 
 	return Object.assign(
 		{

--- a/src/test/dart_debug/debug/dart_test.test.ts
+++ b/src/test/dart_debug/debug/dart_test.test.ts
@@ -359,6 +359,40 @@ ${helloWorldTestSkipFile} (Skipped / Skipped)
 		}
 	}).timeout(160000); // This test runs lots of tests, and they're quite slow to start up currently.
 
+	it("can rerun only skipped tests", async () => {
+		await openFile(helloWorldTestTreeFile);
+		const config = await startDebugger(helloWorldTestTreeFile);
+		config!.noDebug = true;
+		await waitAllThrowIfTerminates(dc,
+			dc.configurationSequence(),
+			dc.waitForEvent("terminated"),
+			dc.launch(config),
+		);
+
+		// Now run only skipped tests.
+		await vs.commands.executeCommand("dart.runAllSkippedTestsWithoutDebugging");
+
+		await openFile(helloWorldTestTreeFile);
+		// Expected results differ from what's in the file as the skipped tests will be run
+		// and also the parent groups/suite status will be recomputed so they will be not-stale
+		// in the new results (so we can't just filter to skipped, like we do in the failed test).
+		const expectedResults = `
+test/tree_test.dart [8/11 passed, {duration}ms] (fail.svg)
+    failing group 1 [3/4 passed, {duration}ms] (fail.svg)
+        skipped test 1 [{duration}ms] (pass.svg)
+    skipped group 2 [4/6 passed, {duration}ms] (fail.svg)
+        skipped group 2.1 [2/3 passed, {duration}ms] (fail.svg)
+            passing test 1 [{duration}ms] (pass.svg)
+            failing test 1 [{duration}ms] (fail.svg)
+            skipped test 1 [{duration}ms] (pass.svg)
+        skipped test 1 [{duration}ms] (pass.svg)
+		`.trim();
+
+		// Get the actual tree, filtered only to those that ran in the last run.
+		const actualResults = (await makeTextTree(helloWorldTestTreeFile, extApi.testTreeProvider, { onlyActive: true })).join("\n");
+		assert.strictEqual(actualResults, expectedResults);
+	});
+
 	it("can rerun only failed tests", async () => {
 		const testFiles = [helloWorldTestTreeFile, helloWorldTestBrokenFile];
 		for (const file of testFiles) {


### PR DESCRIPTION
Applies to Dart-only projects as Flutter doesn't support --run-skipped.

Fixes #3097, #3107, #3048.