### PR TITLE
Use --no-serve-devtools and re-enable dev tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,8 +24,8 @@ jobs:
             flutter-version: stable
             code-version: stable
           - build-version: dev
-            dart-version: stable
-            flutter-version: stable
+            dart-version: dev
+            flutter-version: dev
             code-version: insiders
           - os: ubuntu-latest
             bot: flutter_snap

--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -401,6 +401,8 @@ export class DartDebugSession extends DebugSession {
 			this.expectAdditionalPidToTerminate = true;
 			appArgs.push(`--enable-vm-service=${args.vmServicePort}`);
 			appArgs.push("--pause_isolates_on_start=true");
+			if (this.dartCapabilities.supportsNoServeDevTools)
+				appArgs.push("--no-serve-devtools");
 		}
 		if (this.useWriteServiceInfo && this.vmServiceInfoFile) {
 			appArgs.push(`--write-service-info=${formatPathForVm(this.vmServiceInfoFile)}`);

--- a/src/debug/dart_test_debug_impl.ts
+++ b/src/debug/dart_test_debug_impl.ts
@@ -55,7 +55,10 @@ export class DartTestDebugSession extends DartDebugSession {
 		const dartPath = path.join(args.dartSdkPath, dartVMPath);
 		if (this.dartCapabilities.supportsDartRunTest) {
 			// Use "dart --vm-args run test:test"
-			appArgs = appArgs.concat(["run", "test:test"]);
+			appArgs.push("run");
+			if (this.dartCapabilities.supportsNoServeDevTools)
+				appArgs.push("--no-serve-devtools");
+			appArgs.push("test:test");
 		} else {
 			// Use "dart --vm-args [pub-snapshot] run test"
 			appArgs.push(path.join(args.dartSdkPath, pubSnapshotPath));

--- a/src/shared/capabilities/dart.ts
+++ b/src/shared/capabilities/dart.ts
@@ -20,6 +20,7 @@ export class DartCapabilities {
 	get supportsDebugInternalLibraries() { return versionIsAtLeast(this.version, "2.9.0-a"); }
 	get supportsDisableDartDev() { return versionIsAtLeast(this.version, "2.12.0-0"); }
 	get hasDdsTimingFix() { return versionIsAtLeast(this.version, "2.13.0-117"); }
+	get supportsNoServeDevTools() { return versionIsAtLeast(this.version, "2.14.0-172.0"); }
 	get supportsPubUpgradeMajorVersions() { return versionIsAtLeast(this.version, "2.12.0"); }
 	get supportsPubOutdated() { return versionIsAtLeast(this.version, "2.8.0-a"); }
 	get supportsPubDepsJson() { return versionIsAtLeast(this.version, "2.14.0-0"); }

--- a/src/test/dart/providers/dart_signature_help_provider.test.ts
+++ b/src/test/dart/providers/dart_signature_help_provider.test.ts
@@ -32,9 +32,9 @@ main() {
 		assert.equal(sigs.activeSignature, 0);
 		assert.equal(sigs.signatures.length, 1);
 		const sig = sigs.signatures[0];
-		assert.equal(sig.label, "print(Object object)");
+		assert.equal(sig.label, sig.label.includes("?") ? "print(Object? object)" : "print(Object object)");
 		assert.equal(sig.parameters.length, 1);
-		assert.equal(sig.parameters[0].label, "Object object");
+		assert.equal(sig.parameters[0].label, (sig.parameters[0].label as string).includes("?") ? "Object? object" : "Object object");
 		assert.equal(sig.parameters[0].documentation, undefined);
 		assert.equal((sig.documentation as vs.MarkdownString).value, "Prints a string representation of the object to the console.");
 	});

--- a/src/test/flutter_debug/debug/flutter_run.test.ts
+++ b/src/test/flutter_debug/debug/flutter_run.test.ts
@@ -1369,7 +1369,6 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		const timingRegex = new RegExp("\[[ \d]+\] ", "g");
 		stdErrLines = stdErrLines.map((line) => line.replace(timingRegex, ""));
 
-		// Handle old/new error messages for stable/dev.
 		const expectedErrorLines = [
 			`stderr: ════════ Exception caught by widgets library ═══════════════════════════════════`,
 			`stdout: The following _Exception was thrown building MyBrokenHomePage(dirty):`,
@@ -1383,11 +1382,15 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 			`stdout: ${faint("#2      StatelessElement.build")}`,
 			`stdout: ${faint("#3      ComponentElement.performRebuild")}`,
 			`stdout: ${faint("#4      Element.rebuild")}`,
-			`stdout: ...`,
-			`stderr: ════════════════════════════════════════════════════════════════════════════════`,
+			// Don't check any more past this, since they can change with Flutter framework changes.
 		];
 
-		assert.deepStrictEqual(stdErrLines.map((s) => s.toLowerCase()), expectedErrorLines.map((s) => s.toLowerCase()));
+		assert.deepStrictEqual(
+			// Only check top expectedErrorLines.length to avoid all the frames that are
+			// likely to change with Flutter changes.
+			stdErrLines.slice(0, expectedErrorLines.length).map((s) => s.toLowerCase()),
+			expectedErrorLines.map((s) => s.toLowerCase()),
+		);
 	});
 
 	it("does not print original error if using structured errors", async function () {


### PR DESCRIPTION
With these changes the bots should start passing once the `--no-serve-devtools` change reaches a published Dart SDK dev build.

Edit: Also requires some solution to https://github.com/dart-lang/sdk/issues/46274 and that rolled into dev.