### PR TITLE
Switch arg order for rudimentary bazel run

### DIFF
--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -184,10 +184,6 @@ export class FlutterDebugSession extends DartDebugSession {
 
 	protected spawnRunDaemon(isAttach: boolean, args: FlutterLaunchRequestArguments, logger: Logger): RunDaemonBase {
 		let appArgs = [];
-		if (!isAttach || args.program) {
-			appArgs.push("--target");
-			appArgs.push(this.sourceFileForArgs(args));
-		}
 
 		if (args.deviceId) {
 			appArgs.push("-d");
@@ -256,6 +252,13 @@ export class FlutterDebugSession extends DartDebugSession {
 
 		if (args.forceFlutterVerboseMode === true && appArgs.indexOf("-v") === -1 && appArgs.indexOf("--verbose") === -1) {
 			appArgs.push("-v");
+		}
+
+		if (!isAttach || args.program) {
+			if (!args.workspaceConfig?.skipTargetFlag) {
+				appArgs.push("--target");
+			}
+			appArgs.push(this.sourceFileForArgs(args));
 		}
 
 		return new FlutterRun(isAttach ? RunMode.Attach : RunMode.Run, args.flutterSdkPath, args.workspaceConfig, args.globalFlutterArgs || [], args.cwd, appArgs, { envOverrides: args.env, toolEnv: this.toolEnv }, args.flutterRunLogFile, logger, (url) => this.exposeUrl(url), this.maxLogLineLength);

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -150,7 +150,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			&& !isInsideFolderNamed(debugConfig.program, "tool")
 			&& !isInsideFolderNamed(debugConfig.program, ".dart_tool")) {
 			// Check if we're a Flutter or Web project.
-			if (isFlutterProjectFolder(debugConfig.cwd)) {
+			if (isFlutterProjectFolder(debugConfig.cwd) || this.wsContext.config.forceFlutterMode) {
 				debugType = DebuggerType.Flutter;
 			} else if (isInsideFolderNamed(debugConfig.program, "web") && !isInsideFolderNamed(debugConfig.program, "test"))
 				debugType = DebuggerType.Web;

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -150,7 +150,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			&& !isInsideFolderNamed(debugConfig.program, "tool")
 			&& !isInsideFolderNamed(debugConfig.program, ".dart_tool")) {
 			// Check if we're a Flutter or Web project.
-			if (isFlutterProjectFolder(debugConfig.cwd) || this.wsContext.config.forceFlutterMode) {
+			if (isFlutterProjectFolder(debugConfig.cwd) || this.wsContext.config.forceFlutterDebug) {
 				debugType = DebuggerType.Flutter;
 			} else if (isInsideFolderNamed(debugConfig.program, "web") && !isInsideFolderNamed(debugConfig.program, "test"))
 				debugType = DebuggerType.Web;

--- a/src/extension/sdk/utils.ts
+++ b/src/extension/sdk/utils.ts
@@ -244,7 +244,7 @@ export class SdkUtils {
 		}
 
 		let flutterSdkPath;
-		if (workspaceConfig.forceFlutterMode) {
+		if (workspaceConfig.forceFlutterWorkspace) {
 			hasAnyFlutterProject = true;
 			hasAnyFlutterMobileProject = true;
 			flutterSdkPath = workspaceConfig?.flutterSdkHome;

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -53,7 +53,8 @@ export interface WritableWorkspaceConfig {
 	flutterVersion?: string;
 	useLsp?: boolean;
 	useVmForTests?: boolean;
-	forceFlutterMode?: boolean;
+	forceFlutterWorkspace?: boolean;
+	forceFlutterDebug?: boolean;
 	skipFlutterInitialization?: boolean;
 	skipTargetFlag?: boolean;
 }

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -55,6 +55,7 @@ export interface WritableWorkspaceConfig {
 	useVmForTests?: boolean;
 	forceFlutterMode?: boolean;
 	skipFlutterInitialization?: boolean;
+	skipTargetFlag?: boolean;
 }
 
 export type WorkspaceConfig = Readonly<WritableWorkspaceConfig>;

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -56,6 +56,7 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 
 		config.forceFlutterMode = true;
 		config.skipFlutterInitialization = true;
+		config.skipTargetFlag = true;
 		config.flutterVersion = MAX_VERSION;
 		config.flutterDaemonScript = makeScript(flutterConfig.daemonScript);
 		config.flutterDoctorScript = makeScript(flutterConfig.doctorScript);

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -54,7 +54,8 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 			}
 		}
 
-		config.forceFlutterMode = true;
+		config.forceFlutterWorkspace = true;
+		config.forceFlutterDebug = true;
 		config.skipFlutterInitialization = true;
 		config.skipTargetFlag = true;
 		config.flutterVersion = MAX_VERSION;

--- a/src/test/flutter_bazel/extension.test.ts
+++ b/src/test/flutter_bazel/extension.test.ts
@@ -39,7 +39,8 @@ describe("extension", () => {
 		assert.ok(workspaceContext.config);
 		assert.strictEqual(workspaceContext.config?.disableAutomaticPackageGet, true);
 		assert.strictEqual(workspaceContext.config?.flutterVersion, MAX_VERSION);
-		assert.strictEqual(workspaceContext.config?.forceFlutterMode, true);
+		assert.strictEqual(workspaceContext.config?.forceFlutterWorkspace, true);
+		assert.strictEqual(workspaceContext.config?.forceFlutterDebug, true);
 		assert.strictEqual(workspaceContext.config?.skipFlutterInitialization, true);
 		assert.deepStrictEqual(workspaceContext.config?.flutterDaemonScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_daemon.sh"), replacesArgs: 1 });
 		assert.deepStrictEqual(workspaceContext.config?.flutterDoctorScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_doctor.sh"), replacesArgs: 1 });


### PR DESCRIPTION
I needed only minor changes for a basic bazel run app configuration to work, but there are probably other situations where bazel will differ from a standard app due to things like:
- Excluding some arguments
- Arguments having a different flag name
- I think the change in ordering I made for where the target is passed is okay for standard apps too, but if not, argument order may need to be adjustable

Maybe some of these differences could be codified in the workspace, e.g. have an 'arguments' JSON that looks like:
```
{"arguments": [
  {"device": {}},
  {"mode": {"replaceFlagName": "otherMode"}},
  {"target": {"excludeFlagName": "true"}
] }
```

Alternatively, I could add an internal script that translates from standard arguments to the arguments we need. That would be more flexible but seems like it might be tough to make sure we're alerted to changes.

I'm missing something for getting debugging breakpoints to work; may need to hook up something additional for that.