### PR TITLE
Move lot of argument building from Debug Adapter into extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -2416,7 +2416,7 @@
 							},
 							"args": {
 								"type": "array",
-								"description": "Arguments to be passed to your Dart script or the Flutter tool.",
+								"description": "Arguments to be passed to your Dart/Flutter script on the command line. These arguments go after the script filename.",
 								"items": {
 									"type": "string"
 								}
@@ -2424,10 +2424,10 @@
 							"env": {
 								"description": "Environment variables passed to the Dart / Flutter process."
 							},
-							"vmAdditionalArgs": {
+							"toolArgs": {
 								"type": "array",
 								"default": [],
-								"description": "Additional args to pass to the Dart VM when running / debugging command line apps.",
+								"description": "Arguments to be passed to the Dart VM/Flutter tools on the command line. These arguments go before the script filename.",
 								"items": {
 									"type": "string"
 								}

--- a/src/debug/dart_test_debug_impl.ts
+++ b/src/debug/dart_test_debug_impl.ts
@@ -48,10 +48,6 @@ export class DartTestDebugSession extends DartDebugSession {
 			appArgs.push("--pause_isolates_on_start=true");
 		}
 
-		if (args.toolArgs) {
-			appArgs = appArgs.concat(args.toolArgs);
-		}
-
 		const dartPath = path.join(args.dartSdkPath, dartVMPath);
 		if (this.dartCapabilities.supportsDartRunTest) {
 			// Use "dart --vm-args run test:test"

--- a/src/debug/flutter_run.ts
+++ b/src/debug/flutter_run.ts
@@ -7,7 +7,7 @@ import { usingCustomScript } from "../shared/utils";
 import { RunDaemonBase, RunMode } from "./run_daemon_base";
 
 export class FlutterRun extends RunDaemonBase {
-	constructor(mode: RunMode, flutterSdkPath: string, wsConfig: WorkspaceConfig | undefined, globalFlutterArgs: string[], projectFolder: string | undefined, args: string[], env: { envOverrides?: { [key: string]: string | undefined }, toolEnv: any }, logFile: string | undefined, logger: Logger, urlExposer: (url: string) => Promise<{ url: string }>, maxLogLineLength: number) {
+	constructor(mode: RunMode, flutterSdkPath: string, wsConfig: WorkspaceConfig | undefined, projectFolder: string | undefined, args: string[], env: { envOverrides?: { [key: string]: string | undefined }, toolEnv: any }, logFile: string | undefined, logger: Logger, urlExposer: (url: string) => Promise<{ url: string }>, maxLogLineLength: number) {
 		super(mode, logFile, new CategoryLogger(logger, LogCategory.FlutterRun), urlExposer, maxLogLineLength, true, true);
 
 		const command = mode === RunMode.Attach ? "attach" : "run";
@@ -18,6 +18,6 @@ export class FlutterRun extends RunDaemonBase {
 			mode === RunMode.Run ? wsConfig?.flutterRunScript || wsConfig?.flutterScript : undefined ,
 		);
 
-		this.createProcess(projectFolder, binPath, globalFlutterArgs.concat(binArgs).concat(args), env);
+		this.createProcess(projectFolder, binPath, binArgs.concat(args), env);
 	}
 }

--- a/src/debug/web_debug_impl.ts
+++ b/src/debug/web_debug_impl.ts
@@ -15,7 +15,7 @@ export class WebDebugSession extends FlutterDebugSession {
 		this.logCategory = LogCategory.WebDaemon;
 	}
 
-	protected spawnRunDaemon(isAttach: boolean, args: DartLaunchArgs, logger: Logger): RunDaemonBase {
+	protected spawnRunDaemon(isAttach: boolean, deviceId: string | undefined, args: DartLaunchArgs, logger: Logger): RunDaemonBase {
 		let appArgs: string[] = [];
 
 		// TODO: Is any of this relevant?

--- a/src/debug/web_debug_impl.ts
+++ b/src/debug/web_debug_impl.ts
@@ -1,4 +1,4 @@
-import { FlutterLaunchRequestArguments } from "../shared/debug/interfaces";
+import { DartLaunchArgs } from "../shared/debug/interfaces";
 import { LogCategory } from "../shared/enums";
 import { Logger } from "../shared/interfaces";
 import { FlutterDebugSession } from "./flutter_debug_impl";
@@ -15,7 +15,7 @@ export class WebDebugSession extends FlutterDebugSession {
 		this.logCategory = LogCategory.WebDaemon;
 	}
 
-	protected spawnRunDaemon(isAttach: boolean, args: FlutterLaunchRequestArguments, logger: Logger): RunDaemonBase {
+	protected spawnRunDaemon(isAttach: boolean, args: DartLaunchArgs, logger: Logger): RunDaemonBase {
 		let appArgs: string[] = [];
 
 		// TODO: Is any of this relevant?
@@ -27,9 +27,6 @@ export class WebDebugSession extends FlutterDebugSession {
 		// 	} else {
 		// 		// Debug mode
 
-		// 		if (this.flutterTrackWidgetCreation) {
-		// 			appArgs.push("--track-widget-creation");
-		// 		}
 		// 	}
 
 		// 	if (this.shouldConnectDebugger) {

--- a/src/debug/web_test_debug_impl.ts
+++ b/src/debug/web_test_debug_impl.ts
@@ -1,10 +1,10 @@
-import { DartLaunchRequestArguments } from "../shared/debug/interfaces";
+import { DartLaunchArgs } from "../shared/debug/interfaces";
 import { SpawnedProcess } from "../shared/interfaces";
 import { DartTestDebugSession } from "./dart_test_debug_impl";
 
 export class WebTestDebugSession extends DartTestDebugSession {
 
-	protected async spawnProcess(args: DartLaunchRequestArguments): Promise<SpawnedProcess> {
+	protected async spawnProcess(args: DartLaunchArgs): Promise<SpawnedProcess> {
 		// TODO: This!
 		throw new Error("NYI");
 	}

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -163,7 +163,7 @@ class Config {
 	}
 }
 
-class ResourceConfig {
+export class ResourceConfig {
 	public uri?: Uri;
 	public config: WorkspaceConfiguration;
 

--- a/src/extension/flutter/flutter_task_provider.ts
+++ b/src/extension/flutter/flutter_task_provider.ts
@@ -1,7 +1,7 @@
 
 import * as vs from "vscode";
 import { FlutterCapabilities } from "../../shared/capabilities/flutter";
-import { getFutterWebRendererArg } from "../../shared/flutter/utils";
+import { getFutterWebRenderer } from "../../shared/flutter/utils";
 import { DartSdks, Logger } from "../../shared/interfaces";
 import { notUndefined } from "../../shared/utils";
 import { arrayStartsWith } from "../../shared/utils/array";
@@ -53,10 +53,12 @@ export class FlutterTaskProvider extends BaseTaskProvider {
 		if (definition.command === "flutter") {
 			// Inject web-renderer if required.
 			const isWebBuild = arrayStartsWith(definition.args, ["build", "web"]);
-			if (isWebBuild) {
-				const rendererArg = getFutterWebRendererArg(this.flutterCapabilities, config.flutterWebRenderer, definition.args);
-				if (rendererArg)
-					definition.args.push(rendererArg);
+			if (isWebBuild && !definition.args.includes("--web-renderer")) {
+				const renderer = getFutterWebRenderer(this.flutterCapabilities, config.flutterWebRenderer);
+				if (renderer) {
+					definition.args.push("--web-renderer");
+					definition.args.push(renderer);
+				}
 			}
 		}
 	}

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -101,7 +101,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		const isFlutter = debugType === DebuggerType.Flutter || debugType === DebuggerType.FlutterTest;
 		const isTest = isTestFileOrFolder(debugConfig.program);
 		const isIntegrationTest = debugConfig.program && isInsideFolderNamed(debugConfig.program, "integration_test");
-		const argsHaveTestNameFilter = debugConfig.args ? (debugConfig.args.includes("--name") || debugConfig.args.includes("--pname")) : false;
+		const argsHaveTestNameFilter = debugConfig.toolArgs ? (debugConfig.toolArgs.includes("--name") || debugConfig.toolArgs.includes("--pname")) : false;
 
 		// Handle test_driver tests that can be pointed at an existing running instrumented app.
 		if (debugType === DebuggerType.FlutterTest && isInsideFolderNamed(debugConfig.program, "test_driver") && !debugConfig.env?.VM_SERVICE_URL) {
@@ -301,7 +301,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		const isTest = isTestFileOrFolder(debugConfig.program);
 		const isIntegrationTest = debugConfig.program && isInsideFolderNamed(debugConfig.program, "integration_test");
 		// TODO: Remove argsHaveTestNameFilter now that "flutter test" supports running tests on device (integration tests).
-		const argsHaveTestNameFilter = debugConfig.args ? (debugConfig.args.includes("--name") || debugConfig.args.includes("--pname")) : false;
+		const argsHaveTestNameFilter = debugConfig.toolArgs ? (debugConfig.toolArgs.includes("--name") || debugConfig.toolArgs.includes("--pname")) : false;
 
 		let debugType = DebuggerType.Dart;
 		if (debugConfig.cwd

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -456,6 +456,13 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 				debugConfig.name = "Dart";
 			}
 		}
+
+		// Some properties depend ont he device, so infer that first if required.
+		if (isFlutter && !debugConfig.deviceId && device) {
+			debugConfig.deviceId = device.id;
+			debugConfig.deviceName = `${deviceManager ? deviceManager.labelForDevice(device) : device.name} (${device.platform})`;
+		}
+
 		debugConfig.toolEnv = getToolEnv();
 		debugConfig.sendLogsToClient = true;
 		debugConfig.cwd = debugConfig.cwd || (folder && fsPath(folder.uri));
@@ -486,10 +493,6 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			debugConfig.workspaceConfig = this.wsContext.config;
 			debugConfig.flutterRunLogFile = this.insertSessionName(debugConfig, debugConfig.flutterRunLogFile || conf.flutterRunLogFile);
 			debugConfig.flutterTestLogFile = this.insertSessionName(debugConfig, debugConfig.flutterTestLogFile || conf.flutterTestLogFile);
-			if (!debugConfig.deviceId && device) {
-				debugConfig.deviceId = device.id;
-				debugConfig.deviceName = `${deviceManager ? deviceManager.labelForDevice(device) : device.name} (${device.platform})`;
-			}
 			debugConfig.showMemoryUsage =
 				debugConfig.showMemoryUsage || debugConfig.showMemoryUsage === false
 					? debugConfig.showMemoryUsage

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -89,7 +89,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		this.configureProgramAndCwd(debugConfig, folder, openFile);
 
 		// If we still don't have an entry point, the user will have to provide it.
-		if (!debugConfig.program) {
+		if (!isAttachRequest && !debugConfig.program) {
 			this.logger.warn("No program was set in launch config");
 			const exampleEntryPoint = this.wsContext.hasAnyFlutterProjects ? "lib/main.dart" : "bin/main.dart";
 			window.showInformationMessage(`Set the 'program' value in your launch config (eg '${exampleEntryPoint}') then launch again`);
@@ -230,7 +230,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 				? Object.values(this.testTreeModel.suites)
 					.map((suite) => suite.path)
 					.filter((p) => p.startsWith(debugConfig.program!))
-				: [debugConfig.program];
+				: [debugConfig.program!];
 			for (const suitePath of suitePaths)
 				this.testTreeModel.flagSuiteStart(suitePath, !argsHaveTestNameFilter);
 		}

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -9,7 +9,7 @@ import { CHROME_OS_VM_SERVICE_PORT, debugAnywayAction, HAS_LAST_DEBUG_CONFIG, HA
 import { DartLaunchArgs, DartVsCodeLaunchArgs } from "../../shared/debug/interfaces";
 import { DebuggerType, VmServiceExtension } from "../../shared/enums";
 import { Device } from "../../shared/flutter/daemon_interfaces";
-import { getFutterWebRendererArg } from "../../shared/flutter/utils";
+import { getFutterWebRenderer } from "../../shared/flutter/utils";
 import { IFlutterDaemon, Logger } from "../../shared/interfaces";
 import { TestTreeModel } from "../../shared/test/test_model";
 import { filenameSafe, isWebDevice } from "../../shared/utils";
@@ -571,10 +571,9 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		if (debugConfig.flutterPlatform && debugConfig.flutterPlatform !== "default")
 			this.addArgsIfNotExist(args, "--target-platform", debugConfig.flutterPlatform);
 
-		if (this.flutterCapabilities.supportsWsVmService && !args.includes("--web-server-debug-protocol"))
-			this.addArgsIfNotExist(args, "--web-server-debug-protocol", "ws");
-
 		if (debugConfig.deviceId === "web-server") {
+			if (this.flutterCapabilities.supportsWsVmService && !args.includes("--web-server-debug-protocol"))
+				this.addArgsIfNotExist(args, "--web-server-debug-protocol", "ws");
 			if (config.debugExtensionBackendProtocol && this.flutterCapabilities.supportsWsDebugBackend)
 				this.addArgsIfNotExist(args, "--web-server-debug-backend-protocol", config.debugExtensionBackendProtocol);
 			if (config.debugExtensionBackendProtocol && this.flutterCapabilities.supportsWsInjectedClient)
@@ -587,9 +586,9 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			this.addArgsIfNotExist(args, "-v");
 
 		if (!isAttach && isWeb) {
-			const rendererArg = getFutterWebRendererArg(this.flutterCapabilities, config.flutterWebRenderer, debugConfig.args);
-			if (rendererArg)
-				this.addArgsIfNotExist(args, "--web-renderer", rendererArg);
+			const renderer = getFutterWebRenderer(this.flutterCapabilities, config.flutterWebRenderer);
+			if (renderer)
+				this.addArgsIfNotExist(args, "--web-renderer", renderer);
 		}
 
 		if (config.shareDevToolsWithFlutter && this.flutterCapabilities.supportsDevToolsServerAddress && !args.includes("--devtools-server-address")) {

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -580,46 +580,45 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		else
 			this.addArgsIfNotExist(args, ...conf.flutterRunAdditionalArgs);
 
-		switch (debugConfig.flutterMode) {
-			case "profile":
-			case "release":
-				if (!args.includes(debugConfig.flutterMode))
-					args.push(`--${debugConfig.flutterMode}`);
-				break;
-
-			default: // Debug mode.
-				if (debugConfig.vmServicePort && isDebug)
-					this.addArgsIfNotExist(args, "--observatory-port", debugConfig.vmServicePort.toString());
-				if (!conf.flutterTrackWidgetCreation && !args.includes("--no-track-widget-creation"))
-					this.addArgsIfNotExist(args, "--no-track-widget-creation");
-				if (conf.flutterStructuredErrors && this.flutterCapabilities.supportsDartDefine)
-					this.addArgsIfNotExist(args, "--dart-define=flutter.inspector.structuredErrors=true");
-		}
-
 		if (debugConfig.deviceId)
 			this.addArgsIfNotExist(args, "-d", debugConfig.deviceId);
 
-		if (debugConfig.flutterPlatform && debugConfig.flutterPlatform !== "default")
-			this.addArgsIfNotExist(args, "--target-platform", debugConfig.flutterPlatform);
+		if (!isAttach) {
+			switch (debugConfig.flutterMode) {
+				case "profile":
+				case "release":
+					if (!args.includes(debugConfig.flutterMode))
+						args.push(`--${debugConfig.flutterMode}`);
+					break;
 
-		if (debugConfig.deviceId === "web-server") {
-			if (this.flutterCapabilities.supportsWsVmService && !args.includes("--web-server-debug-protocol"))
-				this.addArgsIfNotExist(args, "--web-server-debug-protocol", "ws");
-			if (config.debugExtensionBackendProtocol && this.flutterCapabilities.supportsWsDebugBackend)
-				this.addArgsIfNotExist(args, "--web-server-debug-backend-protocol", config.debugExtensionBackendProtocol);
-			if (config.debugExtensionBackendProtocol && this.flutterCapabilities.supportsWsInjectedClient)
-				this.addArgsIfNotExist(args, "--web-server-debug-injected-client-protocol", config.debugExtensionBackendProtocol);
-		}
-		if (this.flutterCapabilities.supportsExposeUrl)
-			this.addArgsIfNotExist(args, "--web-allow-expose-url");
+				default: // Debug mode.
+					if (debugConfig.vmServicePort && isDebug)
+						this.addArgsIfNotExist(args, "--observatory-port", debugConfig.vmServicePort.toString());
+					if (!conf.flutterTrackWidgetCreation && !args.includes("--no-track-widget-creation"))
+						this.addArgsIfNotExist(args, "--no-track-widget-creation");
+					if (conf.flutterStructuredErrors && this.flutterCapabilities.supportsDartDefine)
+						this.addArgsIfNotExist(args, "--dart-define=flutter.inspector.structuredErrors=true");
+			}
 
-		if (isLogging && !args.includes("--verbose"))
-			this.addArgsIfNotExist(args, "-v");
+			if (debugConfig.flutterPlatform && debugConfig.flutterPlatform !== "default")
+				this.addArgsIfNotExist(args, "--target-platform", debugConfig.flutterPlatform);
 
-		if (!isAttach && isWeb) {
-			const renderer = getFutterWebRenderer(this.flutterCapabilities, config.flutterWebRenderer);
-			if (renderer)
-				this.addArgsIfNotExist(args, "--web-renderer", renderer);
+			if (debugConfig.deviceId === "web-server") {
+				if (this.flutterCapabilities.supportsWsVmService && !args.includes("--web-server-debug-protocol"))
+					this.addArgsIfNotExist(args, "--web-server-debug-protocol", "ws");
+				if (config.debugExtensionBackendProtocol && this.flutterCapabilities.supportsWsDebugBackend)
+					this.addArgsIfNotExist(args, "--web-server-debug-backend-protocol", config.debugExtensionBackendProtocol);
+				if (config.debugExtensionBackendProtocol && this.flutterCapabilities.supportsWsInjectedClient)
+					this.addArgsIfNotExist(args, "--web-server-debug-injected-client-protocol", config.debugExtensionBackendProtocol);
+			}
+			if (this.flutterCapabilities.supportsExposeUrl)
+				this.addArgsIfNotExist(args, "--web-allow-expose-url");
+
+			if (isWeb) {
+				const renderer = getFutterWebRenderer(this.flutterCapabilities, config.flutterWebRenderer);
+				if (renderer)
+					this.addArgsIfNotExist(args, "--web-renderer", renderer);
+			}
 		}
 
 		if (config.shareDevToolsWithFlutter && this.flutterCapabilities.supportsDevToolsServerAddress && !args.includes("--devtools-server-address")) {
@@ -634,6 +633,9 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 				this.logger.error(`Failed to get DevTools server address ${e}`);
 			}
 		}
+
+		if (isLogging && !args.includes("--verbose"))
+			this.addArgsIfNotExist(args, "-v");
 
 		return args;
 	}

--- a/src/shared/capabilities/flutter.ts
+++ b/src/shared/capabilities/flutter.ts
@@ -15,7 +15,6 @@ export class FlutterCapabilities {
 	get supportsWsVmService() { return versionIsAtLeast(this.version, "1.18.0-5"); }
 	get supportsWsDebugBackend() { return versionIsAtLeast(this.version, "1.21.0-0"); }
 	get supportsWsInjectedClient() { return versionIsAtLeast(this.version, "2.1.0-13.0"); }
-	get supportsDebuggerForWebProfileBuilds() { return false; }
 	get supportsExposeUrl() { return versionIsAtLeast(this.version, "1.18.0-5"); }
 	get supportsDartDefine() { return versionIsAtLeast(this.version, "1.17.0"); }
 	get supportsRestartDebounce() { return versionIsAtLeast(this.version, "1.21.0-0"); }

--- a/src/shared/debug/interfaces.ts
+++ b/src/shared/debug/interfaces.ts
@@ -1,64 +1,55 @@
-import { DebugProtocol } from "vscode-debugprotocol";
 import { WorkspaceConfig } from "../interfaces";
 
-export interface DartSharedArgs {
+/// Launch arguments that are passed to (and understood by) the debug adapters.
+export interface DartLaunchArgs {
 	args?: string[];
 	console?: "debugConsole" | "terminal";
 	cwd?: string;
 	dartSdkPath: string;
-	debugExtensionBackendProtocol: "sse" | "ws";
 	debugExternalLibraries: boolean;
 	debugSdkLibraries: boolean;
 	deleteServiceInfoFile?: boolean;
-	enableAsserts?: boolean;
 	env?: { [key: string]: string | undefined };
 	evaluateGettersInDebugViews: boolean;
 	evaluateToStringInDebugViews: boolean;
 	expectSingleTest?: boolean;
-	injectedClientProtocol: "sse" | "ws";
+	flutterRunLogFile?: string;
+	flutterSdkPath?: string;
+	flutterTestLogFile?: string;
 	maxLogLineLength: number;
 	name: string;
+	noDebug?: boolean;
 	observatoryUri?: string; // For backwards compatibility
 	packages?: string;
 	program?: string;
 	pubTestLogFile?: string;
-	request: string;
+	request: "launch" | "attach";
 	sendLogsToClient?: boolean;
 	serviceInfoFile?: string;
 	showDartDeveloperLogs: boolean;
 	showMemoryUsage?: boolean;
 	toolEnv?: { [key: string]: string | undefined };
-	type: string;
-	useFlutterStructuredErrors?: boolean;
+	type: "dart";
 	useInspectorNotificationsForWidgetErrors?: boolean;
-	vmAdditionalArgs?: string[];
+	toolArgs?: string[];
 	vmServiceLogFile?: string;
 	vmServicePort?: number;
 	vmServiceUri?: string;
 	webDaemonLogFile?: string;
+	workspaceConfig?: WorkspaceConfig;
 }
 
-export interface FlutterSharedArgs {
+/// Launch arguments that are valid in launch.json and map be mapped into
+/// DartLaunchArgs fields by the editor (in DebugConfigurationProvider).
+///
+/// These are not understood by the debug adapters.
+export interface DartVsCodeLaunchArgs extends DartLaunchArgs {
 	deviceId?: string;
 	deviceName?: string;
-	forceFlutterVerboseMode?: boolean;
-	flutterTrackWidgetCreation?: boolean;
-	flutterSdkPath: string;
-	globalFlutterArgs?: string[];
-	workspaceConfig?: WorkspaceConfig;
+	enableAsserts?: boolean;
 	flutterMode?: "debug" | "profile" | "release";
 	flutterPlatform?: "default" | "android-arm" | "android-arm64" | "android-x86" | "android-x64";
-	flutterRunLogFile?: string;
-	flutterTestLogFile?: string;
 }
-
-export interface DartLaunchRequestArguments extends DebugProtocol.LaunchRequestArguments, DartSharedArgs { }
-
-export interface FlutterLaunchRequestArguments extends DartLaunchRequestArguments, FlutterSharedArgs { }
-
-export interface DartAttachRequestArguments extends DebugProtocol.AttachRequestArguments, DartSharedArgs { }
-
-export interface FlutterAttachRequestArguments extends DartAttachRequestArguments, FlutterSharedArgs { }
 
 export interface FileLocation {
 	line: number;

--- a/src/shared/flutter/utils.ts
+++ b/src/shared/flutter/utils.ts
@@ -1,15 +1,11 @@
 import { FlutterCapabilities } from "../capabilities/flutter";
 
-export function getFutterWebRendererArg(flutterCapabilities: FlutterCapabilities, renderer: "default" | "auto" | "html" | "canvaskit", existingArgs: string[] | undefined) {
+export function getFutterWebRenderer(flutterCapabilities: FlutterCapabilities, renderer: "auto" | "html" | "canvaskit") {
 	if (!flutterCapabilities.supportsWebRendererOption)
 		return;
 
-	if (!renderer || renderer === "default")
+	if (!renderer || renderer === "auto")
 		return;
 
-	const alreadyHasArg = existingArgs?.find((a) => a.startsWith("--web-renderer=") || a === "--web-renderer");
-	if (alreadyHasArg)
-		return;
-
-	return `--web-renderer=${renderer}`;
+	return renderer;
 }

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -221,6 +221,10 @@ export function escapeDartString(input: string) {
 	return input.replace(/(['"\\])/g, "\\$1");
 }
 
+export function isWebDevice(deviceId: string | undefined): boolean {
+	return !!(deviceId?.startsWith("web") || deviceId === "chrome" || deviceId === "edge");
+}
+
 export function disposeAll(disposables: IAmDisposable[]) {
 	const toDispose = disposables.slice();
 	disposables.length = 0;

--- a/src/shared/utils/array.ts
+++ b/src/shared/utils/array.ts
@@ -21,5 +21,15 @@ export function arraysEqual<T>(items1: T[], items2: T[]) {
 }
 
 export function arrayStartsWith<T>(items1: T[], items2: T[]) {
-	return items1.length >= items2.length && items1.slice(0, items2.length).every((val, i) => val === items2[i]);
+	return items1.length >= items2.length && arraysEqual(items1.slice(0, items2.length), items2);
+}
+
+export function arrayContainsArray<T>(haystack: T[], needle: T[]): boolean {
+	// Loop over valid starting points for the subarray
+	for (let i = 0; i <= haystack.length - needle.length; i++) {
+		// Check if the relevant length sublist equals the other array.
+		if (arraysEqual(haystack.slice(i, i + needle.length), needle))
+			return true;
+	}
+	return false;
 }

--- a/src/shared/utils/test.ts
+++ b/src/shared/utils/test.ts
@@ -3,14 +3,15 @@ import { escapeRegExp } from "../../shared/utils";
 import { OpenedFileInformation } from "../interfaces";
 
 export function getLaunchConfig(noDebug: boolean, path: string, testNames: string[] | undefined, isGroup: boolean, runSkippedTests?: boolean, template?: any | undefined) {
-	const templateArgs = template?.args || [];
-	const testNameArgs = testNames
-		? ["--name", makeRegexForTests(testNames, isGroup)]
-		: [];
-	const args = templateArgs.concat(testNameArgs);
-
+	let toolArgs: string[] = [];
+	if (template?.toolArgs)
+		toolArgs = toolArgs.concat(template?.toolArgs);
+	if (testNames) {
+		toolArgs.push("--name");
+		toolArgs.push(makeRegexForTests(testNames, isGroup));
+	}
 	if (runSkippedTests)
-		args.push("--run-skipped");
+		toolArgs.push("--run-skipped");
 
 	return Object.assign(
 		{
@@ -22,9 +23,10 @@ export function getLaunchConfig(noDebug: boolean, path: string, testNames: strin
 		},
 		template,
 		{
-			args,
+			args: template?.args,
 			expectSingleTest: !isGroup && testNames?.length === 1 && !testNames[0].includes("$"),
 			program: path,
+			toolArgs,
 		},
 	);
 }

--- a/src/test/dart/util.test.ts
+++ b/src/test/dart/util.test.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import * as path from "path";
 import { escapeDartString, generateTestNameFromFileName, isDartSdkFromFlutter, isStableSdk, pubVersionIsAtLeast, versionIsAtLeast } from "../../shared/utils";
+import { arrayContainsArray } from "../../shared/utils/array";
 import { applyColor, red } from "../../shared/utils/colors";
 import { fsPath, isWithinPath, isWithinPathOrEqual } from "../../shared/utils/fs";
 import { emptyFile, everythingFile, ext, flutterEmptyFile, flutterHelloWorldFolder, flutterHelloWorldMainFile, helloWorldFolder } from "../helpers";
@@ -206,5 +207,29 @@ describe("isWithinPathOrEqual", () => {
 		assert.equal(isWithinPathOrEqual(fsPath(flutterHelloWorldFolder), fsPath(flutterHelloWorldFolder)), true);
 		assert.equal(isWithinPathOrEqual(fsPath(flutterEmptyFile), fsPath(flutterEmptyFile)), true);
 		assert.equal(isWithinPathOrEqual(fsPath(flutterHelloWorldMainFile), fsPath(flutterHelloWorldMainFile)), true);
+	});
+});
+
+describe("arrayContainsArray", () => {
+	it("handles haystacks that equal needle", () => {
+		assert.equal(arrayContainsArray([1], [1]), true);
+		assert.equal(arrayContainsArray([1, 2], [1, 2]), true);
+	});
+	it("handles haystacks that start with needle", () => {
+		assert.equal(arrayContainsArray([1, 2], [1]), true);
+		assert.equal(arrayContainsArray([1, 2, 3], [1, 2]), true);
+	});
+	it("handles haystacks that contain needle", () => {
+		assert.equal(arrayContainsArray([0, 1, 2], [1]), true);
+		assert.equal(arrayContainsArray([0, 1, 2, 3], [1, 2]), true);
+	});
+	it("handles haystacks that end with needle", () => {
+		assert.equal(arrayContainsArray([0, 1], [1]), true);
+		assert.equal(arrayContainsArray([0, 1, 2], [1, 2]), true);
+	});
+	it("handles haystacks that do not contain needle", () => {
+		assert.equal(arrayContainsArray([], [1]), false);
+		assert.equal(arrayContainsArray([1], [1, 1]), false);
+		assert.equal(arrayContainsArray([0, 2, 3], [3, 2, 0]), false);
 	});
 });

--- a/src/test/dart_debug/debug/dart_cli.test.ts
+++ b/src/test/dart_debug/debug/dart_cli.test.ts
@@ -155,9 +155,10 @@ describe("dart cli debugger", () => {
 		);
 	});
 
-	it("passes launch.json's vmAdditionalArgs to the VM", async () => {
+	it("passes launch.json's toolArgs to the VM", async () => {
+		// TODO: Redo this like others...
 		const config = await startDebugger(dc, helloWorldMainFile);
-		config.vmAdditionalArgs = ["--fake-flag"];
+		config.toolArgs = ["--fake-flag"];
 		await waitAllThrowIfTerminates(dc,
 			// TODO: Figure out if this is a bug - because we never connect to Observatory, we never
 			// resolve this properly.

--- a/src/test/debug_helpers.ts
+++ b/src/test/debug_helpers.ts
@@ -3,7 +3,6 @@ import * as path from "path";
 import { DebugConfiguration, Uri } from "vscode";
 import { DebugProtocol } from "vscode-debugprotocol";
 import { dartVMPath, debugAdapterPath, flutterPath, isWin, vmServiceListeningBannerPattern } from "../shared/constants";
-import { FlutterLaunchRequestArguments } from "../shared/debug/interfaces";
 import { DebuggerType, LogCategory, TestStatus } from "../shared/enums";
 import { SpawnedProcess } from "../shared/interfaces";
 import { logProcess } from "../shared/logging";
@@ -224,7 +223,7 @@ export function spawnDartProcessPaused(program: Uri, cwd: Uri, ...vmArgs: string
 }
 
 export async function spawnFlutterProcess(script: string | Uri): Promise<DartProcess> {
-	const config = await getLaunchConfiguration(script, { deviceId: "flutter-tester" }) as FlutterLaunchRequestArguments;
+	const config = await getLaunchConfiguration(script, { deviceId: "flutter-tester" });
 	if (!config)
 		throw new Error(`Could not get launch configuration (got ${config})`);
 	const process = extApi.safeToolSpawn(

--- a/src/test/flutter_debug/debug/flutter_run.test.ts
+++ b/src/test/flutter_debug/debug/flutter_run.test.ts
@@ -32,7 +32,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		deferUntilLast(() => watchPromise("Killing flutter_tester processes", killFlutterTester()));
 	});
 
-	describe.only("resolves the correct debug config", () => {
+	describe("resolves the correct debug config", () => {
 
 		it("for a simple script", async () => {
 			const resolvedConfig = await getResolvedDebugConfiguration({

--- a/src/test/flutter_debug/debug/flutter_run.test.ts
+++ b/src/test/flutter_debug/debug/flutter_run.test.ts
@@ -55,7 +55,6 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 				program: fsPath(flutterHelloWorldMainFile),
 			})!;
 
-			ensureArrayContainsArray(resolvedConfig!.toolArgs!, ["--web-renderer", "html"]);
 			ensureArrayContainsArray(resolvedConfig!.toolArgs!, ["--web-server-debug-protocol", "ws"]);
 			ensureArrayContainsArray(resolvedConfig!.toolArgs!, ["--web-server-debug-injected-client-protocol", "ws"]);
 		});


### PR DESCRIPTION
This simplifies the debug adapters somewhat (reducing the amount of work needed for SDK-based debug adapters) and makes it easier for the client to customise.

Args are now passed to the DA in two fields:

- `args`: user-args that are generally passed to the script
- `toolArgs` args passed to the VM or Flutter tool

The difference is that the users `program` is generally inserted in between them:

- `dart [toolArgs] foo.dart [args]`
- `flutter run [toolArgs] --target foo.dart [args]`
- `flutter test [toolArgs] test/foo_test.dart [args]`
