### PR TITLE
Add support for DevTools to open external links

### DIFF
--- a/src/extension/sdk/dev_tools/embedded_view.ts
+++ b/src/extension/sdk/dev_tools/embedded_view.ts
@@ -66,7 +66,7 @@ export class DevToolsEmbeddedView {
 		this.messageDisposable = this.panel.webview.onDidReceiveMessage(
 			async (message) => {
 				if (message.command === "launchUrl") {
-					await envUtils.openInBrowser(message.data);
+					await envUtils.openInBrowser(message.data.url);
 				}
 			},
 		);


### PR DESCRIPTION
See https://github.com/flutter/devtools/issues/3251 - external links are currently failing when DevTools are embedded in VSCode due to the "allow-popups" sandbox restriction being enabled.

There might be a simpler solution to this that I'm unaware of.

I'm not very experienced with VSCode/TypeScript development, please check carefully 😁

Especially not sure if I got the dispose logic right.

Buddy PR on DevTools: https://github.com/flutter/devtools/pull/3252