### PR TITLE
Use daemon to start bazel DevTools (WIP)

### DIFF
--- a/src/extension/commands/debug.ts
+++ b/src/extension/commands/debug.ts
@@ -56,7 +56,7 @@ export class DebugCommands {
 	public readonly devTools: DevToolsManager;
 	private suppressFlutterWidgetErrors = false;
 
-	constructor(private readonly logger: Logger, private context: Context, workspaceContext: DartWorkspaceContext, private readonly flutterCapabilities: FlutterCapabilities, private readonly analytics: Analytics, pubGlobal: PubGlobal, flutterDaemon?: IFlutterDaemon) {
+	constructor(private readonly logger: Logger, private context: Context, workspaceContext: DartWorkspaceContext, private readonly flutterCapabilities: FlutterCapabilities, private readonly analytics: Analytics, pubGlobal: PubGlobal, flutterDaemon: IFlutterDaemon | undefined) {
 		this.vmServices = new VmServiceExtensions(logger, this);
 		this.devTools = new DevToolsManager(logger, workspaceContext, this, analytics, pubGlobal, flutterCapabilities, flutterDaemon);
 		context.subscriptions.push(this.devTools);

--- a/src/extension/commands/debug.ts
+++ b/src/extension/commands/debug.ts
@@ -4,7 +4,7 @@ import * as vs from "vscode";
 import { FlutterCapabilities } from "../../shared/capabilities/flutter";
 import { debugLaunchProgressId, debugTerminatingProgressId, devToolsPages, doNotAskAgainAction, isInFlutterDebugModeDebugSessionContext, isInFlutterProfileModeDebugSessionContext, widgetInspectorPage } from "../../shared/constants";
 import { DebuggerType, DebugOption, debugOptionNames, LogSeverity, VmServiceExtension } from "../../shared/enums";
-import { DartWorkspaceContext, DevToolsPage, Logger, LogMessage, WidgetErrorInspectData } from "../../shared/interfaces";
+import { DartWorkspaceContext, DevToolsPage, IFlutterDaemon, Logger, LogMessage, WidgetErrorInspectData } from "../../shared/interfaces";
 import { PromiseCompleter } from "../../shared/utils";
 import { fsPath } from "../../shared/utils/fs";
 import { showDevToolsNotificationIfAppropriate } from "../../shared/vscode/user_prompts";
@@ -56,9 +56,9 @@ export class DebugCommands {
 	public readonly devTools: DevToolsManager;
 	private suppressFlutterWidgetErrors = false;
 
-	constructor(private readonly logger: Logger, private context: Context, workspaceContext: DartWorkspaceContext, private readonly flutterCapabilities: FlutterCapabilities, private readonly analytics: Analytics, pubGlobal: PubGlobal) {
+	constructor(private readonly logger: Logger, private context: Context, workspaceContext: DartWorkspaceContext, private readonly flutterCapabilities: FlutterCapabilities, private readonly analytics: Analytics, pubGlobal: PubGlobal, flutterDaemon?: IFlutterDaemon) {
 		this.vmServices = new VmServiceExtensions(logger, this);
-		this.devTools = new DevToolsManager(logger, workspaceContext, this, analytics, pubGlobal, flutterCapabilities);
+		this.devTools = new DevToolsManager(logger, workspaceContext, this, analytics, pubGlobal, flutterCapabilities, flutterDaemon);
 		context.subscriptions.push(this.devTools);
 		this.debugOptions.name = "Dart Debug Options";
 		context.subscriptions.push(this.debugOptions);

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -258,10 +258,24 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 
 	vs.commands.executeCommand("setContext", PUB_OUTDATED_SUPPORTED_CONTEXT, dartCapabilities.supportsPubOutdated);
 
+	// Fire up Flutter daemon if required.
+	if (workspaceContext.hasAnyFlutterMobileProjects && sdks.flutter) {
+		flutterDaemon = new FlutterDaemon(logger, workspaceContext as FlutterWorkspaceContext, flutterCapabilities);
+		deviceManager = new FlutterDeviceManager(logger, flutterDaemon, config);
+
+		context.subscriptions.push(deviceManager);
+		context.subscriptions.push(flutterDaemon);
+
+		setUpDaemonMessageHandler(logger, context, flutterDaemon);
+
+		context.subscriptions.push(vs.commands.registerCommand("flutter.selectDevice", deviceManager.showDevicePicker, deviceManager));
+		context.subscriptions.push(vs.commands.registerCommand("flutter.launchEmulator", deviceManager.promptForAndLaunchEmulator, deviceManager));
+	}
+
 	const pubApi = new PubApi(webClient);
 	const pubGlobal = new PubGlobal(logger, extContext, sdks, pubApi);
 	const sdkCommands = new SdkCommands(logger, extContext, workspaceContext, sdkUtils, pubGlobal, dartCapabilities, flutterCapabilities, deviceManager);
-	const debugCommands = new DebugCommands(logger, extContext, workspaceContext, flutterCapabilities, analytics, pubGlobal);
+	const debugCommands = new DebugCommands(logger, extContext, workspaceContext, flutterCapabilities, analytics, pubGlobal, flutterDaemon);
 
 	// Handle new projects before creating the analyer to avoid a few issues with
 	// showing errors while packages are fetched, plus issues like
@@ -447,20 +461,6 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 
 		// Hook editor changes to send updated contents to analyzer.
 		context.subscriptions.push(new FileChangeHandler(dasClient));
-	}
-
-	// Fire up Flutter daemon if required.
-	if (workspaceContext.hasAnyFlutterMobileProjects && sdks.flutter) {
-		flutterDaemon = new FlutterDaemon(logger, workspaceContext as FlutterWorkspaceContext, flutterCapabilities);
-		deviceManager = new FlutterDeviceManager(logger, flutterDaemon, config);
-
-		context.subscriptions.push(deviceManager);
-		context.subscriptions.push(flutterDaemon);
-
-		setUpDaemonMessageHandler(logger, context, flutterDaemon);
-
-		context.subscriptions.push(vs.commands.registerCommand("flutter.selectDevice", deviceManager.showDevicePicker, deviceManager));
-		context.subscriptions.push(vs.commands.registerCommand("flutter.launchEmulator", deviceManager.promptForAndLaunchEmulator, deviceManager));
 	}
 
 	util.logTime("All other stuff before debugger..");

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -118,7 +118,7 @@ export const SERVICE_EXTENSION_CONTEXT_PREFIX = "dart-code:serviceExtension.";
 export const SERVICE_CONTEXT_PREFIX = "dart-code:service.";
 
 let analyzer: Analyzer;
-let flutterDaemon: IFlutterDaemon;
+let flutterDaemon: IFlutterDaemon | undefined;
 let deviceManager: FlutterDeviceManager;
 const dartCapabilities = DartCapabilities.empty;
 const flutterCapabilities = FlutterCapabilities.empty;

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -891,6 +891,7 @@ export async function deactivate(isRestart: boolean = false): Promise<void> {
 		await Promise.all(loggers.map((logger) => logger.dispose()));
 		loggers.length = 0;
 	}
+	await flutterDaemon?.shutdown();
 	vs.commands.executeCommand("setContext", FLUTTER_SUPPORTS_ATTACH, false);
 	if (!isRestart) {
 		vs.commands.executeCommand("setContext", HAS_LAST_DEBUG_CONFIG, false);

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -887,11 +887,11 @@ function getSettingsThatRequireRestart() {
 export async function deactivate(isRestart: boolean = false): Promise<void> {
 	setCommandVisiblity(false);
 	analyzer?.dispose();
+	await flutterDaemon?.shutdown();
 	if (loggers) {
 		await Promise.all(loggers.map((logger) => logger.dispose()));
 		loggers.length = 0;
 	}
-	await flutterDaemon?.shutdown();
 	vs.commands.executeCommand("setContext", FLUTTER_SUPPORTS_ATTACH, false);
 	if (!isRestart) {
 		vs.commands.executeCommand("setContext", HAS_LAST_DEBUG_CONFIG, false);

--- a/src/extension/flutter/flutter_daemon.ts
+++ b/src/extension/flutter/flutter_daemon.ts
@@ -208,6 +208,10 @@ export class FlutterDaemon extends StdIOService<UnknownNotification> implements 
 		return this.sendRequest("devtools.serve");
 	}
 
+	public shutdown(): Thenable<void> {
+		return this.sendRequest("daemon.shutdown");
+	}
+
 	// Subscription methods.
 
 	public registerForDaemonConnected(subscriber: (notification: f.DaemonConnected) => void): vs.Disposable {

--- a/src/extension/flutter/flutter_daemon.ts
+++ b/src/extension/flutter/flutter_daemon.ts
@@ -204,6 +204,10 @@ export class FlutterDaemon extends StdIOService<UnknownNotification> implements 
 		return this.sendRequest("daemon.getSupportedPlatforms", { projectRoot });
 	}
 
+	public serveDevTools(): Thenable<f.ServeDevToolsResponse> {
+		return this.sendRequest("devtools.serve");
+	}
+
 	// Subscription methods.
 
 	public registerForDaemonConnected(subscriber: (notification: f.DaemonConnected) => void): vs.Disposable {

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -28,7 +28,7 @@ import { getExcludedFolders, isFlutterProjectFolder, isInsideFolderNamed, isTest
 import { getGlobalFlutterArgs, getToolEnv } from "../utils/processes";
 
 export class DebugConfigProvider implements DebugConfigurationProvider {
-	constructor(private readonly logger: Logger, private readonly wsContext: WorkspaceContext, private readonly analytics: Analytics, private readonly pubGlobal: PubGlobal, private readonly testTreeModel: TestTreeModel, private readonly daemon: IFlutterDaemon, private readonly deviceManager: FlutterDeviceManager, private readonly debugCommands: DebugCommands, private dartCapabilities: DartCapabilities, private readonly flutterCapabilities: FlutterCapabilities) { }
+	constructor(private readonly logger: Logger, private readonly wsContext: WorkspaceContext, private readonly analytics: Analytics, private readonly pubGlobal: PubGlobal, private readonly testTreeModel: TestTreeModel, private readonly daemon: IFlutterDaemon | undefined, private readonly deviceManager: FlutterDeviceManager, private readonly debugCommands: DebugCommands, private dartCapabilities: DartCapabilities, private readonly flutterCapabilities: FlutterCapabilities) { }
 
 	public resolveDebugConfiguration(folder: WorkspaceFolder | undefined, debugConfig: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration> {
 		debugConfig.type = debugConfig.type || "dart";

--- a/src/extension/sdk/dev_tools/manager.ts
+++ b/src/extension/sdk/dev_tools/manager.ts
@@ -106,7 +106,7 @@ export class DevToolsManager implements vs.Disposable {
 			if (flutterDaemon != null) {
 				const result = await flutterDaemon.serveDevTools();
 				this.devtoolsUrl = new Promise<string>((resolve, reject) => {
-					if (result.host != null && result.port != null) {
+					if (result.host && result.port) {
 						resolve(`http://${result.host}:${result.port}/`);
 					} else {
 						reject("Unable to serve DevTools");

--- a/src/extension/sdk/dev_tools/manager.ts
+++ b/src/extension/sdk/dev_tools/manager.ts
@@ -47,18 +47,18 @@ export class DevToolsManager implements vs.Disposable {
 	/// concurrent launches can wait on the same promise.
 	public devtoolsUrl: Thenable<string> | undefined;
 
-	constructor(private readonly logger: Logger, private readonly workspaceContext: DartWorkspaceContext, private readonly debugCommands: DebugCommands, private readonly analytics: Analytics, private readonly pubGlobal: PubGlobal, private readonly flutterCapabilities: FlutterCapabilities, flutterDaemon?: IFlutterDaemon) {
+	constructor(private readonly logger: Logger, private readonly workspaceContext: DartWorkspaceContext, private readonly debugCommands: DebugCommands, private readonly analytics: Analytics, private readonly pubGlobal: PubGlobal, private readonly flutterCapabilities: FlutterCapabilities, private readonly flutterDaemon: IFlutterDaemon) {
 		this.devToolsStatusBarItem.name = "Dart/Flutter DevTools";
 		this.disposables.push(this.devToolsStatusBarItem);
 
-		this.handleEagerActivationAndStartup(workspaceContext, flutterDaemon);
+		this.handleEagerActivationAndStartup(workspaceContext);
 	}
 
-	private async handleEagerActivationAndStartup(workspaceContext: DartWorkspaceContext, flutterDaemon?: IFlutterDaemon) {
+	private async handleEagerActivationAndStartup(workspaceContext: DartWorkspaceContext) {
 		if (workspaceContext.config?.startDevToolsServerEagerly) {
 			try {
 				if (workspaceContext.config?.startDevToolsServerEagerly) {
-					await this.spawnIfRequired(workspaceContext.config?.startDevToolsFromDaemon ? flutterDaemon : undefined, true);
+					await this.spawnIfRequired(workspaceContext.config?.startDevToolsFromDaemon ? this.flutterDaemon : undefined, true);
 				}
 			} catch (e) {
 				this.logger.error("Failed to background start DevTools");

--- a/src/shared/flutter/daemon_interfaces.ts
+++ b/src/shared/flutter/daemon_interfaces.ts
@@ -80,6 +80,6 @@ export interface SupportedPlatformsResponse {
 }
 
 export interface ServeDevToolsResponse {
-	host: string;
-	port: string;
+	host: string | null;
+	port: string | null;
 }

--- a/src/shared/flutter/daemon_interfaces.ts
+++ b/src/shared/flutter/daemon_interfaces.ts
@@ -78,3 +78,8 @@ export interface ShowMessage {
 export interface SupportedPlatformsResponse {
 	platforms: PlatformType[];
 }
+
+export interface ServeDevToolsResponse {
+	host: string;
+	port: string;
+}

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -107,6 +107,7 @@ export interface IFlutterDaemon extends IAmDisposable {
 	createEmulator(name?: string): Thenable<{ success: boolean, emulatorName: string, error: string }>;
 	getSupportedPlatforms(projectRoot: string): Thenable<f.SupportedPlatformsResponse>;
 	serveDevTools(): Thenable<f.ServeDevToolsResponse>;
+	shutdown(): Thenable<void>
 
 	registerForDaemonConnected(subscriber: (notification: f.DaemonConnected) => void): IAmDisposable;
 	registerForDeviceAdded(subscriber: (notification: f.Device) => void): IAmDisposable;

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -42,6 +42,7 @@ export interface WritableWorkspaceConfig {
 	// config.
 
 	startDevToolsServerEagerly?: boolean;
+	startDevToolsFromDaemon?: boolean;
 	disableAutomaticPackageGet?: boolean;
 	disableSdkUpdateChecks?: boolean;
 	flutterDaemonScript?: CustomScript;
@@ -105,6 +106,7 @@ export interface IFlutterDaemon extends IAmDisposable {
 	launchEmulator(emulatorId: string, coldBoot: boolean): Thenable<void>;
 	createEmulator(name?: string): Thenable<{ success: boolean, emulatorName: string, error: string }>;
 	getSupportedPlatforms(projectRoot: string): Thenable<f.SupportedPlatformsResponse>;
+	serveDevTools(): Thenable<f.ServeDevToolsResponse>;
 
 	registerForDaemonConnected(subscriber: (notification: f.DaemonConnected) => void): IAmDisposable;
 	registerForDeviceAdded(subscriber: (notification: f.Device) => void): IAmDisposable;

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -58,6 +58,8 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 		config.forceFlutterDebug = true;
 		config.skipFlutterInitialization = true;
 		config.skipTargetFlag = true;
+		config.startDevToolsServerEagerly = true;
+		config.startDevToolsFromDaemon = true;
 		config.flutterVersion = MAX_VERSION;
 		config.flutterDaemonScript = makeScript(flutterConfig.daemonScript);
 		config.flutterDoctorScript = makeScript(flutterConfig.doctorScript);

--- a/src/test/flutter/device_manager.test.ts
+++ b/src/test/flutter/device_manager.test.ts
@@ -251,6 +251,10 @@ class FakeFlutterDaemon extends FakeProcessStdIOService<unknown> implements IFlu
 		return { host: "", port: ""};
 	}
 
+	public async shutdown(): Promise<void> {
+		return;
+	}
+
 	// Subscription methods.
 
 	public registerForDaemonConnected(subscriber: (notification: f.DaemonConnected) => void): IAmDisposable {

--- a/src/test/flutter/device_manager.test.ts
+++ b/src/test/flutter/device_manager.test.ts
@@ -247,6 +247,10 @@ class FakeFlutterDaemon extends FakeProcessStdIOService<unknown> implements IFlu
 		return { platforms: this.supportedPlatforms };
 	}
 
+	public async serveDevTools(): Promise<f.ServeDevToolsResponse> {
+		return { host: "", port: ""};
+	}
+
 	// Subscription methods.
 
 	public registerForDaemonConnected(subscriber: (notification: f.DaemonConnected) => void): IAmDisposable {


### PR DESCRIPTION
This sets up a running DevTools server using a script specified in the workspace, but trying to get the embedded inspector page fails with "Dart DevTools was unable to launch Chrome so your default browser was launched instead", along with "Request must contain a "method" key." (I don't see a default browser opening either)

I see that this logic goes through `launchInEmbeddedWebView` but I'm not sure what parameters are expected here for a successful launch and not sure what I may be missing.

Also, is there a hook on workspace close to shut down the daemon process?