### PR TITLE
Reduce the amount of Snap-specific code requires to set up Flutter

### DIFF
--- a/src/extension/sdk/flutter.ts
+++ b/src/extension/sdk/flutter.ts
@@ -1,5 +1,5 @@
 import { ProgressLocation, window } from "vscode";
-import { initializingFlutterMessage, noAction, showLogAction, yesAction } from "../../shared/constants";
+import { initializingFlutterMessage, showLogAction } from "../../shared/constants";
 import { LogCategory } from "../../shared/enums";
 import { Logger } from "../../shared/interfaces";
 import { logProcess } from "../../shared/logging";
@@ -8,52 +8,47 @@ import { ringLog } from "../extension";
 import { openLogContents } from "../utils";
 import { safeToolSpawn } from "../utils/processes";
 
-export async function initializeFlutterSdk(logger: Logger, flutterScript: string, promptText?: string): Promise<void> {
-	const selectedItem = promptText ? await window.showInformationMessage(promptText, yesAction, noAction) : yesAction;
-	if (selectedItem === yesAction) {
-		logger.info(`Flutter is not initialized, running 'flutter config --machine'...`);
-		try {
-			await window.withProgress(
-				{
-					location: ProgressLocation.Notification,
-					title: initializingFlutterMessage,
-				},
-				async (progress, cancellationToken) => {
-					const proc = safeToolSpawn(undefined, flutterScript, ["doctor", "-v"]);
+export async function initializeFlutterSdk(logger: Logger, flutterScript: string): Promise<void> {
+	logger.info(`Flutter is not initialized, running 'flutter doctor' to force...`);
+	try {
+		await window.withProgress(
+			{
+				location: ProgressLocation.Notification,
+				title: initializingFlutterMessage,
+			},
+			async (progress, cancellationToken) => {
+				const proc = safeToolSpawn(undefined, flutterScript, ["doctor", "-v"]);
 
-					// Show the output in an output channel so if it gets stuck the user can see it.
-					const channel = channels.getOutputChannel(`flutter doctor`, true);
-					channel.show();
-					channels.runProcessInOutputChannel(proc, channel);
+				// Show the output in an output channel so if it gets stuck the user can see it.
+				const channel = channels.getOutputChannel(`flutter doctor`);
+				channel.show();
+				channels.runProcessInOutputChannel(proc, channel);
 
-					cancellationToken.onCancellationRequested((e) => {
-						logger.info(`User canceled!`);
-						proc.kill();
-					});
-					// Log this to general as it's startup stuff that can't be captured with
-					// Capture Logs so log it to the main log file.
-					logProcess(logger, LogCategory.General, proc);
-					return new Promise<void>((resolve, reject) => proc.on("exit", (code) => {
-						if (code) {
-							const ringLogContents = ringLog.toString();
-							logger.error(`Failed to initialize Flutter: Process exited with code ${code}.`);
-							window.showErrorMessage(`Failed to initialize Flutter: Process exited with code ${code}.`, showLogAction).then((chosenAction) => {
-								if (chosenAction === showLogAction)
-									openLogContents(undefined, ringLogContents);
-							});
-							reject();
-						} else {
-							channel.hide();
-							resolve();
-						}
-					}));
-				},
-			);
-			logger.info(`Flutter initialized!`);
-		} catch (e) {
-			logger.warn(`Flutter initialization failed, proceeding without!`);
-		}
-	} else {
-		logger.info(`User cancelled Flutter initialization`);
+				cancellationToken.onCancellationRequested((e) => {
+					logger.info(`User canceled!`);
+					proc.kill();
+				});
+				// Log this to general as it's startup stuff that can't be captured with
+				// Capture Logs so log it to the main log file.
+				logProcess(logger, LogCategory.General, proc);
+				return new Promise<void>((resolve, reject) => proc.on("exit", (code) => {
+					if (code) {
+						const ringLogContents = ringLog.toString();
+						logger.error(`Failed to initialize Flutter: Process exited with code ${code}.`);
+						window.showErrorMessage(`Failed to initialize Flutter: Process exited with code ${code}.`, showLogAction).then((chosenAction) => {
+							if (chosenAction === showLogAction)
+								openLogContents(undefined, ringLogContents);
+						});
+						reject();
+					} else {
+						channel.hide();
+						resolve();
+					}
+				}));
+			},
+		);
+		logger.info(`Flutter initialized!`);
+	} catch (e) {
+		logger.warn(`Flutter initialization failed, proceeding without!`);
 	}
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -30,7 +30,6 @@ export const pubPath = "bin/" + executableNames.pub;
 export const flutterPath = "bin/" + executableNames.flutter;
 export const pubSnapshotPath = "bin/snapshots/pub.dart.snapshot";
 export const analyzerSnapshotPath = "bin/snapshots/analysis_server.dart.snapshot";
-export const flutterSnapScript = "/snap/flutter/current/flutter.sh";
 export const androidStudioPaths = androidStudioExecutableNames.map((s) => "bin/" + s);
 export const DART_DOWNLOAD_URL = "https://dart.dev/get-dart";
 export const FLUTTER_DOWNLOAD_URL = "https://flutter.dev/setup/";
@@ -81,9 +80,10 @@ export const takeSurveyAction = "Take Survey";
 export const skipThisSurveyAction = "Skip This Survey";
 
 export const modifyingFilesOutsideWorkspaceInfoUrl = "https://dartcode.org/docs/modifying-files-outside-workspace/";
-
-export const initializeSnapPrompt = "The Flutter snap is installed but not initialized. Would you like to initialize it now?";
 export const initializingFlutterMessage = "Initializing Flutter. This may take a few minutes.";
+
+export const snapBinaryPath = "/usr/bin/snap";
+export const snapFlutterBinaryPath = "/snap/bin/flutter";
 
 // Minutes.
 export const fiveMinutesInMs = 1000 * 60 * 5;

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -6,6 +6,11 @@ import * as f from "./flutter/daemon_interfaces";
 import { UnknownResponse } from "./services/interfaces";
 import { WorkspaceContext } from "./workspace";
 
+export interface SdkSearchResults {
+	sdkPath: string | undefined;
+	candidatePaths: string[];
+}
+
 export interface Sdks {
 	readonly dart?: string;
 	readonly dartVersion?: string;

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import { flutterSnapScript, isWin } from "../constants";
+import { isWin } from "../constants";
 import { CustomScript, Logger, WritableWorkspaceConfig } from "../interfaces";
 
 export function processKnownGitRepositories(logger: Logger, config: WritableWorkspaceConfig, gitRoot: string) {
@@ -10,11 +10,6 @@ export function processKnownGitRepositories(logger: Logger, config: WritableWork
 		// The Dart SDKs tests cannot run using pub, so also force them to use the VM.
 		config.useVmForTests = true;
 	}
-}
-
-export function processFlutterSnap(logger: Logger, config: WritableWorkspaceConfig, snapSdkRoot: string) {
-	config.flutterSdkHome = snapSdkRoot;
-	config.flutterScript = { replacesArgs: 0, script: flutterSnapScript };
 }
 
 export function processFuchsiaWorkspace(logger: Logger, config: WritableWorkspaceConfig, fuchsiaRoot: string) {

--- a/src/test/flutter_snap/extension.test.ts
+++ b/src/test/flutter_snap/extension.test.ts
@@ -2,9 +2,9 @@ import * as assert from "assert";
 import * as os from "os";
 import * as path from "path";
 import * as vs from "vscode";
-import { initializeSnapPrompt, isLinux, yesAction } from "../../shared/constants";
+import { isLinux } from "../../shared/constants";
 import { fsPath } from "../../shared/utils/fs";
-import { activate, extApi, logger, sb } from "../helpers";
+import { activate, extApi, logger } from "../helpers";
 import sinon = require("sinon");
 
 describe("test environment", () => {
@@ -25,23 +25,18 @@ describe("extension", () => {
 	});
 
 	it("initializes the snap and locates the SDK", async () => {
-		// Automatically approve the initialization.
-		const showInformationMessage = sb.stub(vs.window, "showInformationMessage");
-		const initializeSnapMessagePrompt = showInformationMessage.withArgs(initializeSnapPrompt, sinon.match.any, sinon.match.any).resolves(yesAction);
-
 		await activate();
-
-		assert.ok(initializeSnapMessagePrompt.calledOnce);
 
 		const workspaceContext = extApi.workspaceContext;
 
 		assert.ok(workspaceContext.sdks);
 		assert.ok(workspaceContext.sdks.dart);
 		assert.equal(workspaceContext.sdks.flutter, `${path.join(os.homedir(), "/snap/flutter/common/flutter")}`);
+		assert.equal(workspaceContext.sdks.dart, `${path.join(os.homedir(), "/snap/flutter/common/flutter/bin/cache/dart-sdk")}`);
 		assert.ok(workspaceContext.config);
 		assert.equal(workspaceContext.config?.dartSdkHomeLinux, undefined);
 		assert.equal(workspaceContext.config?.dartSdkHomeMac, undefined);
-		assert.deepStrictEqual(workspaceContext.config?.flutterScript, { script: "/snap/flutter/current/flutter.sh", replacesArgs: 0 });
+		assert.equal(workspaceContext.config?.flutterScript, undefined);
 		logger.info("        " + JSON.stringify(workspaceContext, undefined, 8).trim().slice(1, -1).trim());
 	});
 });


### PR DESCRIPTION
Fixes #2853.

@MarcusTomlinson FYI - this is to remove a lot of the snap-specific code that should no longer be required (https://github.com/canonical/flutter-snap/issues/8).

There is still a _little_ code to detect where a user has never invoked `flutter` so it hasn't been initialised, which is in the block here:

https://github.com/Dart-Code/Dart-Code/pull/3292/files?diff=split&w=1#diff-a4ef2b6ac3b51b2727e1fdae4a827f588e33df8c71bbad63fde3b96a92b5bfd1R265

It detects when no Flutter SDK is found, but there is a `flutter` binary that is a symlink to the Snap binary (it seems like this is created by Snap initially, so that the first run of `flutter` will trigger the initialisation), forces initialisation, and then re-searches for the SDK (since after initialisation, there is a _new_ `flutter` binary on `PATH` that is a real SDK - the original Snap-symlink seems to remain, further down the `PATH`).

Unless you have any objections, I'll merge this early next week. The tests that confirm it's located and initialised are still green when they ran on this branch.