### PR TITLE
Set bazel project flutter SDK version to latest

### DIFF
--- a/src/extension/sdk/status_bar_version_tracker.ts
+++ b/src/extension/sdk/status_bar_version_tracker.ts
@@ -1,4 +1,5 @@
 import * as vs from "vscode";
+import { MAX_VERSION } from "../../shared/constants";
 import { disposeAll } from "../../shared/utils";
 import { WorkspaceContext } from "../../shared/workspace";
 import { config } from "../config";
@@ -20,9 +21,12 @@ export class StatusBarVersionTracker implements vs.Disposable {
 			? "Flutter"
 			: (dartIsFromFlutter ? "Dart from Flutter" : "Dart");
 
-		const versionLabel = (workspaceContext.hasAnyFlutterProjects || dartIsFromFlutter)
+		let versionLabel = (workspaceContext.hasAnyFlutterProjects || dartIsFromFlutter)
 			? workspaceContext.sdks.flutterVersion
 			: workspaceContext.sdks.dartVersion;
+
+		if (versionLabel === MAX_VERSION)
+			versionLabel = "latest";
 
 		if (versionLabel) {
 			this.addStatusBarItem(

--- a/src/extension/sdk/utils.ts
+++ b/src/extension/sdk/utils.ts
@@ -286,7 +286,8 @@ export class SdkUtils {
 		// If we're a Flutter workspace but we couldn't get the version, try running Flutter to initialise it first.
 		// Do this before searching for the Dart SDK, as it might download the Dart SDK we'd like to find.
 		if (hasAnyFlutterProject && flutterSdkPath && !workspaceConfig.skipFlutterInitialization) {
-			const flutterNeedsInitializing = !getSdkVersion(this.logger, { sdkRoot: flutterSdkPath, versionFile: workspaceConfig?.flutterVersionFile, isLatest: workspaceConfig?.isFlutterVersionLatest })
+			const flutterVersion = workspaceConfig?.flutterVersion ?? getSdkVersion(this.logger, { sdkRoot: flutterSdkPath });
+			const flutterNeedsInitializing = !flutterVersion
 				|| !fs.existsSync(path.join(flutterSdkPath, "bin/cache/dart-sdk"));
 
 			if (flutterNeedsInitializing)
@@ -324,7 +325,7 @@ export class SdkUtils {
 				dartSdkIsFromFlutter: !!dartSdkPath && isDartSdkFromFlutter(dartSdkPath),
 				dartVersion: getSdkVersion(this.logger, { sdkRoot: dartSdkPath }),
 				flutter: flutterSdkPath,
-				flutterVersion: getSdkVersion(this.logger, { sdkRoot: flutterSdkPath, versionFile: workspaceConfig?.flutterVersionFile, isLatest: workspaceConfig?.isFlutterVersionLatest }),
+				flutterVersion: workspaceConfig?.flutterVersion ?? getSdkVersion(this.logger, { sdkRoot: flutterSdkPath }),
 			} as Sdks,
 			workspaceConfig,
 			hasAnyFlutterMobileProject,

--- a/src/extension/sdk/utils.ts
+++ b/src/extension/sdk/utils.ts
@@ -286,7 +286,7 @@ export class SdkUtils {
 		// If we're a Flutter workspace but we couldn't get the version, try running Flutter to initialise it first.
 		// Do this before searching for the Dart SDK, as it might download the Dart SDK we'd like to find.
 		if (hasAnyFlutterProject && flutterSdkPath && !workspaceConfig.skipFlutterInitialization) {
-			const flutterNeedsInitializing = !getSdkVersion(this.logger, { sdkRoot: flutterSdkPath, versionFile: workspaceConfig?.flutterVersionFile })
+			const flutterNeedsInitializing = !getSdkVersion(this.logger, { sdkRoot: flutterSdkPath, versionFile: workspaceConfig?.flutterVersionFile, isLatest: workspaceConfig?.isFlutterVersionLatest })
 				|| !fs.existsSync(path.join(flutterSdkPath, "bin/cache/dart-sdk"));
 
 			if (flutterNeedsInitializing)
@@ -324,7 +324,7 @@ export class SdkUtils {
 				dartSdkIsFromFlutter: !!dartSdkPath && isDartSdkFromFlutter(dartSdkPath),
 				dartVersion: getSdkVersion(this.logger, { sdkRoot: dartSdkPath }),
 				flutter: flutterSdkPath,
-				flutterVersion: getSdkVersion(this.logger, { sdkRoot: flutterSdkPath, versionFile: workspaceConfig?.flutterVersionFile }),
+				flutterVersion: getSdkVersion(this.logger, { sdkRoot: flutterSdkPath, versionFile: workspaceConfig?.flutterVersionFile, isLatest: workspaceConfig?.isFlutterVersionLatest }),
 			} as Sdks,
 			workspaceConfig,
 			hasAnyFlutterMobileProject,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -205,4 +205,5 @@ export const defaultLaunchJson = JSON.stringify(
 	undefined, "\t"
 );
 
-export const LATEST_SDK_VERSION = "latest";
+// This indicates that a version is the latest possible.
+export const MAX_VERSION = "999.999.999";

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -204,3 +204,5 @@ export const defaultLaunchJson = JSON.stringify(
 	},
 	undefined, "\t"
 );
+
+export const LATEST_SDK_VERSION = "latest";

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -51,6 +51,7 @@ export interface WritableWorkspaceConfig {
 	flutterSdkHome?: string;
 	flutterTestScript?: CustomScript;
 	flutterVersionFile?: string;
+	isFlutterVersionLatest?: boolean;
 	useLsp?: boolean;
 	useVmForTests?: boolean;
 	forceFlutterMode?: boolean;

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -50,8 +50,7 @@ export interface WritableWorkspaceConfig {
 	flutterScript?: CustomScript;
 	flutterSdkHome?: string;
 	flutterTestScript?: CustomScript;
-	flutterVersionFile?: string;
-	isFlutterVersionLatest?: boolean;
+	flutterVersion?: string;
 	useLsp?: boolean;
 	useVmForTests?: boolean;
 	forceFlutterMode?: boolean;

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as semver from "semver";
-import { executableNames, isWin, LATEST_SDK_VERSION } from "./constants";
+import { executableNames, isWin } from "./constants";
 import { LogCategory } from "./enums";
 import { CustomScript, IAmDisposable, Logger, SomeError } from "./interfaces";
 
@@ -85,9 +85,6 @@ export function isDartSdkFromFlutter(dartSdkPath: string) {
 }
 
 export function versionIsAtLeast(inputVersion: string, requiredVersion: string): boolean {
-	if (inputVersion == LATEST_SDK_VERSION) {
-		return true;
-	}
 	return semver.gte(inputVersion, requiredVersion);
 }
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as semver from "semver";
-import { executableNames, isWin } from "./constants";
+import { executableNames, isWin, LATEST_SDK_VERSION } from "./constants";
 import { LogCategory } from "./enums";
 import { CustomScript, IAmDisposable, Logger, SomeError } from "./interfaces";
 
@@ -85,6 +85,9 @@ export function isDartSdkFromFlutter(dartSdkPath: string) {
 }
 
 export function versionIsAtLeast(inputVersion: string, requiredVersion: string): boolean {
+	if (inputVersion == LATEST_SDK_VERSION) {
+		return true;
+	}
 	return semver.gte(inputVersion, requiredVersion);
 }
 

--- a/src/shared/utils/fs.ts
+++ b/src/shared/utils/fs.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { FLUTTER_CREATE_PROJECT_TRIGGER_FILE, isWin } from "../constants";
+import { FLUTTER_CREATE_PROJECT_TRIGGER_FILE, isWin, LATEST_SDK_VERSION } from "../constants";
 import { Logger } from "../interfaces";
 import { flatMapAsync } from "../utils";
 import { sortBy } from "./array";
@@ -131,9 +131,12 @@ export async function findProjectFolders(logger: Logger, roots: string[], exclud
 		: projectFolders;
 }
 
-export function getSdkVersion(logger: Logger, { sdkRoot, versionFile }: { sdkRoot?: string, versionFile?: string }): string | undefined {
-	if (!sdkRoot && !versionFile)
+export function getSdkVersion(logger: Logger, { sdkRoot, versionFile, isLatest }: { sdkRoot?: string, versionFile?: string, isLatest?: boolean }): string | undefined {
+	if (!sdkRoot && !versionFile && !isLatest)
 		return undefined;
+	if (isLatest) {
+		return LATEST_SDK_VERSION;
+	}
 	if (!versionFile)
 		versionFile = path.join(sdkRoot!, "version");
 	if (!fs.existsSync(versionFile))

--- a/src/shared/utils/fs.ts
+++ b/src/shared/utils/fs.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { FLUTTER_CREATE_PROJECT_TRIGGER_FILE, isWin, LATEST_SDK_VERSION } from "../constants";
+import { FLUTTER_CREATE_PROJECT_TRIGGER_FILE, isWin } from "../constants";
 import { Logger } from "../interfaces";
 import { flatMapAsync } from "../utils";
 import { sortBy } from "./array";
@@ -131,14 +131,10 @@ export async function findProjectFolders(logger: Logger, roots: string[], exclud
 		: projectFolders;
 }
 
-export function getSdkVersion(logger: Logger, { sdkRoot, versionFile, isLatest }: { sdkRoot?: string, versionFile?: string, isLatest?: boolean }): string | undefined {
-	if (!sdkRoot && !versionFile && !isLatest)
+export function getSdkVersion(logger: Logger, { sdkRoot }: { sdkRoot?: string }): string | undefined {
+	if (!sdkRoot)
 		return undefined;
-	if (isLatest) {
-		return LATEST_SDK_VERSION;
-	}
-	if (!versionFile)
-		versionFile = path.join(sdkRoot!, "version");
+	const versionFile = path.join(sdkRoot, "version");
 	if (!fs.existsSync(versionFile))
 		return undefined;
 	try {

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -56,12 +56,12 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 
 		config.forceFlutterMode = true;
 		config.skipFlutterInitialization = true;
+		config.isFlutterVersionLatest = true;
 		config.flutterDaemonScript = makeScript(flutterConfig.daemonScript);
 		config.flutterDoctorScript = makeScript(flutterConfig.doctorScript);
 		config.flutterRunScript = makeScript(flutterConfig.runScript);
 		config.flutterSdkHome = makeFullPath(flutterConfig.sdkHome);
 		config.flutterTestScript = makeScript(flutterConfig.testScript);
-		config.flutterVersionFile = makeFullPath(flutterConfig.versionFile);
 	} catch (e) {
 		logger.error(e);
 	}

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import { isWin } from "../constants";
+import { isWin, MAX_VERSION } from "../constants";
 import { CustomScript, Logger, WritableWorkspaceConfig } from "../interfaces";
 
 export function processKnownGitRepositories(logger: Logger, config: WritableWorkspaceConfig, gitRoot: string) {
@@ -56,7 +56,7 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 
 		config.forceFlutterMode = true;
 		config.skipFlutterInitialization = true;
-		config.isFlutterVersionLatest = true;
+		config.flutterVersion = MAX_VERSION;
 		config.flutterDaemonScript = makeScript(flutterConfig.daemonScript);
 		config.flutterDoctorScript = makeScript(flutterConfig.doctorScript);
 		config.flutterRunScript = makeScript(flutterConfig.runScript);

--- a/src/test/flutter_bazel/extension.test.ts
+++ b/src/test/flutter_bazel/extension.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as path from "path";
 import * as vs from "vscode";
-import { isWin } from "../../shared/constants";
+import { isWin, MAX_VERSION } from "../../shared/constants";
 import { Sdks } from "../../shared/interfaces";
 import { fsPath } from "../../shared/utils/fs";
 import { activateWithoutAnalysis, ext, extApi, flutterBazelRoot, logger } from "../helpers";
@@ -38,7 +38,7 @@ describe("extension", () => {
 		assert.ok(workspaceContext.sdks.flutter);
 		assert.ok(workspaceContext.config);
 		assert.strictEqual(workspaceContext.config?.disableAutomaticPackageGet, true);
-		assert.strictEqual(workspaceContext.config?.isFlutterVersionLatest, true);
+		assert.strictEqual(workspaceContext.config?.flutterVersion, MAX_VERSION);
 		assert.strictEqual(workspaceContext.config?.forceFlutterMode, true);
 		assert.strictEqual(workspaceContext.config?.skipFlutterInitialization, true);
 		assert.deepStrictEqual(workspaceContext.config?.flutterDaemonScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_daemon.sh"), replacesArgs: 1 });

--- a/src/test/flutter_bazel/extension.test.ts
+++ b/src/test/flutter_bazel/extension.test.ts
@@ -37,14 +37,15 @@ describe("extension", () => {
 		assert.ok(workspaceContext.sdks.dart);
 		assert.ok(workspaceContext.sdks.flutter);
 		assert.ok(workspaceContext.config);
-		assert.equal(workspaceContext.config?.disableAutomaticPackageGet, true);
-		assert.equal(workspaceContext.config?.disableSdkUpdateChecks, true);
+		assert.strictEqual(workspaceContext.config?.disableAutomaticPackageGet, true);
+		assert.strictEqual(workspaceContext.config?.isFlutterVersionLatest, true);
+		assert.strictEqual(workspaceContext.config?.forceFlutterMode, true);
+		assert.strictEqual(workspaceContext.config?.skipFlutterInitialization, true);
 		assert.deepStrictEqual(workspaceContext.config?.flutterDaemonScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_daemon.sh"), replacesArgs: 1 });
 		assert.deepStrictEqual(workspaceContext.config?.flutterDoctorScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_doctor.sh"), replacesArgs: 1 });
 		assert.deepStrictEqual(workspaceContext.config?.flutterRunScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_run.sh"), replacesArgs: 1 });
-		assert.equal(workspaceContext.config?.flutterSdkHome, path.join(fsPath(flutterBazelRoot), "my-flutter-sdk"));
+		assert.strictEqual(workspaceContext.config?.flutterSdkHome, path.join(fsPath(flutterBazelRoot), "my-flutter-sdk"));
 		assert.deepStrictEqual(workspaceContext.config?.flutterTestScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_test.sh"), replacesArgs: 1 });
-		assert.equal(workspaceContext.config?.flutterVersionFile, path.join(fsPath(flutterBazelRoot), "my-flutter-version"));
 		logger.info("        " + JSON.stringify(workspaceContext, undefined, 8).trim().slice(1, -1).trim());
 	});
 	// This test requires another clone of the SDK to verify the path (symlinks

--- a/src/test/test_projects/bazel_workspace/flutter_hello_world_bazel/dart/config/intellij-plugins/flutter.json
+++ b/src/test/test_projects/bazel_workspace/flutter_hello_world_bazel/dart/config/intellij-plugins/flutter.json
@@ -5,7 +5,6 @@
 	"runScript": "../scripts/custom_run.sh",
 	"syncScript": "../scripts/custom_sync.sh",
 	"sdkHome": "../my-flutter-sdk",
-	"versionFile": "../my-flutter-version",
 	"requiredIJPluginID": "ij-plugin-id",
 	"requiredIJPluginMessage": "IJ plugin message",
 	"configWarningPrefix": "Configuration warning prefix"


### PR DESCRIPTION
The version file isn't needed for bazel projects, so just setting it to latest. I may be able to remove the `flutterVersionFile` completely. 