### PR TITLE
Enable device daemon for bazel workspace (WIP)

### DIFF
--- a/src/extension/sdk/utils.ts
+++ b/src/extension/sdk/utils.ts
@@ -243,43 +243,49 @@ export class SdkUtils {
 				this.logger.info(`Found Fuchsia project that is not vanilla Flutter`);
 		}
 
-		const flutterSdkSearchPaths = [
-			workspaceConfig?.flutterSdkHome,
-			config.flutterSdkPath,
-			// TODO: These could move into processFuchsiaWorkspace and be set on the config?
-			fuchsiaRoot && path.join(fuchsiaRoot, "lib/flutter"),
-			fuchsiaRoot && path.join(fuchsiaRoot, "third_party/dart-pkg/git/flutter"),
-			firstFlutterMobileProject,
-			firstFlutterMobileProject && extractFlutterSdkPathFromPackagesFile(firstFlutterMobileProject),
-			firstFlutterMobileProject && path.join(firstFlutterMobileProject, ".flutter"),
-			firstFlutterMobileProject && path.join(firstFlutterMobileProject, "vendor/flutter"),
-			process.env.FLUTTER_ROOT,
-			isLinux ? "~/snap/flutter/common/flutter" : undefined,
-			"~/flutter-sdk",
-			"~/.flutter-sdk",
-		].concat(paths).filter(notUndefined);
+		let flutterSdkPath;
+		if (workspaceConfig.flutterBazel) {
+			hasAnyFlutterProject = true;
+			hasAnyFlutterMobileProject = true;
+			flutterSdkPath = workspaceConfig?.flutterSdkHome;
+		} else {
+			const flutterSdkSearchPaths = [
+				config.flutterSdkPath,
+				// TODO: These could move into processFuchsiaWorkspace and be set on the config?
+				fuchsiaRoot && path.join(fuchsiaRoot, "lib/flutter"),
+				fuchsiaRoot && path.join(fuchsiaRoot, "third_party/dart-pkg/git/flutter"),
+				firstFlutterMobileProject,
+				firstFlutterMobileProject && extractFlutterSdkPathFromPackagesFile(firstFlutterMobileProject),
+				firstFlutterMobileProject && path.join(firstFlutterMobileProject, ".flutter"),
+				firstFlutterMobileProject && path.join(firstFlutterMobileProject, "vendor/flutter"),
+				process.env.FLUTTER_ROOT,
+				isLinux ? "~/snap/flutter/common/flutter" : undefined,
+				"~/flutter-sdk",
+				"~/.flutter-sdk",
+			].concat(paths).filter(notUndefined);
 
-		let flutterSdkResult = this.findFlutterSdk(flutterSdkSearchPaths);
+			let flutterSdkResult = this.findFlutterSdk(flutterSdkSearchPaths);
 
-		// Handle the case where the Flutter snap has not been initialised.
-		if (!flutterSdkResult.sdkPath && flutterSdkResult.candidatePaths.includes(snapBinaryPath)) {
-			// Trigger initialization.
-			this.logger.info(`No Flutter SDK found, but a 'flutter' binary did point at ${snapBinaryPath} so attempting to initialize...`);
-			await initializeFlutterSdk(this.logger, snapFlutterBinaryPath);
+			// Handle the case where the Flutter snap has not been initialised.
+			if (!flutterSdkResult.sdkPath && flutterSdkResult.candidatePaths.includes(snapBinaryPath)) {
+				// Trigger initialization.
+				this.logger.info(`No Flutter SDK found, but a 'flutter' binary did point at ${snapBinaryPath} so attempting to initialize...`);
+				await initializeFlutterSdk(this.logger, snapFlutterBinaryPath);
 
-			// Then search again.
-			this.logger.info(`Snap initialization completed, searching for Flutter SDK again...`);
-			flutterSdkResult = this.findFlutterSdk(flutterSdkSearchPaths);
+				// Then search again.
+				this.logger.info(`Snap initialization completed, searching for Flutter SDK again...`);
+				flutterSdkResult = this.findFlutterSdk(flutterSdkSearchPaths);
+			}
+
+			flutterSdkPath = flutterSdkResult.sdkPath;
 		}
-
-		const flutterSdkPath = flutterSdkResult.sdkPath;
 
 		// Since we just blocked on a lot of sync FS, yield.
 		await resolvedPromise;
 
 		// If we're a Flutter workspace but we couldn't get the version, try running Flutter to initialise it first.
 		// Do this before searching for the Dart SDK, as it might download the Dart SDK we'd like to find.
-		if (hasAnyFlutterProject && flutterSdkPath) {
+		if (hasAnyFlutterProject && flutterSdkPath && !workspaceConfig.flutterBazel) {
 			const flutterNeedsInitializing = !getSdkVersion(this.logger, { sdkRoot: flutterSdkPath, versionFile: workspaceConfig?.flutterVersionFile })
 				|| !fs.existsSync(path.join(flutterSdkPath, "bin/cache/dart-sdk"));
 

--- a/src/extension/sdk/utils.ts
+++ b/src/extension/sdk/utils.ts
@@ -244,7 +244,7 @@ export class SdkUtils {
 		}
 
 		let flutterSdkPath;
-		if (workspaceConfig.flutterBazel) {
+		if (workspaceConfig.forceFlutterMode) {
 			hasAnyFlutterProject = true;
 			hasAnyFlutterMobileProject = true;
 			flutterSdkPath = workspaceConfig?.flutterSdkHome;
@@ -285,7 +285,7 @@ export class SdkUtils {
 
 		// If we're a Flutter workspace but we couldn't get the version, try running Flutter to initialise it first.
 		// Do this before searching for the Dart SDK, as it might download the Dart SDK we'd like to find.
-		if (hasAnyFlutterProject && flutterSdkPath && !workspaceConfig.flutterBazel) {
+		if (hasAnyFlutterProject && flutterSdkPath && !workspaceConfig.forceFlutterMode) {
 			const flutterNeedsInitializing = !getSdkVersion(this.logger, { sdkRoot: flutterSdkPath, versionFile: workspaceConfig?.flutterVersionFile })
 				|| !fs.existsSync(path.join(flutterSdkPath, "bin/cache/dart-sdk"));
 

--- a/src/extension/sdk/utils.ts
+++ b/src/extension/sdk/utils.ts
@@ -285,7 +285,7 @@ export class SdkUtils {
 
 		// If we're a Flutter workspace but we couldn't get the version, try running Flutter to initialise it first.
 		// Do this before searching for the Dart SDK, as it might download the Dart SDK we'd like to find.
-		if (hasAnyFlutterProject && flutterSdkPath && !workspaceConfig.forceFlutterMode) {
+		if (hasAnyFlutterProject && flutterSdkPath && !workspaceConfig.skipFlutterInitialization) {
 			const flutterNeedsInitializing = !getSdkVersion(this.logger, { sdkRoot: flutterSdkPath, versionFile: workspaceConfig?.flutterVersionFile })
 				|| !fs.existsSync(path.join(flutterSdkPath, "bin/cache/dart-sdk"));
 

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -54,6 +54,7 @@ export interface WritableWorkspaceConfig {
 	useLsp?: boolean;
 	useVmForTests?: boolean;
 	forceFlutterMode?: boolean;
+	skipFlutterInitialization?: boolean;
 }
 
 export type WorkspaceConfig = Readonly<WritableWorkspaceConfig>;

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -53,6 +53,7 @@ export interface WritableWorkspaceConfig {
 	flutterVersionFile?: string;
 	useLsp?: boolean;
 	useVmForTests?: boolean;
+	flutterBazel?: boolean;
 }
 
 export type WorkspaceConfig = Readonly<WritableWorkspaceConfig>;

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -53,7 +53,7 @@ export interface WritableWorkspaceConfig {
 	flutterVersionFile?: string;
 	useLsp?: boolean;
 	useVmForTests?: boolean;
-	flutterBazel?: boolean;
+	forceFlutterMode?: boolean;
 }
 
 export type WorkspaceConfig = Readonly<WritableWorkspaceConfig>;

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -54,6 +54,7 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 			}
 		}
 
+		config.flutterBazel = true;
 		config.flutterDaemonScript = makeScript(flutterConfig.daemonScript);
 		config.flutterDoctorScript = makeScript(flutterConfig.doctorScript);
 		config.flutterRunScript = makeScript(flutterConfig.runScript);

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -54,7 +54,7 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 			}
 		}
 
-		config.flutterBazel = true;
+		config.forceFlutterMode = true;
 		config.flutterDaemonScript = makeScript(flutterConfig.daemonScript);
 		config.flutterDoctorScript = makeScript(flutterConfig.doctorScript);
 		config.flutterRunScript = makeScript(flutterConfig.runScript);

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -55,6 +55,7 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 		}
 
 		config.forceFlutterMode = true;
+		config.skipFlutterInitialization = true;
 		config.flutterDaemonScript = makeScript(flutterConfig.daemonScript);
 		config.flutterDoctorScript = makeScript(flutterConfig.doctorScript);
 		config.flutterRunScript = makeScript(flutterConfig.runScript);

--- a/src/test/flutter_bazel/debug/flutter_run.test.ts
+++ b/src/test/flutter_bazel/debug/flutter_run.test.ts
@@ -3,7 +3,7 @@ import { isWin } from "../../../shared/constants";
 import { DebuggerType } from "../../../shared/enums";
 import { DartDebugClient } from "../../dart_debug_client";
 import { createDebugClient, flutterTestDeviceIsWeb, killFlutterTester, startDebugger, waitAllThrowIfTerminates } from "../../debug_helpers";
-import { activate, ensureHasRunRecently, flutterBazelHelloWorldMainFile, getPackages, prepareHasRunFile, watchPromise } from "../../helpers";
+import { activate, ensureHasRunRecently, flutterBazelHelloWorldMainFile, prepareHasRunFile, watchPromise } from "../../helpers";
 
 const deviceName = flutterTestDeviceIsWeb ? "Chrome" : "Flutter test device";
 
@@ -14,7 +14,8 @@ describe(`flutter run debugger`, () => {
 	});
 
 	// We have tests that require external packages.
-	before("get packages", () => getPackages());
+	// TODO(helin24): This requires a full flutter SDK but we need to handle this differently for bazel workspaces without an SDK.
+	// before("get packages", () => getPackages());
 	beforeEach("activate flutterHelloWorldMainFile", () => activate(flutterBazelHelloWorldMainFile));
 
 	let dc: DartDebugClient;


### PR DESCRIPTION
I think for now it'll be okay to assume that any internal workspace is a Flutter workspace, since the added functionality (showing device menu in this case) doesn't interfere with other workspaces. We may want to change this later to require an indication of Flutter in a `.code-workspace` file.

The internal "Flutter SDK" path isn't really a path with a binary to run Flutter, since we rely on scripts to execute the equivalent  flutter commands instead, but it is necessary that we are in the right working directory to execute the scripts. Versioning isn't important since we can assume all internal users will be on a close to the latest version or will update if not.

The script for running a daemon to find devices can have stdout that results in lines like: `[3:27:46 PM] [FlutterDaemon] [Error] ` in the debug console for the extension - I'm not sure where this is coming from and why the stdout from this process is recognized as errors.

I think some similar changes are required to do things like show the flutter outline and show "Flutter" in the spot to the left of the device menu, so let me know if there's a better place to put this logic where all of these activities could be handled gracefully.