### PR TITLE
Allow bazel target that's not a main file

### DIFF
--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -208,7 +208,11 @@ export class FlutterDebugSession extends DartDebugSession {
 		if (!isAttach || args.program) {
 			if (!args.workspaceConfig?.skipTargetFlag)
 				appArgs.push("--target");
-			appArgs.push(this.sourceFileForArgs(args));
+			if (!!args.workspaceConfig?.nonMainTargetPrefix && args.program!.startsWith(args.workspaceConfig?.nonMainTargetPrefix)) {
+				appArgs.push(args.program!);
+			} else {
+				appArgs.push(this.sourceFileForArgs(args));
+			}
 		}
 
 		if (args.args)

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -58,6 +58,7 @@ export interface WritableWorkspaceConfig {
 	forceFlutterDebug?: boolean;
 	skipFlutterInitialization?: boolean;
 	skipTargetFlag?: boolean;
+	nonMainTargetPrefix?: string;
 }
 
 export type WorkspaceConfig = Readonly<WritableWorkspaceConfig>;

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -60,6 +60,7 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 		config.skipTargetFlag = true;
 		config.startDevToolsServerEagerly = true;
 		config.startDevToolsFromDaemon = true;
+		config.nonMainTargetPrefix = "//";
 		config.flutterVersion = MAX_VERSION;
 		config.flutterDaemonScript = makeScript(flutterConfig.daemonScript);
 		config.flutterDoctorScript = makeScript(flutterConfig.doctorScript);


### PR DESCRIPTION
I had wanted to use only main files as targets to minimize divergence from the external workflow, but it would be nice to have an exception for now. It will take more time to investigate how much work it would be to get teams to change their configurations to using main files only.