### PR TITLE
Match latest flutter.json

### DIFF
--- a/src/extension/pub/global.ts
+++ b/src/extension/pub/global.ts
@@ -83,13 +83,13 @@ export class PubGlobal {
 		return undefined;
 	}
 
-	public async backgroundActivate(packageName: string, packageID: string, silent: boolean, customActivateScript: CustomScript | undefined): Promise<void> {
+	public async backgroundActivate(packageName: string, packageID: string, silent: boolean): Promise<void> {
 		const actionName = `Activating ${packageName}`;
 		const args = ["global", "activate", packageID];
 		if (silent)
-			await this.runCommand(packageName, args, customActivateScript);
+			await this.runCommand(packageName, args);
 		else
-			await this.runCommandWithProgress(packageName, `${actionName}...`, args, customActivateScript);
+			await this.runCommandWithProgress(packageName, `${actionName}...`, args);
 	}
 
 	public async uninstall(packageID: string): Promise<void> {

--- a/src/extension/sdk/dev_tools/manager.ts
+++ b/src/extension/sdk/dev_tools/manager.ts
@@ -53,17 +53,6 @@ export class DevToolsManager implements vs.Disposable {
 	}
 
 	private async handleEagerActivationAndStartup(workspaceContext: DartWorkspaceContext) {
-		if (workspaceContext.config?.activateDevToolsEagerly) {
-			try {
-				await this.preActivate(true);
-				this.logger.info(`Finished background activating DevTools`);
-			} catch (e) {
-				this.logger.error("Failed to background activate DevTools");
-				this.logger.error(e);
-				vs.window.showErrorMessage(`Failed to activate DevTools: ${e}`);
-			}
-		}
-
 		if (workspaceContext.config?.startDevToolsServerEagerly) {
 			try {
 				if (workspaceContext.config?.startDevToolsServerEagerly)

--- a/src/extension/sdk/utils.ts
+++ b/src/extension/sdk/utils.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { commands, ExtensionContext, window } from "vscode";
-import { analyzerSnapshotPath, dartPlatformName, dartVMPath, DART_DOWNLOAD_URL, executableNames, flutterPath, FLUTTER_CREATE_PROJECT_TRIGGER_FILE, FLUTTER_DOWNLOAD_URL, isLinux, isMac, isWin, showLogAction, snapBinaryPath, snapFlutterBinaryPath } from "../../shared/constants";
+import { analyzerSnapshotPath, dartPlatformName, dartVMPath, DART_DOWNLOAD_URL, executableNames, flutterPath, FLUTTER_CREATE_PROJECT_TRIGGER_FILE, FLUTTER_DOWNLOAD_URL, isLinux, isWin, showLogAction, snapBinaryPath, snapFlutterBinaryPath } from "../../shared/constants";
 import { Logger, Sdks, SdkSearchResults, WorkspaceConfig } from "../../shared/interfaces";
 import { nullLogger } from "../../shared/logging";
 import { PackageMap } from "../../shared/pub/package_map";
@@ -288,7 +288,6 @@ export class SdkUtils {
 		}
 
 		const dartSdkSearchPaths = [
-			isMac ? workspaceConfig?.dartSdkHomeMac : workspaceConfig?.dartSdkHomeLinux,
 			// TODO: These could move into processFuchsiaWorkspace and be set on the config?
 			fuchsiaRoot && path.join(fuchsiaRoot, "topaz/tools/prebuilt-dart-sdk", `${dartPlatformName}-x64`),
 			fuchsiaRoot && path.join(fuchsiaRoot, "third_party/dart/tools/sdks/dart-sdk"),

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -43,10 +43,6 @@ export interface WritableWorkspaceConfig {
 
 	activateDevToolsEagerly?: boolean;
 	startDevToolsServerEagerly?: boolean;
-	dartSdkHomeLinux?: string;
-	dartSdkHomeMac?: string;
-	devtoolsActivateScript?: CustomScript;
-	devtoolsRunScript?: CustomScript;
 	disableAutomaticPackageGet?: boolean;
 	disableSdkUpdateChecks?: boolean;
 	flutterDaemonScript?: CustomScript;

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -41,7 +41,6 @@ export interface WritableWorkspaceConfig {
 	// should be what is expected from a standard workspace without any additional
 	// config.
 
-	activateDevToolsEagerly?: boolean;
 	startDevToolsServerEagerly?: boolean;
 	disableAutomaticPackageGet?: boolean;
 	disableSdkUpdateChecks?: boolean;

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -54,8 +54,6 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 			}
 		}
 
-		// TODO(helin24): Check where this is used
-		config.activateDevToolsEagerly = false;
 		config.flutterDaemonScript = makeScript(flutterConfig.daemonScript);
 		config.flutterDoctorScript = makeScript(flutterConfig.doctorScript);
 		config.flutterRunScript = makeScript(flutterConfig.runScript);

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -54,13 +54,8 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 			}
 		}
 
-		config.activateDevToolsEagerly = !!flutterConfig.devtoolsActivateScript;
-		config.dartSdkHomeLinux = makeFullPath(flutterConfig.dartSdkHome?.linux);
-		config.dartSdkHomeMac = makeFullPath(flutterConfig.dartSdkHome?.macos);
-		// This one replaces the args "global activate devtools"
-		config.devtoolsActivateScript = makeScript(flutterConfig.devtoolsActivateScript, 3);
-		// This one replaces the args "global run devtools"
-		config.devtoolsRunScript = makeScript(flutterConfig.devtoolsRunScript, 3);
+		// TODO(helin24): Check where this is used
+		config.activateDevToolsEagerly = false;
 		config.flutterDaemonScript = makeScript(flutterConfig.daemonScript);
 		config.flutterDoctorScript = makeScript(flutterConfig.doctorScript);
 		config.flutterRunScript = makeScript(flutterConfig.runScript);

--- a/src/test/flutter_bazel/extension.test.ts
+++ b/src/test/flutter_bazel/extension.test.ts
@@ -38,10 +38,6 @@ describe("extension", () => {
 		assert.ok(workspaceContext.sdks.flutter);
 		assert.ok(workspaceContext.config);
 		assert.equal(workspaceContext.config?.activateDevToolsEagerly, true);
-		assert.equal(workspaceContext.config?.dartSdkHomeLinux, path.join(fsPath(flutterBazelRoot), "my-linux-dart-sdk"));
-		assert.equal(workspaceContext.config?.dartSdkHomeMac, path.join(fsPath(flutterBazelRoot), "my-mac-dart-sdk"));
-		assert.deepStrictEqual(workspaceContext.config?.devtoolsActivateScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_devtools_activate.sh"), replacesArgs: 3 });
-		assert.deepStrictEqual(workspaceContext.config?.devtoolsRunScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_devtools_run.sh"), replacesArgs: 3 });
 		assert.equal(workspaceContext.config?.disableAutomaticPackageGet, true);
 		assert.equal(workspaceContext.config?.disableSdkUpdateChecks, true);
 		assert.deepStrictEqual(workspaceContext.config?.flutterDaemonScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_daemon.sh"), replacesArgs: 1 });

--- a/src/test/flutter_bazel/extension.test.ts
+++ b/src/test/flutter_bazel/extension.test.ts
@@ -37,7 +37,6 @@ describe("extension", () => {
 		assert.ok(workspaceContext.sdks.dart);
 		assert.ok(workspaceContext.sdks.flutter);
 		assert.ok(workspaceContext.config);
-		assert.equal(workspaceContext.config?.activateDevToolsEagerly, true);
 		assert.equal(workspaceContext.config?.disableAutomaticPackageGet, true);
 		assert.equal(workspaceContext.config?.disableSdkUpdateChecks, true);
 		assert.deepStrictEqual(workspaceContext.config?.flutterDaemonScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_daemon.sh"), replacesArgs: 1 });

--- a/src/test/flutter_snap/extension.test.ts
+++ b/src/test/flutter_snap/extension.test.ts
@@ -34,8 +34,6 @@ describe("extension", () => {
 		assert.equal(workspaceContext.sdks.flutter, `${path.join(os.homedir(), "/snap/flutter/common/flutter")}`);
 		assert.equal(workspaceContext.sdks.dart, `${path.join(os.homedir(), "/snap/flutter/common/flutter/bin/cache/dart-sdk")}`);
 		assert.ok(workspaceContext.config);
-		assert.equal(workspaceContext.config?.dartSdkHomeLinux, undefined);
-		assert.equal(workspaceContext.config?.dartSdkHomeMac, undefined);
 		assert.equal(workspaceContext.config?.flutterScript, undefined);
 		logger.info("        " + JSON.stringify(workspaceContext, undefined, 8).trim().slice(1, -1).trim());
 	});

--- a/src/test/test_projects/bazel_workspace/flutter_hello_world_bazel/dart/config/intellij-plugins/flutter.json
+++ b/src/test/test_projects/bazel_workspace/flutter_hello_world_bazel/dart/config/intellij-plugins/flutter.json
@@ -1,14 +1,12 @@
 {
-	"dartSdkHome": {
-		"linux": "../my-linux-dart-sdk",
-		"macos": "../my-mac-dart-sdk"
-	},
-	"sdkHome": "../my-flutter-sdk",
-	"versionFile": "../my-flutter-version",
 	"daemonScript": "../scripts/custom_daemon.sh",
 	"doctorScript": "../scripts/custom_doctor.sh",
-	"runScript": "../scripts/custom_run.sh",
 	"testScript": "../scripts/custom_test.sh",
-	"devtoolsActivateScript": "../scripts/custom_devtools_activate.sh",
-	"devtoolsRunScript": "../scripts/custom_devtools_run.sh"
+	"runScript": "../scripts/custom_run.sh",
+	"syncScript": "../scripts/custom_sync.sh",
+	"sdkHome": "../my-flutter-sdk",
+	"versionFile": "../my-flutter-version",
+	"requiredIJPluginID": "ij-plugin-id",
+	"requiredIJPluginMessage": "IJ plugin message",
+	"configWarningPrefix": "Configuration warning prefix"
 }

--- a/src/test/test_projects/bazel_workspace/scripts/custom_devtools_activate.sh
+++ b/src/test/test_projects/bazel_workspace/scripts/custom_devtools_activate.sh
@@ -1,2 +1,0 @@
-mkdir -p `dirname "$0"`/has_run && touch `dirname "$0"`/has_run/devtools_activate
-pub global activate devtools "$@"

--- a/src/test/test_projects/bazel_workspace/scripts/custom_devtools_run.sh
+++ b/src/test/test_projects/bazel_workspace/scripts/custom_devtools_run.sh
@@ -1,2 +1,0 @@
-mkdir -p `dirname "$0"`/has_run && touch `dirname "$0"`/has_run/devtools_run
-pub global run devtools "$@"


### PR DESCRIPTION
This is to clean up VSCode's view of flutter.json, which has changed significantly since this was last updated. This simplifies DevTools startup since we no longer have a separate script to start DevTools; this may change in the future to either using the daemon (see comments for more details) or another method.