### PR TITLE
 Add a "Dart: Add Dependency" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,11 @@
 				"category": "Dart"
 			},
 			{
+				"command": "dart.addDevDependency",
+				"title": "Add Dev Dependency",
+				"category": "Dart"
+			},
+			{
 				"command": "dart.toggleDartdocComment",
 				"title": "Toggle Dartdoc Comment",
 				"category": "Dart"
@@ -754,6 +759,10 @@
 				},
 				{
 					"command": "dart.addDependency",
+					"when": "dart-code:anyProjectLoaded"
+				},
+				{
+					"command": "dart.addDevDependency",
 					"when": "dart-code:anyProjectLoaded"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -128,6 +128,11 @@
 				"category": "Dart"
 			},
 			{
+				"command": "dart.addDependency",
+				"title": "Add Dependency",
+				"category": "Dart"
+			},
+			{
 				"command": "dart.toggleDartdocComment",
 				"title": "Toggle Dartdoc Comment",
 				"category": "Dart"
@@ -745,6 +750,10 @@
 				},
 				{
 					"command": "dart.writeRecommendedSettings",
+					"when": "dart-code:anyProjectLoaded"
+				},
+				{
+					"command": "dart.addDependency",
 					"when": "dart-code:anyProjectLoaded"
 				},
 				{

--- a/src/extension/commands/add_dependency.ts
+++ b/src/extension/commands/add_dependency.ts
@@ -19,7 +19,7 @@ const knownFlutterSdkPackages = [
 	"integration_test",
 ];
 
-export class AddPackageCommand extends BaseSdkCommands {
+export class AddDependencyCommand extends BaseSdkCommands {
 	private readonly extensionStoragePath: string | undefined;
 	private cache: PackageCacheData | undefined;
 	private nextPackageNameFetchTimeout: NodeJS.Timeout | undefined;
@@ -99,12 +99,11 @@ export class AddPackageCommand extends BaseSdkCommands {
 		if (typeof uri === "string")
 			uri = vs.Uri.file(uri);
 
-		const selectedPackage = await this.promptForPackage();
-		if (!selectedPackage)
+		const selectedPackageName = await this.promptForPackage();
+		if (!selectedPackageName)
 			return;
-		const packageName = selectedPackage.packageName;
 
-		this.addDependency(uri, packageName, isDevDependency);
+		this.addDependency(uri, selectedPackageName, isDevDependency);
 	}
 
 	private async addDependency(uri: string | vs.Uri, packageName: string, isDevDependency: boolean) {
@@ -128,7 +127,7 @@ export class AddPackageCommand extends BaseSdkCommands {
 		}
 	}
 
-	private async promptForPackage(): Promise<PickablePackage | undefined> {
+	private async promptForPackage(): Promise<string | undefined> {
 		const quickPick = vs.window.createQuickPick<PickablePackage>();
 		quickPick.placeholder = "Enter a package name";
 		quickPick.items = this.getMatchingPackages();
@@ -144,7 +143,7 @@ export class AddPackageCommand extends BaseSdkCommands {
 
 		quickPick.dispose();
 
-		return selectedPackage;
+		return selectedPackage?.packageName;
 	}
 
 	private getMatchingPackages(prefix?: string): PickablePackage[] {
@@ -169,4 +168,4 @@ export class AddPackageCommand extends BaseSdkCommands {
 	}
 }
 
-type PickablePackage = vs.QuickPickItem & { packageName: string };
+export type PickablePackage = vs.QuickPickItem & { packageName: string };

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -35,6 +35,7 @@ import { MainCodeLensProvider } from "./code_lens/main_code_lens_provider";
 import { LspMainCodeLensProvider } from "./code_lens/main_code_lens_provider_lsp";
 import { TestCodeLensProvider } from "./code_lens/test_code_lens_provider";
 import { LspTestCodeLensProvider } from "./code_lens/test_code_lens_provider_lsp";
+import { AddDependencyCommand } from "./commands/add_dependency";
 import { AnalyzerCommands } from "./commands/analyzer";
 import { getOutputChannel } from "./commands/channels";
 import { DartCommands } from "./commands/dart";
@@ -48,7 +49,6 @@ import { GoToSuperCommand } from "./commands/go_to_super";
 import { LoggingCommands } from "./commands/logging";
 import { OpenInOtherEditorCommands } from "./commands/open_in_other_editors";
 import { PackageCommands } from "./commands/packages";
-import { AddPackageCommand } from "./commands/packages_add";
 import { RefactorCommands } from "./commands/refactor";
 import { SdkCommands } from "./commands/sdk";
 import { cursorIsInTest, DasTestCommands, isInImplementationFileThatCanHaveTest, isInTestFileThatHasImplementation, LspTestCommands } from "./commands/test";
@@ -283,12 +283,12 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 	const dartCommands = new DartCommands(logger, extContext, workspaceContext, sdkUtils, pubGlobal, dartCapabilities);
 	const flutterCommands = new FlutterCommands(logger, extContext, workspaceContext, sdkUtils, dartCapabilities, flutterCapabilities, deviceManager);
 	const packageCommands = new PackageCommands(logger, extContext, workspaceContext, dartCapabilities);
-	const addPackageCommand = new AddPackageCommand(logger, extContext, workspaceContext, dartCapabilities, pubApi);
+	const addDependencyCommand = new AddDependencyCommand(logger, extContext, workspaceContext, dartCapabilities, pubApi);
 	context.subscriptions.push(sdkCommands);
 	context.subscriptions.push(dartCommands);
 	context.subscriptions.push(flutterCommands);
 	context.subscriptions.push(packageCommands);
-	context.subscriptions.push(addPackageCommand);
+	context.subscriptions.push(addDependencyCommand);
 	const debugCommands = new DebugCommands(logger, extContext, workspaceContext, flutterCapabilities, analytics, pubGlobal, flutterDaemon);
 	context.subscriptions.push(debugCommands);
 
@@ -733,6 +733,7 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 	return {
 		...new DartExtensionApi(),
 		[internalApiSymbol]: {
+			addDependencyCommand,
 			analyzer,
 			analyzerCapabilities: dasClient && dasClient.capabilities,
 			cancelAllAnalysisRequests: () => dasClient && dasClient.cancelAllRequests(),

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -360,6 +360,8 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 	// registered providers.
 	const rankingCodeActionProvider = new RankingCodeActionProvider();
 
+	rankingCodeActionProvider.registerProvider(new AddDependencyCodeActionProvider(DART_MODE));
+
 	const triggerCharacters = ".(${'\"/\\".split("");
 	if (!isUsingLsp && dasClient) {
 		context.subscriptions.push(vs.languages.registerHoverProvider(activeFileFilters, new DartHoverProvider(logger, dasClient)));

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -71,6 +71,7 @@ import { LspAnalyzerStatusReporter } from "./lsp/analyzer_status_reporter";
 import { LspClosingLabelsDecorations } from "./lsp/closing_labels_decorations";
 import { LspGoToSuperCommand } from "./lsp/go_to_super";
 import { TestDiscoverer } from "./lsp/test_discoverer";
+import { AddDependencyCodeActionProvider } from "./providers/add_dependency_code_action_provider";
 import { AssistCodeActionProvider } from "./providers/assist_code_action_provider";
 import { DartCompletionItemProvider } from "./providers/dart_completion_item_provider";
 import { DartDiagnosticProvider } from "./providers/dart_diagnostic_provider";

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -48,6 +48,7 @@ import { GoToSuperCommand } from "./commands/go_to_super";
 import { LoggingCommands } from "./commands/logging";
 import { OpenInOtherEditorCommands } from "./commands/open_in_other_editors";
 import { PackageCommands } from "./commands/packages";
+import { AddPackageCommand } from "./commands/packages_add";
 import { RefactorCommands } from "./commands/refactor";
 import { SdkCommands } from "./commands/sdk";
 import { cursorIsInTest, DasTestCommands, isInImplementationFileThatCanHaveTest, isInTestFileThatHasImplementation, LspTestCommands } from "./commands/test";
@@ -281,10 +282,12 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 	const dartCommands = new DartCommands(logger, extContext, workspaceContext, sdkUtils, pubGlobal, dartCapabilities);
 	const flutterCommands = new FlutterCommands(logger, extContext, workspaceContext, sdkUtils, dartCapabilities, flutterCapabilities, deviceManager);
 	const packageCommands = new PackageCommands(logger, extContext, workspaceContext, dartCapabilities);
+	const addPackageCommand = new AddPackageCommand(logger, extContext, workspaceContext, dartCapabilities, pubApi);
 	context.subscriptions.push(sdkCommands);
 	context.subscriptions.push(dartCommands);
 	context.subscriptions.push(flutterCommands);
 	context.subscriptions.push(packageCommands);
+	context.subscriptions.push(addPackageCommand);
 	const debugCommands = new DebugCommands(logger, extContext, workspaceContext, flutterCapabilities, analytics, pubGlobal, flutterDaemon);
 	context.subscriptions.push(debugCommands);
 

--- a/src/extension/providers/add_dependency_code_action_provider.ts
+++ b/src/extension/providers/add_dependency_code_action_provider.ts
@@ -1,0 +1,114 @@
+import * as fs from "fs";
+import * as path from "path";
+import { CancellationToken, CodeAction, CodeActionContext, CodeActionKind, CodeActionProviderMetadata, Diagnostic, DocumentSelector, Range, Selection, TextDocument } from "vscode";
+import { flatMap } from "../../shared/utils";
+import { fsPath } from "../../shared/utils/fs";
+import { locateBestProjectRoot } from "../project";
+import { isAnalyzableAndInWorkspace } from "../utils";
+import { RankedCodeActionProvider } from "./ranking_code_action_provider";
+
+const applicableErrorCodes = ["uri_does_not_exist", "conditional_uri_does_not_exist"];
+const packageUriSourceCodePattern = new RegExp(`r?['"]+package:(.*)\\/`);
+
+export class AddDependencyCodeActionProvider implements RankedCodeActionProvider {
+	constructor(public readonly selector: DocumentSelector) { }
+
+	public readonly rank = 90;
+
+	public readonly metadata: CodeActionProviderMetadata = {
+		providedCodeActionKinds: [CodeActionKind.QuickFix],
+	};
+
+	public provideCodeActions(document: TextDocument, range: Range | Selection, context: CodeActionContext, token: CancellationToken): CodeAction[] | undefined {
+		if (!isAnalyzableAndInWorkspace(document))
+			return;
+
+		// If we were only asked for specific action types and that doesn't include
+		// quickfix (which is all we supply), bail out.
+		if (context && context.only && !CodeActionKind.QuickFix.contains(context.only))
+			return;
+
+		if (!context || !context.diagnostics || !context.diagnostics.length)
+			return;
+
+		const projectRoot = locateBestProjectRoot(fsPath(document.uri));
+		if (!projectRoot)
+			return;
+
+		let diagnosticsWithPackageNames = context.diagnostics
+			.filter((d) => d.range.intersection(range) && d.source === "dart")
+			.map((diagnostic) => ({ diagnostic, packageName: this.extractPackageNameForUriNotFoundDiagnostic(document, diagnostic) }))
+			.filter((d) => d.packageName);
+		if (!diagnosticsWithPackageNames.length)
+			return;
+
+		const pubspec = path.join(projectRoot, "pubspec.yaml");
+		const pubspecContent = fs.existsSync(pubspec) ? fs.readFileSync(pubspec).toString() : undefined;
+
+		if (!pubspecContent)
+			return;
+
+		// Next, filter out any already in pubspec, as that suggests the URI is incorrect
+		// for another reason (and we wouldn't want to try to add something that exists).
+		diagnosticsWithPackageNames = diagnosticsWithPackageNames
+			.filter((obj) => obj.packageName && !pubspecContent.includes(`  ${obj.packageName}`));
+
+		if (!diagnosticsWithPackageNames.length)
+			return;
+
+		return flatMap(diagnosticsWithPackageNames, (item) => this.createActions(document, item.diagnostic, item.packageName!));
+	}
+
+	/// Checks if the diagnostic is a uri_does_not_exist and the URI is a package:
+	/// URI and returns the package name.
+	private extractPackageNameForUriNotFoundDiagnostic(document: TextDocument, diag: Diagnostic): string | undefined {
+		const code = diag.code;
+		if (!code)
+			return;
+
+		const errorCode = typeof code === "string" || typeof code === "number"
+			? code.toString()
+			: ("value" in code)
+				? code.value.toString()
+				: undefined;
+		if (!errorCode)
+			return;
+
+		if (!applicableErrorCodes.includes(errorCode))
+			return;
+
+		// Finally, ensure the URI is a package: URI and something that exists in the pub cache list
+		// we have.
+		const uriSourceCode = document.getText(diag.range);
+		const match = packageUriSourceCodePattern.exec(uriSourceCode);
+		if (!match)
+			return;
+
+		return match[1];
+	}
+
+	private createActions(document: TextDocument, diagnostic: Diagnostic, packageName: string): CodeAction[] {
+		const createAction = (isDevDependency: boolean) => {
+			const dependencyTypeName = isDevDependency ? "dev_dependencies" : "dependencies";
+			const title = `Add '${packageName}' to ${dependencyTypeName} in pubspec.yaml`;
+			const action = new CodeAction(title, CodeActionKind.QuickFix);
+			action.command = {
+				arguments: [
+					document.uri,
+					packageName,
+					isDevDependency,
+				],
+				command: "_dart.addDependency",
+				title,
+			};
+			return action;
+		};
+		const actions = [createAction(false)];
+
+		// When outside of lib, dev_dependency is an option too.
+		if (!document.uri.path.includes("/lib/"))
+			actions.push(createAction(true));
+
+		return actions;
+	}
+}

--- a/src/extension/utils/vscode/projects.ts
+++ b/src/extension/utils/vscode/projects.ts
@@ -23,7 +23,7 @@ export async function getFolderToRunCommandIn(logger: Logger, placeHolder: strin
 
 	if (!selectableFolders || !selectableFolders.length) {
 		const projectTypes = flutterOnly ? "Flutter" : "Dart/Flutter";
-		vs.window.showWarningMessage(`No ${projectTypes} projects were found.`);
+		vs.window.showWarningMessage(`No ${projectTypes} project roots were found. Do you have a pubspec.yaml file?`);
 		return undefined;
 	}
 

--- a/src/shared/pub/api.ts
+++ b/src/shared/pub/api.ts
@@ -10,11 +10,17 @@ export class PubApi {
 		return this.get<PubPackage>(`packages/${packageID}`);
 	}
 
+	public async getPackageNames(): Promise<PackageNameCompletionData> {
+		return this.get<PackageNameCompletionData>(`package-name-completion-data`);
+	}
+
 	private async get<T>(url: string): Promise<T> {
 		const headers = {
 			Accept: "application/vnd.pub.v2+json",
+			"Accept-Encoding": "gzip",
 		};
-		return JSON.parse(await this.webClient.fetch(`${this.pubHost}/api/${url}`, headers)) as T;
+		const response = await this.webClient.fetch(`${this.pubHost}/api/${url}`, headers);
+		return JSON.parse(response) as T;
 	}
 }
 
@@ -35,4 +41,8 @@ interface PubPackageVersion {
 		description: string;
 		homepage: string;
 	};
+}
+
+interface PackageNameCompletionData {
+	packages: string[];
 }

--- a/src/shared/pub/pub_add.ts
+++ b/src/shared/pub/pub_add.ts
@@ -1,0 +1,73 @@
+export class PackageDetailsCache {
+	static cacheVersion = 1;
+	static maxCacheAgeHours = 18;
+	static get maxCacheAgeMs() { return PackageDetailsCache.maxCacheAgeHours * 60 * 60 * 1000; }
+	static maxPackageDetailsRequestsInFlight = 5;
+
+	constructor(
+		private readonly lastUpdated: number,
+		private readonly packages: Map<string, string | undefined>,
+	) { }
+
+	static fromPackageNames(packages: string[]): PackageDetailsCache {
+		const packageMap = new Map<string, string | undefined>();
+		packages.forEach((p) => packageMap.set(p, undefined));
+		return new PackageDetailsCache(
+			new Date().getTime(),
+			packageMap,
+		);
+	}
+
+	public get packageNames() {
+		// TODO: Can we avoid this and just iterate in the callee, since we often
+		// bail out early?
+		return Array.from(this.packages.keys());
+	}
+
+	public get cacheTimeRemainingMs() {
+		const ageMs = new Date().getTime() - this.lastUpdated;
+		const timeRemainingMs = PackageDetailsCache.maxCacheAgeMs - ageMs;
+		return timeRemainingMs < 0
+			? 0
+			: timeRemainingMs;
+	}
+
+	static fromJson(json: string): PackageDetailsCache | undefined {
+		const data = JSON.parse(json, PackageDetailsCache.mapReviver);
+
+		if (data.version !== PackageDetailsCache.cacheVersion)
+			return undefined;
+
+		return new PackageDetailsCache(
+			data.lastUpdated,
+			data.packages,
+		);
+	}
+
+	public toJson(): string {
+		return JSON.stringify(
+			{
+				lastUpdated: this.lastUpdated,
+				packages: this.packages,
+				version: PackageDetailsCache.cacheVersion,
+			},
+			PackageDetailsCache.mapReplacer,
+			2,
+		);
+	}
+
+	private static mapReplacer(key: unknown, value: unknown) {
+		return value instanceof Map
+			? {
+				dataType: "Map",
+				value: [...value],
+			}
+			: value;
+	}
+
+	private static mapReviver(key: unknown, value: any): unknown {
+		return typeof value === "object" && value?.dataType === "Map"
+			? new Map(value.value)
+			: value;
+	}
+}

--- a/src/shared/pub/pub_add.ts
+++ b/src/shared/pub/pub_add.ts
@@ -1,7 +1,7 @@
-export class PackageDetailsCache {
+export class PackageCacheData {
 	static cacheVersion = 1;
 	static maxCacheAgeHours = 18;
-	static get maxCacheAgeMs() { return PackageDetailsCache.maxCacheAgeHours * 60 * 60 * 1000; }
+	static get maxCacheAgeMs() { return PackageCacheData.maxCacheAgeHours * 60 * 60 * 1000; }
 	static maxPackageDetailsRequestsInFlight = 5;
 
 	constructor(
@@ -9,10 +9,10 @@ export class PackageDetailsCache {
 		private readonly packages: Map<string, string | undefined>,
 	) { }
 
-	static fromPackageNames(packages: string[]): PackageDetailsCache {
+	static fromPackageNames(packages: string[]): PackageCacheData {
 		const packageMap = new Map<string, string | undefined>();
 		packages.forEach((p) => packageMap.set(p, undefined));
-		return new PackageDetailsCache(
+		return new PackageCacheData(
 			new Date().getTime(),
 			packageMap,
 		);
@@ -26,19 +26,19 @@ export class PackageDetailsCache {
 
 	public get cacheTimeRemainingMs() {
 		const ageMs = new Date().getTime() - this.lastUpdated;
-		const timeRemainingMs = PackageDetailsCache.maxCacheAgeMs - ageMs;
+		const timeRemainingMs = PackageCacheData.maxCacheAgeMs - ageMs;
 		return timeRemainingMs < 0
 			? 0
 			: timeRemainingMs;
 	}
 
-	static fromJson(json: string): PackageDetailsCache | undefined {
-		const data = JSON.parse(json, PackageDetailsCache.mapReviver);
+	static fromJson(json: string): PackageCacheData | undefined {
+		const data = JSON.parse(json, PackageCacheData.mapReviver);
 
-		if (data.version !== PackageDetailsCache.cacheVersion)
+		if (data.version !== PackageCacheData.cacheVersion)
 			return undefined;
 
-		return new PackageDetailsCache(
+		return new PackageCacheData(
 			data.lastUpdated,
 			data.packages,
 		);
@@ -49,9 +49,9 @@ export class PackageDetailsCache {
 			{
 				lastUpdated: this.lastUpdated,
 				packages: this.packages,
-				version: PackageDetailsCache.cacheVersion,
+				version: PackageCacheData.cacheVersion,
 			},
-			PackageDetailsCache.mapReplacer,
+			PackageCacheData.mapReplacer,
 			2,
 		);
 	}

--- a/src/shared/vscode/interfaces.ts
+++ b/src/shared/vscode/interfaces.ts
@@ -29,6 +29,7 @@ export interface DebugCommandHandler {
 }
 
 export interface InternalExtensionApi {
+	addDependencyCommand: any,
 	analyzerCapabilities?: {
 		supportsGetSignature: boolean;
 		supportsAvailableSuggestions: boolean;

--- a/src/shared/vscode/workspace.ts
+++ b/src/shared/vscode/workspace.ts
@@ -1,5 +1,5 @@
 import { ExtensionContext } from "vscode";
-import { fsPath } from "../utils/fs";
+import { fsPath, mkDirRecursive } from "../utils/fs";
 
 export class Context {
 	private constructor(private readonly context: ExtensionContext) { }
@@ -9,8 +9,11 @@ export class Context {
 	}
 
 	get extensionStoragePath(): string | undefined {
-		const uri = this.context.extensionUri;
-		return uri.scheme === "file" ? fsPath(uri) : undefined;
+		const uri = this.context.globalStorageUri;
+		const path = uri.scheme === "file" ? fsPath(uri) : undefined;
+		if (path)
+			mkDirRecursive(path);
+		return path;
 	}
 
 	get devToolsNotificationLastShown(): number | undefined { return this.context.globalState.get("devToolsNotificationLastShown") as number; }

--- a/src/test/dart/pub/add.test.ts
+++ b/src/test/dart/pub/add.test.ts
@@ -1,0 +1,9 @@
+import { activate } from "../../helpers";
+
+describe.only("pub add", () => {
+	beforeEach("activate", () => activate());
+
+	describe("cache", () => {
+
+	});
+});

--- a/src/test/dart/pub/add.test.ts
+++ b/src/test/dart/pub/add.test.ts
@@ -1,9 +1,25 @@
 import { activate } from "../../helpers";
 
-describe.only("pub add", () => {
+describe("pub add", () => {
 	beforeEach("activate", () => activate());
 
-	describe("cache", () => {
+	describe.skip("can add a dependency using command", () => {
+
+	});
+
+	describe.skip("can add a dev-dependency using command", () => {
+
+	});
+
+	describe.skip("can add a Flutter SDK dependency using command", () => {
+
+	});
+
+	describe.skip("can add from a quick fix if not listed in pubspec.yaml", () => {
+
+	});
+
+	describe.skip("cannot add from a quick fix if already listed in pubspec.yaml", () => {
 
 	});
 });

--- a/src/test/dart/pub/add.test.ts
+++ b/src/test/dart/pub/add.test.ts
@@ -1,25 +1,56 @@
-import { activate } from "../../helpers";
+import { strict as assert } from "assert";
+import * as fs from "fs";
+import * as vs from "vscode";
+import { fsPath } from "../../../shared/utils/fs";
+import { waitFor } from "../../../shared/utils/promises";
+import { activate, currentDoc, defer, extApi, helloWorldPubspec, rangeOf, sb, setTestContent, waitForNextAnalysis } from "../../helpers";
 
 describe("pub add", () => {
+	const pubspecPath = fsPath(helloWorldPubspec);
 	beforeEach("activate", () => activate());
-
-	describe.skip("can add a dependency using command", () => {
-
+	beforeEach("ensure pubspec resets", () => {
+		const contents = fs.readFileSync(pubspecPath);
+		defer(() => fs.writeFileSync(pubspecPath, contents));
 	});
 
-	describe.skip("can add a dev-dependency using command", () => {
+	function pubspecContains(packageName: string) {
+		const contents = fs.readFileSync(pubspecPath);
+		return contents.includes(`  ${packageName}:`);
+	}
 
+	it("can add a dependency using command", async () => {
+		assert.equal(pubspecContains("collection"), false);
+		sb.stub(extApi.addDependencyCommand, "promptForPackage").resolves("collection");
+		await vs.commands.executeCommand("dart.addDependency");
+		await waitFor(() => pubspecContains("collection"));
+		assert.equal(pubspecContains("collection"), true);
 	});
 
-	describe.skip("can add a Flutter SDK dependency using command", () => {
-
+	it("can add a dev-dependency using command", async () => {
+		assert.equal(pubspecContains("collection"), false);
+		sb.stub(extApi.addDependencyCommand, "promptForPackage").resolves("collection");
+		await vs.commands.executeCommand("dart.addDevDependency");
+		await waitFor(() => pubspecContains("collection"));
+		assert.equal(pubspecContains("collection"), true);
 	});
 
-	describe.skip("can add from a quick fix if not listed in pubspec.yaml", () => {
+	it("can add from a quick fix if not listed in pubspec.yaml", async () => {
+		const packageName = "built_value";
+		assert.equal(pubspecContains(packageName), false);
+		await waitForNextAnalysis(() => setTestContent(`import 'package:${packageName}/${packageName}.dart'`));
 
+		const fixResults = await (vs.commands.executeCommand("vscode.executeCodeActionProvider", currentDoc().uri, rangeOf(`|package:${packageName}|`)) as Thenable<vs.CodeAction[]>);
+		const addDependency = fixResults.find((r) => r.title.indexOf(`Add '${packageName}' to dependencies in pubspec.yaml`) !== -1);
+		assert.equal(!!addDependency, true);
 	});
 
-	describe.skip("cannot add from a quick fix if already listed in pubspec.yaml", () => {
+	it("cannot add from a quick fix if already listed in pubspec.yaml", async () => {
+		const packageName = "convert";
+		assert.equal(pubspecContains(packageName), true);
+		await waitForNextAnalysis(() => setTestContent(`import 'package:${packageName}/${packageName}.dart'`));
 
+		const fixResults = await (vs.commands.executeCommand("vscode.executeCodeActionProvider", currentDoc().uri, rangeOf(`|package:${packageName}|`)) as Thenable<vs.CodeAction[]>);
+		const addDependency = fixResults.find((r) => r.title.indexOf(`Add '${packageName}' to dependencies in pubspec.yaml`) !== -1);
+		assert.equal(!!addDependency, false);
 	});
 });

--- a/src/test/flutter/pub/add.test.ts
+++ b/src/test/flutter/pub/add.test.ts
@@ -1,0 +1,45 @@
+import { strict as assert } from "assert";
+import * as fs from "fs";
+import * as vs from "vscode";
+import { fsPath } from "../../../shared/utils/fs";
+import { waitFor } from "../../../shared/utils/promises";
+import { activate, defer, extApi, flutterHelloWorldPubspec, sb } from "../../helpers";
+
+describe("pub add", () => {
+	const pubspecPath = fsPath(flutterHelloWorldPubspec);
+	beforeEach("activate", () => activate());
+	beforeEach("ensure pubspec resets", () => {
+		const contents = fs.readFileSync(pubspecPath);
+		defer(() => fs.writeFileSync(pubspecPath, contents));
+	});
+
+	function pubspecContains(packageName: string) {
+		const contents = fs.readFileSync(pubspecPath);
+		return contents.includes(`  ${packageName}:`);
+	}
+
+	it("can add a dependency using command", async () => {
+		assert.equal(pubspecContains("collection"), false);
+		sb.stub(extApi.addDependencyCommand, "promptForPackage").resolves("collection");
+		await vs.commands.executeCommand("dart.addDependency");
+		await waitFor(() => pubspecContains("collection"));
+		assert.equal(pubspecContains("collection"), true);
+	});
+
+	it("can add a dev-dependency using command", async () => {
+		assert.equal(pubspecContains("collection"), false);
+		sb.stub(extApi.addDependencyCommand, "promptForPackage").resolves("collection");
+		await vs.commands.executeCommand("dart.addDevDependency");
+		await waitFor(() => pubspecContains("collection"));
+		assert.equal(pubspecContains("collection"), true);
+	});
+
+	it("can add a Flutter SDK dependency using command", async () => {
+		assert.equal(pubspecContains("flutter_localizations"), false);
+		sb.stub(extApi.addDependencyCommand, "promptForPackage").resolves("flutter_localizations");
+		await vs.commands.executeCommand("dart.addDevDependency");
+		await waitFor(() => pubspecContains("flutter_localizations"));
+
+		assert.equal(fs.readFileSync(pubspecPath).includes("flutter_localizations: \n    sdk: flutter"), true);
+	});
+});

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -83,6 +83,7 @@ export const helloWorldTestSkipFile = vs.Uri.file(path.join(fsPath(helloWorldTes
 export const flutterHelloWorldFolder = vs.Uri.file(path.join(testFolder, "test_projects/flutter_hello_world"));
 export const flutterEmptyFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "lib/empty.dart"));
 export const flutterHelloWorldMainFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "lib/main.dart"));
+export const flutterHelloWorldPubspec = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "pubspec.yaml"));
 export const flutterHelloWorldCounterAppFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "lib/counter.dart"));
 export const flutterHelloWorldOutlineFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "lib/outline.dart"));
 export const flutterHelloWorldBrokenFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "lib/broken.dart"));


### PR DESCRIPTION
- [x] tests

Possible future improvements:

- [x] quick-fix on missing package URIs? (if we can distinguish from those that are just errors in the filename part)
- [ ] improve error if trying to add Flutter package to a Dart project
- [ ] show (and cache) package descriptions as you move through them
- [x] improve adding Flutter package to non-Flutter project (if Flutter SDK available)

Fixes #3306.