### PR TITLE
Add coldboot option to AVD emulators

### DIFF
--- a/src/extension/flutter/flutter_daemon.ts
+++ b/src/extension/flutter/flutter_daemon.ts
@@ -176,8 +176,8 @@ export class FlutterDaemon extends StdIOService<UnknownNotification> implements 
 		return this.sendRequest("emulator.getEmulators");
 	}
 
-	public launchEmulator(emulatorId: string): Thenable<void> {
-		return this.sendRequest("emulator.launch", { emulatorId });
+	public launchEmulator(emulatorId: string, coldBoot: boolean): Thenable<void> {
+		return this.sendRequest("emulator.launch", { emulatorId, coldBoot });
 	}
 
 	public createEmulator(name?: string): Thenable<{ success: boolean, emulatorName: string, error: string }> {

--- a/src/shared/capabilities/flutter.ts
+++ b/src/shared/capabilities/flutter.ts
@@ -42,4 +42,5 @@ export class DaemonCapabilities {
 	get canCreateEmulators() { return versionIsAtLeast(this.version, "0.4.0"); }
 	get canFlutterAttach() { return versionIsAtLeast(this.version, "0.4.1"); }
 	get providesPlatformTypes() { return versionIsAtLeast(this.version, "0.5.2"); }
+	get supportsAvdColdBootLaunch() { return versionIsAtLeast(this.version, "0.6.1"); }
 }

--- a/src/shared/flutter/daemon_interfaces.ts
+++ b/src/shared/flutter/daemon_interfaces.ts
@@ -11,6 +11,7 @@ export interface Device {
 	platform: string;
 	platformType: PlatformType | undefined | null;
 	type: "device";
+	coldBoot?: boolean;
 }
 
 export interface FlutterEmulator {

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -103,7 +103,7 @@ export interface IFlutterDaemon extends IAmDisposable {
 
 	deviceEnable(): Thenable<UnknownResponse>;
 	getEmulators(): Thenable<f.FlutterEmulator[]>;
-	launchEmulator(emulatorId: string): Thenable<void>;
+	launchEmulator(emulatorId: string, coldBoot: boolean): Thenable<void>;
 	createEmulator(name?: string): Thenable<{ success: boolean, emulatorName: string, error: string }>;
 	getSupportedPlatforms(projectRoot: string): Thenable<f.SupportedPlatformsResponse>;
 

--- a/src/test/flutter/device_manager.test.ts
+++ b/src/test/flutter/device_manager.test.ts
@@ -77,6 +77,24 @@ describe("device_manager", () => {
 		assert.equal(em.label, "Start My custom emulator");
 	});
 
+	it("includes cold boot option for Android emulators only", async () => {
+		// Set a daemon version that does not support cold boot
+		daemon.capabilities = new DaemonCapabilities("0.6.0");
+		let emulators = await dm.getPickableEmulators(true);
+		let coldBootable = emulators.filter((e) => e.coldBoot !== undefined && e.coldBoot === true);
+		assert.strictEqual(coldBootable.length, 0);
+
+		// Set a daemon version that supports cold boot
+		daemon.capabilities = new DaemonCapabilities("0.6.1");
+		emulators = await dm.getPickableEmulators(true);
+		coldBootable = emulators.filter((e) => e.coldBoot !== undefined && e.coldBoot === true);
+		const androidEmulators = emulators.filter((e) => e.device.platformType === "android" && e.device.type === "emulator");
+		// Expect that all android emulators have a coldboot version
+		assert.strictEqual(coldBootable.length, androidEmulators.length);
+		// All cold boot entries should have the type android
+		coldBootable.forEach((e) => assert.strictEqual(e.device.platformType, "android"));
+	});
+
 	it("overrides real emulators with custom definitions", async () => {
 		const emulators = await dm.getPickableEmulators(true);
 		const em = emulators.find((e) => e.device.id === customEmulator2.id);


### PR DESCRIPTION
This pull request adds a cold boot option to each android based emulator.

The command palette looks as follows:
![launch-emulator](https://user-images.githubusercontent.com/977070/120686240-12da3080-c4a1-11eb-9d6f-5df9c9430983.png)

closes #3366 
