### PR TITLE
feat(snippets): create page snippet

### DIFF
--- a/snippets/flutter.json
+++ b/snippets/flutter.json
@@ -72,6 +72,29 @@
 				"  }",
 				"}"
 			]
+		},
+		"Flutter page widget with stateless view": {
+			"prefix": "pge",
+			"description": "Insert a Page with a StatelessWidget view",
+			"body": [
+				"class $1Page extends Page {",
+				"  const $1Page() : super(key: const ValueKey('$1 Page'));",
+				"",
+				"  Route createRoute(BuildContext context) {",
+				"    return MaterialPageRoute(",
+				"        settings: this, builder: (BuildContext context) => $1View());",
+				"  }",
+				"}",
+				"",
+				"class $1View extends StatelessWidget {",
+				"  const $1View();",
+				"",
+				"  @override",
+				"  Widget build(BuildContext context) {",
+				"    return Scaffold(${0:body: Text('Hello, world!')});",
+				"  }",
+				"}"
+			]
 		}
 	}
 }


### PR DESCRIPTION
Closes #3493 
I've been working with Flutter 2.0 and the navigator API and I think it would be really great if we could have a snippet for creating pages.  This is one that I've been using globally in my editor and hopefully others may enjoy the convenience as well.