### PR TITLE
add syntax Highlighting as "modifier"

### DIFF
--- a/syntaxes/dart.json
+++ b/syntaxes/dart.json
@@ -305,7 +305,7 @@
 					"name": "keyword.operator.logical.dart"
 				},
 				{
-					"match": "(?<!\\$)\\b(static|final|const|required|late)\\b(?!\\$)",
+					"match": "(?<!\\$)\\b(static|final|const|required|late|bool|String|int|void|var)\\b(?!\\$)",
 					"name": "storage.modifier.dart"
 				},
 				{


### PR DESCRIPTION
This Pull Request is in response to issue #3308 

Add Syntax Highlighting as Modifier for the following data types/keywords
- bool
- String
- int
- void
- var