### PR TITLE
chore: replace deprecated vscode-test with @vscode/test-electron

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -676,6 +676,18 @@
 			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
 			"dev": true
 		},
+		"@vscode/test-electron": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-1.6.1.tgz",
+			"integrity": "sha512-WTs+OK9YrKSVJNZ9IjytNibHSJG2YslZXuS3pw9gedF25TgYF/+FQhQYL0ZPX4uupS0SGAPKzMnhYDkjPDxowA==",
+			"dev": true,
+			"requires": {
+				"http-proxy-agent": "^4.0.1",
+				"https-proxy-agent": "^5.0.0",
+				"rimraf": "^3.0.2",
+				"unzipper": "^0.10.11"
+			}
+		},
 		"@webassemblyjs/ast": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.0.tgz",
@@ -4245,18 +4257,6 @@
 			"version": "3.16.0",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
 			"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
-		},
-		"vscode-test": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.5.2.tgz",
-			"integrity": "sha512-x9PVfKxF6EInH9iSFGQi0V8H5zIW1fC7RAer6yNQR6sy3WyOwlWkuT3I+wf75xW/cO53hxMi1aj/EvqQfDFOAg==",
-			"dev": true,
-			"requires": {
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "^5.0.0",
-				"rimraf": "^3.0.2",
-				"unzipper": "^0.10.11"
-			}
 		},
 		"watchpack": {
 			"version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -2659,6 +2659,7 @@
 		"@typescript-eslint/eslint-plugin-tslint": "^4.26.1",
 		"@typescript-eslint/eslint-plugin": "^4.26.1",
 		"@typescript-eslint/parser": "^4.26.1",
+		"@vscode/test-electron": "^1.6.1",
 		"eslint": "^7.28.0",
 		"glob": "^7.1.7",
 		"istanbul-instrumenter-loader": "^3.0.1",
@@ -2670,7 +2671,6 @@
 		"tslint": "^6.1.3",
 		"typescript": "^4.3.2",
 		"vscode-debugadapter-testsupport": "^1.47.0",
-		"vscode-test": "^1.5.2",
 		"webpack-cli": "^4.7.2",
 		"webpack": "^5.38.1"
 	},

--- a/src/test/test_all.ts
+++ b/src/test/test_all.ts
@@ -1,6 +1,6 @@
+import * as vstest from "@vscode/test-electron";
 import * as fs from "fs";
 import * as path from "path";
-import * as vstest from "vscode-test";
 
 let exitCode = 0;
 const cwd = process.cwd();


### PR DESCRIPTION
![2021-07-18 15 55 53](https://user-images.githubusercontent.com/14012511/126060080-8d671595-14c2-43d2-8daa-e8ee579140c3.png)

vscode-test be marked as [deprecated](https://www.npmjs.com/package/vscode-test) on npmjs.org(yarnpkg.com), so just replace vscode-test with latest @vscode/test-electron for `Dart-Code`'s CI. cc @DanTup 