### PR TITLE
Support launching emulator devices in remote workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -985,7 +985,7 @@
 				},
 				{
 					"command": "flutter.launchEmulator",
-					"when": "dart-code:anyFlutterProjectLoaded && dart-code:isRunningLocally"
+					"when": "dart-code:anyFlutterProjectLoaded && dart-code:isRunningLocally || dart-code:anyFlutterProjectLoaded && config.dart.flutterShowEmulators == always"
 				},
 				{
 					"when": "false",


### PR DESCRIPTION
Hey @DanTup.

I just saw your fix for #3315. Thanks for that!

I also noticed the "Launch Emulator" command wasn't available in remote workspace. I guess this is because of the `when` clause in `"package.json"`: https://github.com/Dart-Code/Dart-Code/blob/f38e02c2e3384975d4d051484836a7984e31d64d/package.json#L987-L988

I supposed this simple additional condition using the new configuration parameter would allow to run the command in a devcontainer.

Thoughts?