### PR TITLE
Add support for the LSP SnippetTextEdits unofficial extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -2093,6 +2093,12 @@
 					"markdownDescription": "Whether to run the analyzer in [LSP mode](https://microsoft.github.io/language-server-protocol/) (requires restart).",
 					"scope": "window"
 				},
+				"dart.lspSnippetTextEdits": {
+					"type": "boolean",
+					"default": true,
+					"markdownDescription": "Whether to enable [Snippet support in LSP TextEdits](https://github.com/rust-analyzer/rust-analyzer/blob/979e788957ced1957ee9ac1da70fb97abf9fe2b1/docs/dev/lsp-extensions.md#snippet-textedit).",
+					"scope": "window"
+				},
 				"dart.autoImportCompletions": {
 					"type": "boolean",
 					"default": true,

--- a/src/extension/analysis/analyzer_lsp.ts
+++ b/src/extension/analysis/analyzer_lsp.ts
@@ -89,9 +89,10 @@ export class LspAnalyzer extends Analyzer {
 			},
 
 			async provideCodeActions(document: TextDocument, range: Range, context: CodeActionContext, token: CancellationToken, next: ProvideCodeActionsSignature) {
+				const documentVersion = document.version;
 				const res = await next(document, range, context, token);
 
-				snippetTextEdits.rewriteSnippetTextEditsToCommands(res);
+				snippetTextEdits.rewriteSnippetTextEditsToCommands(documentVersion, res);
 
 				return res;
 			},

--- a/src/extension/analysis/analyzer_lsp_snippet_text_edits.ts
+++ b/src/extension/analysis/analyzer_lsp_snippet_text_edits.ts
@@ -61,8 +61,16 @@ export class SnippetTextEditFeature implements IAmDisposable {
 	private async applySnippetTextEdit(uri: vs.Uri, edit: vs.TextEdit) {
 		const doc = await vs.workspace.openTextDocument(uri);
 		const editor = await vs.window.showTextDocument(doc);
-		const snippet = new vs.SnippetString(edit.newText);
+		const leadingIndentCharacters = doc.lineAt(edit.range.start.line).firstNonWhitespaceCharacterIndex;
+		const newText = this.compensateForVsCodeIndenting(edit.newText, leadingIndentCharacters);
+		const snippet = new vs.SnippetString(newText);
 		await editor.insertSnippet(snippet, edit.range);
+	}
+
+	private compensateForVsCodeIndenting(newText: string, leadingIndentCharacters: number) {
+		const indent = " ".repeat(leadingIndentCharacters);
+		const indentPattern = new RegExp(`\n${indent}`, "g");
+		return newText.replace(indentPattern, "\n");
 	}
 
 	public dispose(): any {

--- a/src/extension/analysis/analyzer_lsp_snippet_text_edits.ts
+++ b/src/extension/analysis/analyzer_lsp_snippet_text_edits.ts
@@ -1,0 +1,71 @@
+import * as vs from "vscode";
+import { ClientCapabilities, StaticFeature } from "vscode-languageclient";
+import { DartCapabilities } from "../../shared/capabilities/dart";
+import { IAmDisposable } from "../../shared/interfaces";
+import { disposeAll } from "../../shared/utils";
+import { config } from "../config";
+
+export class SnippetTextEditFeature implements IAmDisposable {
+	private disposables: IAmDisposable[] = [];
+
+	constructor(private readonly dartCapabilities: DartCapabilities) {
+		this.disposables.push(vs.commands.registerCommand("_dart.applySnippetTextEdit", this.applySnippetTextEdit, this));
+	}
+
+	public get feature(): StaticFeature {
+		const supportsSnippetTextEdits = this.dartCapabilities.supportsSnippetTextEdits;
+		const snippetTextEditsEnabled = config.lspSnippetTextEdits;
+
+		return {
+			dispose() { },
+			fillClientCapabilities(capabilities: ClientCapabilities) {
+				capabilities.experimental = capabilities.experimental ?? {};
+				if (supportsSnippetTextEdits && snippetTextEditsEnabled) {
+					(capabilities.experimental as any).snippetTextEdit = true;
+				}
+			},
+			initialize() { },
+		};
+	}
+
+	public rewriteSnippetTextEditsToCommands(res: Array<vs.Command | vs.CodeAction> | null | undefined) {
+		if (!res)
+			return;
+
+		for (const action of res) {
+			if ("edit" in action) {
+				const edit = action.edit;
+				if (edit) {
+					const entries = edit.entries();
+					if (entries.length === 1 && entries[0][1].length === 1) {
+						const uri = entries[0][0];
+						const textEdit = entries[0][1][0];
+						// HACK: This should be checking InsertTextFormat:
+						// https://github.com/microsoft/language-server-protocol/issues/724#issuecomment-800334721
+						const hasSnippet = /\$(0|\{0:([^}]*)\})/.test(textEdit.newText);
+						// if ((textEdit as any).insertTextFormat === InsertTextFormat.Snippet) {
+						if (hasSnippet) {
+							action.edit = undefined;
+							action.command = {
+								arguments: [uri, textEdit],
+								command: "_dart.applySnippetTextEdit",
+								title: "Apply edit",
+							};
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private async applySnippetTextEdit(uri: vs.Uri, edit: vs.TextEdit) {
+		const doc = await vs.workspace.openTextDocument(uri);
+		const editor = await vs.window.showTextDocument(doc);
+		const snippet = new vs.SnippetString(edit.newText);
+		await editor.insertSnippet(snippet, edit.range);
+	}
+
+	public dispose(): any {
+		disposeAll(this.disposables);
+	}
+}

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -97,6 +97,7 @@ class Config {
 	get flutterTestLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("flutterTestLogFile", null))); }
 	get flutterWebRenderer(): "auto" | "html" | "canvaskit" { return this.getConfig<"auto" | "html" | "canvaskit">("flutterWebRenderer", "auto"); }
 	get hotReloadProgress(): "notification" | "statusBar" { return this.getConfig<"notification" | "statusBar">("hotReloadProgress", "notification"); }
+	get lspSnippetTextEdits(): boolean { return this.getConfig<boolean>("lspSnippetTextEdits", true); }
 	get maxLogLineLength(): number { return this.getConfig<number>("maxLogLineLength", 2000); }
 	get notifyAnalyzerErrors(): boolean { return this.getConfig<boolean>("notifyAnalyzerErrors", true); }
 	get openDevTools(): "never" | "flutter" | "always" { return this.getConfig<"never" | "flutter" | "always">("openDevTools", "never"); }

--- a/src/shared/capabilities/dart.ts
+++ b/src/shared/capabilities/dart.ts
@@ -14,8 +14,7 @@ export class DartCapabilities {
 	// https://github.com/dart-lang/sdk/issues/43207
 	get includesSourceForSdkLibs() { return versionIsAtLeast(this.version, "2.2.1") && !this.version.startsWith("2.10."); }
 	get hasLspInsertTextModeSupport() { return versionIsAtLeast(this.version, "2.13.0-0"); }
-	// TODO: !
-	get supportsSnippetTextEdits() { return false; }
+	get supportsSnippetTextEdits() { return versionIsAtLeast(this.version, "2.13.0-150"); }
 	get supportsWriteServiceInfo() { return versionIsAtLeast(this.version, "2.7.1"); }
 	get supportsDebugInternalLibraries() { return versionIsAtLeast(this.version, "2.9.0-a"); }
 	get supportsDisableDartDev() { return versionIsAtLeast(this.version, "2.12.0-0"); }

--- a/src/shared/capabilities/dart.ts
+++ b/src/shared/capabilities/dart.ts
@@ -14,6 +14,8 @@ export class DartCapabilities {
 	// https://github.com/dart-lang/sdk/issues/43207
 	get includesSourceForSdkLibs() { return versionIsAtLeast(this.version, "2.2.1") && !this.version.startsWith("2.10."); }
 	get hasLspInsertTextModeSupport() { return versionIsAtLeast(this.version, "2.13.0-0"); }
+	// TODO: !
+	get supportsSnippetTextEdits() { return false; }
 	get supportsWriteServiceInfo() { return versionIsAtLeast(this.version, "2.7.1"); }
 	get supportsDebugInternalLibraries() { return versionIsAtLeast(this.version, "2.9.0-a"); }
 	get supportsDisableDartDev() { return versionIsAtLeast(this.version, "2.12.0-0"); }

--- a/src/test/flutter/providers/assist_code_action_provider.test.ts
+++ b/src/test/flutter/providers/assist_code_action_provider.test.ts
@@ -1,0 +1,53 @@
+import * as assert from "assert";
+import * as vs from "vscode";
+import { activate, currentDoc, ensureTestContentWithSelection, extApi, flutterEmptyFile, getPackages, openFile, rangeOf, setTestContent } from "../../helpers";
+
+describe("assist_code_action_provider", () => {
+	// We have tests that require external packages.
+	before("get packages", () => getPackages());
+	beforeEach("activate", () => activate());
+
+	it("inserts correct indenting for create_method", async function () {
+		// Doesn't work for non-LSP due to https://github.com/microsoft/vscode/issues/63129.
+		if (!extApi.isLsp)
+			this.skip();
+
+		if (!extApi.dartCapabilities.supportsSnippetTextEdits)
+			this.skip();
+
+		await openFile(flutterEmptyFile);
+		await setTestContent(`
+import 'package:flutter/widgets.dart';
+
+class Danny extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: Text('Hello!'),
+    );
+  }
+}`);
+		const actionResults = await (vs.commands.executeCommand("vscode.executeCodeActionProvider", currentDoc().uri, rangeOf("Co||ntainer(")) as Thenable<vs.CodeAction[]>);
+		assert.ok(actionResults);
+		assert.ok(actionResults.length);
+
+		const wrapAction = actionResults.find((r) => r.title.indexOf("Wrap with widget") !== -1);
+		assert.ok(wrapAction, "Action was not found");
+
+		await vs.commands.executeCommand(wrapAction.command!.command, ...(wrapAction.command!.arguments ?? []));
+
+		await ensureTestContentWithSelection(`
+import 'package:flutter/widgets.dart';
+
+class Danny extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return |widget|(
+      child: Container(
+        child: Text('Hello!'),
+      ),
+    );
+  }
+}`);
+	});
+});


### PR DESCRIPTION
Progress towards #3143.

- [x] Land in analyzer https://github.com/dart-lang/sdk/commit/44275c6001837550d4a6b7339237ae1c27bdbc19
- [x] Tests
- [x] Version number in capabilities
- [x] Check doc version number to ensure not trying to apply snippets if document was modified