### PR TITLE
Add support for VS Code's test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -2335,6 +2335,12 @@
 					"description": "EXPERIMENTAL: Whether to enable custom tracking of Flutter UI guidelines (to hide some latency of waiting for the next Flutter Outline).",
 					"scope": "window"
 				},
+				"dart.previewVsCodeTestRunner": {
+					"type": "boolean",
+					"default": false,
+					"description": "PREVIEW: Whether to enable reporting tests into the VS Code Test Runner (requires restart).",
+					"scope": "window"
+				},
 				"dart.evaluateToStringInDebugViews": {
 					"type": "boolean",
 					"default": true,

--- a/src/extension/commands/test.ts
+++ b/src/extension/commands/test.ts
@@ -125,7 +125,7 @@ abstract class TestCommands implements vs.Disposable {
 			}
 			subs.push(vs.debug.onDidTerminateDebugSession((e) => {
 				if (e.configuration.dartCodeDebugSessionID === dartCodeDebugSessionID)
-					resolve();
+					resolve(true);
 			}));
 			const didStart = await vs.debug.startDebugging(
 				vs.workspace.getWorkspaceFolder(vs.Uri.file(programPath)),

--- a/src/extension/commands/test.ts
+++ b/src/extension/commands/test.ts
@@ -106,13 +106,13 @@ abstract class TestCommands implements vs.Disposable {
 		return this.runTests(programPath, debug, testNames, isGroup, shouldRunSkippedTests, suppressPromptOnErrors, undefined, testRun, token);
 	}
 
-	private runTests(programPath: string, debug: boolean, testNames: string[] | undefined, isGroup: boolean, shouldRunSkippedTests: boolean, suppressPromptOnErrors: boolean, launchTemplate: any | undefined, testRun: vs.TestRun | undefined, token: vs.CancellationToken | undefined) {
+	private runTests(programPath: string, debug: boolean, testNames: string[] | undefined, isGroup: boolean, shouldRunSkippedTests: boolean, suppressPromptOnErrors: boolean, launchTemplate: any | undefined, testRun: vs.TestRun | undefined, token: vs.CancellationToken | undefined): Promise<boolean> {
 		const vsTest = this.vsCodeTestController?.controller;
 		if (vsTest)
 			testRun ??= vsTest.createTestRun(new vs.TestRunRequest(), undefined, true);
 
 		const subs: vs.Disposable[] = [];
-		return new Promise<void>(async (resolve, reject) => {
+		return new Promise<boolean>(async (resolve, reject) => {
 			// Construct a unique ID for this session so we can track when it completes.
 			const dartCodeDebugSessionID = `session-${getRandomInt(0x1000, 0x10000).toString(16)}`;
 			if (testRun)

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -115,6 +115,7 @@ class Config {
 	get previewFlutterUiGuidesCustomTracking(): boolean { return this.getConfig<boolean>("previewFlutterUiGuidesCustomTracking", false); }
 	get previewHotReloadOnSaveWatcher(): boolean { return this.getConfig<boolean>("previewHotReloadOnSaveWatcher", false); }
 	get previewLsp(): undefined | boolean { return this.getConfig<null | boolean>("previewLsp", null); }
+	get previewVsCodeTestRunner(): boolean { return this.getConfig<boolean>("previewVsCodeTestRunner", false); }
 	get promptToRunIfErrors(): boolean { return this.getConfig<boolean>("promptToRunIfErrors", true); }
 	get pubTestLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("pubTestLogFile", null))); }
 	get sdkPath(): undefined | string { return resolvePaths(this.getConfig<null | string>("sdkPath", null)); }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -774,6 +774,7 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 			pubGlobal,
 			renameProvider,
 			safeToolSpawn,
+			testController: vsCodeTestController?.controller,
 			testCoordinator,
 			testModel,
 			testTreeProvider,

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -100,6 +100,7 @@ import { StatusBarVersionTracker } from "./sdk/status_bar_version_tracker";
 import { checkForStandardDartSdkUpdates } from "./sdk/update_check";
 import { SdkUtils } from "./sdk/utils";
 import { DartTerminalLinkProvider } from "./terminal/link_provider";
+import { VsCodeTestController } from "./test/vs_test_controller";
 import { handleNewProjects, showUserPrompts } from "./user_prompts";
 import * as util from "./utils";
 import { addToLogHeader, clearLogHeader, getExtensionLogPath, getLogHeader } from "./utils/log";
@@ -485,6 +486,9 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 	const testModel = new TestModel(config, util.isPathInsideFlutterProject);
 	const testCoordinator = new TestSessionCoordinator(logger, testModel);
 	context.subscriptions.push(testCoordinator);
+	const vsCodeTestController = config.previewVsCodeTestRunner ? new VsCodeTestController(logger, testModel) : undefined;
+	if (vsCodeTestController)
+		context.subscriptions.push(vsCodeTestController);
 
 	const analyzerCommands = new AnalyzerCommands(context, logger, analyzer, analytics);
 
@@ -569,9 +573,9 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 	context.subscriptions.push(new LoggingCommands(logger, context.logPath));
 	context.subscriptions.push(new OpenInOtherEditorCommands(logger, sdks));
 	if (dasAnalyzer)
-		context.subscriptions.push(new DasTestCommands(logger, testModel, workspaceContext, dasAnalyzer.fileTracker, flutterCapabilities));
+		context.subscriptions.push(new DasTestCommands(logger, testModel, workspaceContext, vsCodeTestController, dasAnalyzer.fileTracker, flutterCapabilities));
 	if (lspAnalyzer)
-		context.subscriptions.push(new LspTestCommands(logger, testModel, workspaceContext, lspAnalyzer.fileTracker, flutterCapabilities));
+		context.subscriptions.push(new LspTestCommands(logger, testModel, workspaceContext, vsCodeTestController, lspAnalyzer.fileTracker, flutterCapabilities));
 
 	if (lspClient && lspAnalyzer) {
 		// TODO: LSP equivs of the others...

--- a/src/extension/flutter/flutter_outline_view.ts
+++ b/src/extension/flutter/flutter_outline_view.ts
@@ -56,7 +56,7 @@ export abstract class FlutterOutlineProvider implements vs.TreeDataProvider<Flut
 
 	protected abstract loadExistingOutline(): Promise<void>;
 
-	public async setContexts(selection: FlutterWidgetItem[]) {
+	public async setContexts(selection: FlutterWidgetItem[] | undefined) {
 		// Unmark the old node as being selected.
 		if (this.lastSelectedWidget) {
 			this.lastSelectedWidget.contextValue = undefined;

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -24,7 +24,7 @@ import { config, ResourceConfig } from "../config";
 import { locateBestProjectRoot } from "../project";
 import { PubGlobal } from "../pub/global";
 import { WebDev } from "../pub/webdev";
-import { getExcludedFolders, isFlutterProjectFolder, isInsideFolderNamed, isTestFileOrFolder, isTestFolder, isValidEntryFile, projectShouldUsePubForTests as shouldUsePubForTests } from "../utils";
+import { getExcludedFolders, hasTestNameFilter, isFlutterProjectFolder, isInsideFolderNamed, isTestFileOrFolder, isTestFolder, isValidEntryFile, projectShouldUsePubForTests as shouldUsePubForTests } from "../utils";
 import { getGlobalFlutterArgs, getToolEnv } from "../utils/processes";
 
 export class DebugConfigProvider implements DebugConfigurationProvider {
@@ -101,7 +101,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		const isFlutter = debugType === DebuggerType.Flutter || debugType === DebuggerType.FlutterTest;
 		const isTest = isTestFileOrFolder(debugConfig.program);
 		const isIntegrationTest = debugConfig.program && isInsideFolderNamed(debugConfig.program, "integration_test");
-		const argsHaveTestNameFilter = debugConfig.toolArgs ? (debugConfig.toolArgs.includes("--name") || debugConfig.toolArgs.includes("--pname")) : false;
+		const argsHaveTestNameFilter = hasTestNameFilter(debugConfig.toolArgs, debugConfig.args);
 
 		// Handle test_driver tests that can be pointed at an existing running instrumented app.
 		if (debugType === DebuggerType.FlutterTest && isInsideFolderNamed(debugConfig.program, "test_driver") && !debugConfig.env?.VM_SERVICE_URL) {
@@ -301,7 +301,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		const isTest = isTestFileOrFolder(debugConfig.program);
 		const isIntegrationTest = debugConfig.program && isInsideFolderNamed(debugConfig.program, "integration_test");
 		// TODO: Remove argsHaveTestNameFilter now that "flutter test" supports running tests on device (integration tests).
-		const argsHaveTestNameFilter = debugConfig.toolArgs ? (debugConfig.toolArgs.includes("--name") || debugConfig.toolArgs.includes("--pname")) : false;
+		const argsHaveTestNameFilter = hasTestNameFilter(debugConfig.toolArgs, debugConfig.args);
 
 		let debugType = DebuggerType.Dart;
 		if (debugConfig.cwd

--- a/src/extension/test/vs_test_controller.ts
+++ b/src/extension/test/vs_test_controller.ts
@@ -1,0 +1,231 @@
+import * as path from "path";
+import * as vs from "vscode";
+import { IAmDisposable, Logger } from "../../shared/interfaces";
+import { GroupNode, SuiteNode, TestContainerNode, TestEventListener, TestModel, TestNode, TreeNode } from "../../shared/test/test_model";
+import { disposeAll, notUndefined } from "../../shared/utils";
+import { fsPath } from "../../shared/utils/fs";
+
+export class VsCodeTestController implements TestEventListener, IAmDisposable {
+	private disposables: IAmDisposable[] = [];
+	public readonly controller: vs.TestController;
+	private itemForNode = new WeakMap<TreeNode, vs.TestItem>();
+	private nodeForItem = new WeakMap<vs.TestItem, TreeNode>();
+	private testRuns: { [key: string]: vs.TestRun | undefined } = {};
+
+	public registerTestRun(debugSessionId: string, run: vs.TestRun): void {
+		this.testRuns[debugSessionId] = run;
+	}
+
+	constructor(private readonly logger: Logger, private readonly model: TestModel) {
+		const controller = vs.tests.createTestController("dart", "Dart & Flutter");
+		this.controller = controller;
+		this.disposables.push(controller);
+		this.disposables.push(model.onDidChangeTreeData.listen((node) => this.onDidChangeTreeData(node)));
+		model.addTestEventListener(this);
+
+		controller.createRunProfile("Run", vs.TestRunProfileKind.Run, (request, token) => {
+			this.runTests(false, request, token);
+		});
+
+		controller.createRunProfile("Debug", vs.TestRunProfileKind.Debug, (request, token) => {
+			this.runTests(true, request, token);
+		});
+
+	}
+
+	private async runTests(debug: boolean, request: vs.TestRunRequest, token: vs.CancellationToken): Promise<void> {
+		const run = this.controller.createTestRun(request);
+		const testsToRun: vs.TestItem[] = [];
+		(request.include ?? this.controller.items).forEach((item) => testsToRun.push(item));
+
+		for (const test of testsToRun) {
+			const node = this.nodeForItem.get(test);
+			if (!node) continue;
+
+			const command = debug ? "dart.startDebuggingTest" : "dart.startWithoutDebuggingTest";
+			await vs.commands.executeCommand(command, node, run);
+		}
+	}
+
+	/// Replace the whole tree.
+	private replaceAll() {
+		const suiteTestItems = Object.values(this.model.suites)
+			.map((suite) => this.createOrUpdateNode(suite.node))
+			.filter(notUndefined);
+		this.controller.items.replace(suiteTestItems);
+	}
+
+	private onDidChangeTreeData(node: TreeNode | undefined): void {
+		if (node === undefined) {
+			this.replaceAll();
+			return;
+		}
+
+		this.createOrUpdateNode(node);
+	}
+
+	/// Creates a node (including its children), or if it already exists, updates it
+	/// and its children.
+	///
+	/// Returns undefined if in the case of an error or a node that should
+	/// not be shown in the tree.
+	private createOrUpdateNode(node: TreeNode): vs.TestItem | undefined {
+		if (node instanceof TestNode && node.hidden)
+			return;
+		if (node instanceof GroupNode && node.isPhantomGroup)
+			return;
+
+		let collection;
+		if (node instanceof SuiteNode) {
+			collection = this.controller.items;
+		} else if (node instanceof GroupNode) {
+			// If the parent is a Phantom group, jump over it.
+			let parent = node.parent;
+			while (parent instanceof GroupNode && parent.isPhantomGroup)
+				parent = parent.parent;
+			collection = this.itemForNode.get(parent)?.children;
+		} else {
+			collection = this.itemForNode.get(node.parent!)?.children;
+		}
+
+		if (!collection) {
+			this.logger.error(`Failed to find parent (${node.parent?.label}) of node (${node.label})`);
+			return;
+		}
+		const existingItem = collection.get(this.idForNode(node));
+
+		// Create new item if required.
+		if (!existingItem) {
+			const newItem = this.createTestItem(node);
+			collection.add(newItem);
+			return newItem;
+		}
+
+		// Otherwise, update this item to match the latest state.
+		this.updateFields(existingItem, node);
+
+		if (node instanceof TestContainerNode) {
+			// Update al children. Note: crrateOrUpdateNode() adds the child to the tree
+			// so we don't need to do anything with the result here.
+			for (const child of node.children) {
+				this.createOrUpdateNode(child);
+			}
+		}
+
+		return existingItem;
+	}
+
+	private idForNode(node: TreeNode) {
+		return node instanceof GroupNode || node instanceof TestNode
+			? `${node.suiteData.path}:${node.name}`
+			: node.suiteData.path;
+	}
+
+	private cleanLabel(label: string) {
+		return label.trim().split("\n").map((l) => l.trim()).join(" ");
+	}
+
+	private labelForSuite(node: SuiteNode): string {
+		const suitePath = node.suiteData.path;
+		const wf = vs.workspace.getWorkspaceFolder(vs.Uri.file(suitePath));
+
+		return wf
+			? path.relative(fsPath(wf.uri), node.suiteData.path).replace("\\", "/")
+			: path.basename(suitePath);
+	}
+
+	private createTestItem(node: TreeNode): vs.TestItem {
+		const id = this.idForNode(node);
+		const label = node instanceof SuiteNode
+			? this.labelForSuite(node)
+			: this.cleanLabel(node.label ?? "<unnamed>");
+		const uri = vs.Uri.file(node.suiteData.path);
+
+		const item = this.controller.createTestItem(id, label, uri);
+		this.updateFields(item, node);
+		this.nodeForItem.set(item, node);
+		this.itemForNode.set(node, item);
+
+		if (node instanceof TestContainerNode && node.children) {
+			for (const child of node.children) {
+				item.children.add(this.createTestItem(child));
+			}
+		}
+
+		return item;
+	}
+
+	private updateFields(item: vs.TestItem, node: TreeNode) {
+		item.description = node.description;
+		if ((node instanceof GroupNode || node instanceof TestNode) && node.line) {
+			const pos = new vs.Position(node.line - 1, node.column ?? 0);
+			item.range = new vs.Range(pos, pos);
+		}
+	}
+
+	public suiteDiscovered(sessionID: string, node: SuiteNode): void {
+		const run = this.testRuns[sessionID];
+		const item = this.itemForNode.get(node);
+		if (run && item)
+			run.started(item);
+	}
+
+	public groupDiscovered(sessionID: string, node: GroupNode): void {
+		const run = this.testRuns[sessionID];
+		const item = this.itemForNode.get(node);
+		if (run && item)
+			run.started(item);
+	}
+
+	public testStarted(sessionID: string, node: TestNode): void {
+		const run = this.testRuns[sessionID];
+		const item = this.itemForNode.get(node);
+		if (run && item)
+			run.started(item);
+	}
+
+	public testOutput(sessionID: string, node: TestNode, message: string): void {
+		const run = this.testRuns[sessionID];
+		const item = this.itemForNode.get(node);
+		if (run && item)
+			run.appendOutput(message);
+	}
+
+	public testErrorOutput(sessionID: string, node: TestNode, message: string, isFailure: boolean, stack: string): void {
+		const run = this.testRuns[sessionID];
+		const item = this.itemForNode.get(node);
+		if (run && item) {
+			// TODO: isFailure??
+			run.appendOutput(message);
+			run.appendOutput(stack);
+		}
+	}
+
+	public testDone(sessionID: string, node: TestNode, result: "skipped" | "success" | "failure" | "error" | undefined): void {
+		const run = this.testRuns[sessionID];
+		const item = this.itemForNode.get(node);
+		if (run && item) {
+			switch (result) {
+				case "skipped":
+					run.skipped(item);
+					break;
+				case "success":
+					run.passed(item, node.duration);
+					break;
+				case "failure":
+					run.failed(item, new vs.TestMessage("FAILURE TODO"), node.duration);
+					break;
+				default:
+					run.errored(item, new vs.TestMessage("FAILURE TODO"), node.duration);
+					break;
+			}
+		}
+	}
+
+	public suiteDone(sessionID: string, node: SuiteNode): void {
+	}
+
+	public dispose(): any {
+		disposeAll(this.disposables);
+	}
+}

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -170,6 +170,14 @@ export function isInsideFolderNamed(file: string | undefined, folderName: string
 	return segments.indexOf(folderName.toLowerCase()) !== -1;
 }
 
+export function hasTestNameFilter(...argss: Array<string[] | undefined>) {
+	for (const args of argss) {
+		if (args && (args.includes("--name") || args.includes("--pname")))
+			return true;
+	}
+	return false;
+}
+
 export function isValidEntryFile(file: string | undefined) {
 	return file && isDartFile(file) &&
 		(

--- a/src/extension/views/test_view.ts
+++ b/src/extension/views/test_view.ts
@@ -67,7 +67,7 @@ export class TestResultsProvider implements vs.Disposable, vs.TreeDataProvider<T
 	}
 
 	public handleDebugSessionCustomEvent(e: { session: vs.DebugSession; event: string; body?: any; }) {
-		this.coordinator.handleDebugSessionCustomEvent(e);
+		this.coordinator.handleDebugSessionCustomEvent(e.session.id, e.session.configuration.dartCodeDebugSessionID, e.event, e.body);
 	}
 
 	public handleDebugSessionEnd(session: vs.DebugSession) {

--- a/src/extension/views/test_view.ts
+++ b/src/extension/views/test_view.ts
@@ -71,7 +71,7 @@ export class TestResultsProvider implements vs.Disposable, vs.TreeDataProvider<T
 	}
 
 	public handleDebugSessionEnd(session: vs.DebugSession) {
-		this.coordinator.handleDebugSessionEnd(session.id);
+		this.coordinator.handleDebugSessionEnd(session.id, session.configuration.dartCodeDebugSessionID);
 	}
 
 	private async writeTestOutput(treeNode: TestNode) {

--- a/src/shared/debug/interfaces.ts
+++ b/src/shared/debug/interfaces.ts
@@ -56,3 +56,5 @@ export interface FileLocation {
 	line: number;
 	column: number;
 }
+
+export interface DebugSessionWithDartCodeSessionId { id: string, configuration: { dartCodeDebugSessionID: string | undefined } }

--- a/src/shared/test/coordinator.ts
+++ b/src/shared/test/coordinator.ts
@@ -1,3 +1,4 @@
+import { DebugSessionWithDartCodeSessionId } from "../../shared/debug/interfaces";
 import { IAmDisposable, Logger } from "../interfaces";
 import { ErrorNotification, GroupNotification, Notification, PrintNotification, SuiteNotification, TestDoneNotification, TestStartNotification } from "../test_protocol";
 import { disposeAll, uriToFilePath } from "../utils";
@@ -13,14 +14,14 @@ export class TestSessionCoordinator implements IAmDisposable {
 	constructor(private readonly logger: Logger, private readonly data: TestModel) { }
 
 	public handleDebugSessionCustomEvent(e: { session: { id: string }; event: string; body?: any }) {
+		const session = e.session as DebugSessionWithDartCodeSessionId;
 		if (e.event === "dart.testRunNotification") {
 			// tslint:disable-next-line: no-floating-promises
-			// TODO: Why do we get no session in tests???
-			this.handleNotification(e.session?.id, e.body.suitePath, e.body.notification).catch((e) => this.logger.error(e));
+			this.handleNotification(session.id, session.configuration.dartCodeDebugSessionID, e.body.suitePath, e.body.notification).catch((e) => this.logger.error(e));
 		}
 	}
 
-	public handleDebugSessionEnd(debugSessionID: string) {
+	public handleDebugSessionEnd(debugSessionID: string, dartCodeDebugSessionID: string | undefined) {
 		// Get the suite paths that have us as the owning debug session.
 		const suitePaths = Object.keys(this.owningDebugSessions).filter((suitePath) => {
 			const owningSessionID = this.owningDebugSessions[suitePath];
@@ -29,13 +30,13 @@ export class TestSessionCoordinator implements IAmDisposable {
 
 		// End them all and remove from the lookup.
 		for (const suitePath of suitePaths) {
-			this.handleSuiteEnd(this.data.suites[suitePath]);
+			this.handleSuiteEnd(dartCodeDebugSessionID, this.data.suites[suitePath]);
 			this.owningDebugSessions[suitePath] = undefined;
 			delete this.owningDebugSessions[suitePath];
 		}
 	}
 
-	public async handleNotification(debugSessionID: string | undefined, suitePath: string, evt: Notification): Promise<void> {
+	public async handleNotification(debugSessionID: string, dartCodeDebugSessionID: string | undefined, suitePath: string, evt: Notification): Promise<void> {
 		// If we're starting a suite, record us as the owner so we can clean up later
 		if (evt.type === "suite")
 			this.owningDebugSessions[suitePath] = debugSessionID;
@@ -53,16 +54,16 @@ export class TestSessionCoordinator implements IAmDisposable {
 			// 	this.handleAllSuitesNotification(evt as AllSuitesNotification);
 			// 	break;
 			case "suite":
-				this.handleSuiteNotification(suitePath, evt as SuiteNotification);
+				this.handleSuiteNotification(dartCodeDebugSessionID, suitePath, evt as SuiteNotification);
 				break;
 			case "testStart":
-				this.handleTestStartNotifcation(suite, evt as TestStartNotification);
+				this.handleTestStartNotifcation(dartCodeDebugSessionID, suite, evt as TestStartNotification);
 				break;
 			case "testDone":
-				this.handleTestDoneNotification(suite, evt as TestDoneNotification);
+				this.handleTestDoneNotification(dartCodeDebugSessionID, suite, evt as TestDoneNotification);
 				break;
 			case "group":
-				this.handleGroupNotification(suite, evt as GroupNotification);
+				this.handleGroupNotification(dartCodeDebugSessionID, suite, evt as GroupNotification);
 				break;
 			// We won't get notifications that aren't directly tied to Suites because
 			// of how the DA works.
@@ -70,51 +71,51 @@ export class TestSessionCoordinator implements IAmDisposable {
 			// 	this.handleDoneNotification(suite, evt as DoneNotification);
 			// 	break;
 			case "print":
-				this.handlePrintNotification(suite, evt as PrintNotification);
+				this.handlePrintNotification(dartCodeDebugSessionID, suite, evt as PrintNotification);
 				break;
 			case "error":
-				this.handleErrorNotification(suite, evt as ErrorNotification);
+				this.handleErrorNotification(dartCodeDebugSessionID, suite, evt as ErrorNotification);
 				break;
 		}
 	}
 
-	private handleSuiteNotification(suitePath: string, evt: SuiteNotification) {
-		this.data.suiteDiscovered(evt.suite.path);
+	private handleSuiteNotification(dartCodeDebugSessionID: string | undefined, suitePath: string, evt: SuiteNotification) {
+		this.data.suiteDiscovered(dartCodeDebugSessionID, evt.suite.path);
 	}
 
-	private handleTestStartNotifcation(suite: SuiteData, evt: TestStartNotification) {
+	private handleTestStartNotifcation(dartCodeDebugSessionID: string | undefined, suite: SuiteData, evt: TestStartNotification) {
 		const path = (evt.test.root_url || evt.test.url) ? uriToFilePath(evt.test.root_url || evt.test.url!) : undefined;
 		const line = evt.test.root_line || evt.test.line;
 		const column = evt.test.root_column || evt.test.column;
-		this.data.testStarted(suite.path, evt.test.id, evt.test.name, evt.test.groupIDs, path, line, column, evt.time);
+		this.data.testStarted(dartCodeDebugSessionID, suite.path, evt.test.id, evt.test.name, evt.test.groupIDs, path, line, column, evt.time);
 	}
 
-	private handleTestDoneNotification(suite: SuiteData, evt: TestDoneNotification) {
+	private handleTestDoneNotification(dartCodeDebugSessionID: string | undefined, suite: SuiteData, evt: TestDoneNotification) {
 		const result = evt.skipped ? "skipped" : evt.result;
-		this.data.testDone(suite.path, evt.testID, result, evt.hidden, evt.time);
+		this.data.testDone(dartCodeDebugSessionID, suite.path, evt.testID, result, evt.hidden, evt.time);
 	}
 
-	private handleGroupNotification(suite: SuiteData, evt: GroupNotification) {
+	private handleGroupNotification(dartCodeDebugSessionID: string | undefined, suite: SuiteData, evt: GroupNotification) {
 		const path = (evt.group.root_url || evt.group.url) ? uriToFilePath(evt.group.root_url || evt.group.url!) : undefined;
 		const line = evt.group.root_line || evt.group.line;
 		const column = evt.group.root_column || evt.group.column;
-		this.data.groupDiscovered(suite.path, evt.group.id, evt.group.name, evt.group.parentID, path, line, column);
+		this.data.groupDiscovered(dartCodeDebugSessionID, suite.path, evt.group.id, evt.group.name, evt.group.parentID, path, line, column);
 	}
 
-	private handleSuiteEnd(suite: SuiteData) {
-		this.data.suiteEnd(suite.path);
+	private handleSuiteEnd(dartCodeDebugSessionID: string | undefined, suite: SuiteData) {
+		this.data.suiteDone(dartCodeDebugSessionID, suite.path);
 	}
 
-	private handlePrintNotification(suite: SuiteData, evt: PrintNotification) {
+	private handlePrintNotification(dartCodeDebugSessionID: string | undefined, suite: SuiteData, evt: PrintNotification) {
 		const test = suite.getCurrentTest(evt.testID);
 		test.outputEvents.push(evt);
-		this.data.testOutput(suite.path, evt.testID, evt.message);
+		this.data.testOutput(dartCodeDebugSessionID, suite.path, evt.testID, evt.message);
 	}
 
-	private handleErrorNotification(suite: SuiteData, evt: ErrorNotification) {
+	private handleErrorNotification(dartCodeDebugSessionID: string | undefined, suite: SuiteData, evt: ErrorNotification) {
 		const test = suite.getCurrentTest(evt.testID);
 		test.outputEvents.push(evt);
-		this.data.testErrorOutput(suite.path, evt.testID, evt.isFailure, evt.error, evt.stackTrace);
+		this.data.testErrorOutput(dartCodeDebugSessionID, suite.path, evt.testID, evt.isFailure, evt.error, evt.stackTrace);
 	}
 
 	public dispose(): any {

--- a/src/shared/test/coordinator.ts
+++ b/src/shared/test/coordinator.ts
@@ -1,4 +1,3 @@
-import { DebugSessionWithDartCodeSessionId } from "../../shared/debug/interfaces";
 import { IAmDisposable, Logger } from "../interfaces";
 import { ErrorNotification, GroupNotification, Notification, PrintNotification, SuiteNotification, TestDoneNotification, TestStartNotification } from "../test_protocol";
 import { disposeAll, uriToFilePath } from "../utils";
@@ -13,11 +12,10 @@ export class TestSessionCoordinator implements IAmDisposable {
 
 	constructor(private readonly logger: Logger, private readonly data: TestModel) { }
 
-	public handleDebugSessionCustomEvent(e: { session: { id: string }; event: string; body?: any }) {
-		const session = e.session as DebugSessionWithDartCodeSessionId;
-		if (e.event === "dart.testRunNotification") {
+	public handleDebugSessionCustomEvent(debugSessionID: string, dartCodeDebugSessionID: string | undefined, event: string, body?: any) {
+		if (event === "dart.testRunNotification") {
 			// tslint:disable-next-line: no-floating-promises
-			this.handleNotification(session.id, session.configuration.dartCodeDebugSessionID, e.body.suitePath, e.body.notification).catch((e) => this.logger.error(e));
+			this.handleNotification(debugSessionID, dartCodeDebugSessionID, body.suitePath, body.notification).catch((e) => this.logger.error(e));
 		}
 	}
 

--- a/src/shared/vscode/interfaces.ts
+++ b/src/shared/vscode/interfaces.ts
@@ -1,4 +1,4 @@
-import { CompletionItem, CompletionItemProvider, DebugAdapterDescriptor, DebugConfigurationProvider, DebugSession, DebugSessionCustomEvent, MarkdownString, OutputChannel, RenameProvider, TextDocument, TreeDataProvider, TreeItem, Uri } from "vscode";
+import { CompletionItem, CompletionItemProvider, DebugAdapterDescriptor, DebugConfigurationProvider, DebugSession, DebugSessionCustomEvent, MarkdownString, OutputChannel, RenameProvider, TestController, TextDocument, TreeDataProvider, TreeItem, Uri } from "vscode";
 import * as lsp from "../analysis/lsp/custom_protocol";
 import { AvailableSuggestion, FlutterOutline, Outline } from "../analysis_server_types";
 import { Analyzer } from "../analyzer";
@@ -78,6 +78,7 @@ export interface InternalExtensionApi {
 	renameProvider: RenameProvider | undefined;
 	safeToolSpawn: (workingDirectory: string | undefined, binPath: string, args: string[], envOverrides?: { [key: string]: string | undefined }) => SpawnedProcess;
 	testTreeProvider: TreeDataProvider<TreeNode>;
+	testController: TestController;
 	testCoordinator: TestSessionCoordinator;
 	testModel: TestModel;
 	webClient: WebClient;

--- a/src/test/dart/test/test_view.test.ts
+++ b/src/test/dart/test/test_view.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from "assert";
-import { activate, extApi, getExpectedResults, helloWorldTestDiscoveryFile, makeTextTree, openFile, waitForResult } from "../../helpers";
+import { activate, extApi, getExpectedResults, helloWorldTestDiscoveryFile, makeTestTextTree, openFile, waitForResult } from "../../helpers";
 
 describe("dart test tree", () => {
 	beforeEach("activate", () => activate());
@@ -10,7 +10,7 @@ describe("dart test tree", () => {
 			this.skip();
 
 		// Ensure no results before we start.
-		const initialResults = (await makeTextTree(helloWorldTestDiscoveryFile, extApi.testTreeProvider)).join("\n");
+		const initialResults = (await makeTestTextTree(helloWorldTestDiscoveryFile)).join("\n");
 		assert.equal(initialResults, "");
 
 		// Open the file and allow time for the outline.
@@ -18,7 +18,7 @@ describe("dart test tree", () => {
 		await waitForResult(() => !!extApi.fileTracker.getOutlineFor(helloWorldTestDiscoveryFile));
 
 		const expectedResults = getExpectedResults();
-		const actualResults = (await makeTextTree(helloWorldTestDiscoveryFile, extApi.testTreeProvider)).join("\n");
+		const actualResults = (await makeTestTextTree(helloWorldTestDiscoveryFile)).join("\n");
 
 		assert.ok(expectedResults);
 		assert.ok(actualResults);

--- a/src/test/dart_debug/debug/dart_test.test.ts
+++ b/src/test/dart_debug/debug/dart_test.test.ts
@@ -170,6 +170,27 @@ describe("dart test debugger", () => {
 		assert.equal(actualResults, expectedResults);
 	});
 
+	it.skip("builds the expected tree from a test run (VS Code Test Runner)", async () => {
+		// Skipped because we need this setting to be enabled before the extension activates
+		// for the controller to be setup.
+		setConfigForTest("dart", "previewVsCodeTestRunner", true);
+		await openFile(helloWorldTestTreeFile);
+		const config = await startDebugger(dc, helloWorldTestTreeFile);
+		config.noDebug = true;
+		await waitAllThrowIfTerminates(dc,
+			dc.configurationSequence(),
+			dc.waitForEvent("terminated"),
+			dc.launch(config),
+		);
+
+		const expectedResults = getExpectedResults();
+		const actualResults = (await makeTestTextTree(helloWorldTestTreeFile)).join("\n");
+
+		assert.ok(expectedResults);
+		assert.ok(actualResults);
+		assert.equal(actualResults, expectedResults);
+	});
+
 	it("clears the results from the test tree", async () => {
 		await openFile(helloWorldTestTreeFile);
 		const config = await startDebugger(dc, helloWorldTestTreeFile);

--- a/src/test/dart_debug/debug/dart_test.test.ts
+++ b/src/test/dart_debug/debug/dart_test.test.ts
@@ -9,7 +9,7 @@ import { LspTestOutlineInfo, LspTestOutlineVisitor } from "../../../shared/utils
 import * as testUtils from "../../../shared/utils/test";
 import { DartDebugClient } from "../../dart_debug_client";
 import { createDebugClient, expectTopLevelTestNodeCount, startDebugger, waitAllThrowIfTerminates } from "../../debug_helpers";
-import { activate, captureDebugSessionCustomEvents, clearTestTree, extApi, getCodeLens, getExpectedResults, getPackages, getResolvedDebugConfiguration, helloWorldTestBrokenFile, helloWorldTestDupeNameFile, helloWorldTestMainFile, helloWorldTestShortFile, helloWorldTestSkipFile, helloWorldTestTreeFile, logger, makeTextTree, openFile, positionOf, setConfigForTest, waitForResult } from "../../helpers";
+import { activate, captureDebugSessionCustomEvents, clearTestTree, extApi, getCodeLens, getExpectedResults, getPackages, getResolvedDebugConfiguration, helloWorldTestBrokenFile, helloWorldTestDupeNameFile, helloWorldTestMainFile, helloWorldTestShortFile, helloWorldTestSkipFile, helloWorldTestTreeFile, logger, makeTestTextTree, openFile, positionOf, setConfigForTest, waitForResult } from "../../helpers";
 
 describe("dart test debugger", () => {
 	// We have tests that require external packages.
@@ -163,7 +163,7 @@ describe("dart test debugger", () => {
 		);
 
 		const expectedResults = getExpectedResults();
-		const actualResults = (await makeTextTree(helloWorldTestTreeFile, extApi.testTreeProvider)).join("\n");
+		const actualResults = (await makeTestTextTree(helloWorldTestTreeFile)).join("\n");
 
 		assert.ok(expectedResults);
 		assert.ok(actualResults);
@@ -210,7 +210,7 @@ describe("dart test debugger", () => {
 		]);
 
 		const expectedResults = getExpectedResults();
-		const actualResults = (await makeTextTree(helloWorldTestShortFile, extApi.testTreeProvider)).join("\n");
+		const actualResults = (await makeTestTextTree(helloWorldTestShortFile)).join("\n");
 
 		assert.ok(expectedResults);
 		assert.ok(actualResults);
@@ -288,11 +288,11 @@ ${helloWorldTestSkipFile} (Skipped / Skipped)
 		async function checkResults(description: string): Promise<void> {
 			logger.info(description);
 			const expectedResults = getExpectedResults();
-			const actualResults = (await makeTextTree(helloWorldTestTreeFile, extApi.testTreeProvider)).join("\n");
+			const actualResults = (await makeTestTextTree(helloWorldTestTreeFile)).join("\n");
 
 			assert.ok(expectedResults);
 			assert.ok(actualResults);
-			assert.equal(actualResults, expectedResults);
+			assert.equal(actualResults, expectedResults, description);
 		}
 
 		await runWithoutDebugging(helloWorldTestTreeFile);
@@ -328,7 +328,7 @@ ${helloWorldTestSkipFile} (Skipped / Skipped)
 		async function checkResults(description: string): Promise<void> {
 			logger.info(description);
 			const expectedResults = getExpectedResults();
-			const actualResults = (await makeTextTree(helloWorldTestDupeNameFile, extApi.testTreeProvider)).join("\n");
+			const actualResults = (await makeTestTextTree(helloWorldTestDupeNameFile)).join("\n");
 
 			assert.ok(expectedResults);
 			assert.ok(actualResults);
@@ -393,7 +393,7 @@ test/tree_test.dart [8/11 passed, {duration}ms] (fail.svg)
 		`.trim();
 
 		// Get the actual tree, filtered only to those that ran in the last run.
-		const actualResults = (await makeTextTree(helloWorldTestTreeFile, extApi.testTreeProvider, { onlyActive: true })).join("\n");
+		const actualResults = (await makeTestTextTree(helloWorldTestTreeFile, { onlyActive: true })).join("\n");
 		assert.equal(actualResults, expectedResults);
 	});
 
@@ -418,7 +418,7 @@ test/tree_test.dart [8/11 passed, {duration}ms] (fail.svg)
 			// Get the expected tree and filter it to only failed tests.
 			const expectedResults = getExpectedResults().split("\n").filter((l) => l.includes("fail.svg")).join("\n");
 			// Get the actual tree, filtered only to those that ran in the last run.
-			const actualResults = (await makeTextTree(file, extApi.testTreeProvider, { onlyActive: true })).join("\n");
+			const actualResults = (await makeTestTextTree(file, { onlyActive: true })).join("\n");
 			assert.equal(actualResults, expectedResults);
 		}
 	});
@@ -435,7 +435,7 @@ test/tree_test.dart [8/11 passed, {duration}ms] (fail.svg)
 
 		// First ensure the full results appear.
 		let expectedResults = getExpectedResults();
-		let actualResults = (await makeTextTree(helloWorldTestTreeFile, extApi.testTreeProvider)).join("\n");
+		let actualResults = (await makeTestTextTree(helloWorldTestTreeFile)).join("\n");
 		assert.ok(actualResults);
 		assert.equal(actualResults, expectedResults);
 
@@ -456,7 +456,7 @@ test/tree_test.dart [4/6 passed, {duration}ms] (fail.svg)
     passing group 3 [1/1 passed, {duration}ms] (pass.svg)
         passing test 1 [{duration}ms] (pass.svg)
 		`.trim();
-		actualResults = (await makeTextTree(helloWorldTestTreeFile, extApi.testTreeProvider)).join("\n");
+		actualResults = (await makeTestTextTree(helloWorldTestTreeFile)).join("\n");
 		assert.ok(actualResults);
 		assert.equal(actualResults, expectedResults);
 	});

--- a/src/test/dart_debug_client.ts
+++ b/src/test/dart_debug_client.ts
@@ -78,7 +78,7 @@ export class DartDebugClient extends DebugClient {
 		// debug session.
 		if (testCoordinator) {
 			this.on("dart.testRunNotification", (e: DebugSessionCustomEvent) => testCoordinator.handleDebugSessionCustomEvent(e));
-			this.on("terminated", (e: DebugProtocol.TerminatedEvent) => testCoordinator.handleDebugSessionEnd(this.currentSession!.id));
+			this.on("terminated", (e: DebugProtocol.TerminatedEvent) => testCoordinator.handleDebugSessionEnd(this.currentSession!.id, this.currentSession!.configuration.dartCodeDebugSessionID));
 		}
 	}
 

--- a/src/test/dart_debug_client.ts
+++ b/src/test/dart_debug_client.ts
@@ -77,7 +77,7 @@ export class DartDebugClient extends DebugClient {
 		// it as it won't receive the events normally because this is not a Code-spawned
 		// debug session.
 		if (testCoordinator) {
-			this.on("dart.testRunNotification", (e: DebugSessionCustomEvent) => testCoordinator.handleDebugSessionCustomEvent(e));
+			this.on("dart.testRunNotification", (e: DebugSessionCustomEvent) => testCoordinator.handleDebugSessionCustomEvent(this.currentSession!.id, this.currentSession!.configuration.dartCodeDebugSessionID, e.event, e.body));
 			this.on("terminated", (e: DebugProtocol.TerminatedEvent) => testCoordinator.handleDebugSessionEnd(this.currentSession!.id, this.currentSession!.configuration.dartCodeDebugSessionID));
 		}
 	}

--- a/src/test/flutter/views/flutter_outline.test.ts
+++ b/src/test/flutter/views/flutter_outline.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "assert";
 import { waitFor } from "../../../shared/utils/promises";
-import { activate, extApi, flutterHelloWorldOutlineFile, getExpectedResults, getPackages, makeTextTree, openFile, waitForResult } from "../../helpers";
+import { activate, extApi, flutterHelloWorldOutlineFile, getExpectedResults, getPackages, makeTextTreeUsingCustomTree, openFile, waitForResult } from "../../helpers";
 
 describe("flutter_outline", () => {
 	// We have tests that require external packages.
@@ -20,7 +20,7 @@ describe("flutter_outline", () => {
 		});
 
 		const expectedResults = getExpectedResults();
-		const actualResults = (await makeTextTree(undefined, extApi.flutterOutlineTreeProvider)).join("\n");
+		const actualResults = (await makeTextTreeUsingCustomTree(undefined, extApi.flutterOutlineTreeProvider)).join("\n");
 
 		assert.ok(expectedResults, "Expected results were empty");
 		assert.ok(actualResults, "Actual results were empty");

--- a/src/test/flutter_test_debug/debug/flutter_test.test.ts
+++ b/src/test/flutter_test_debug/debug/flutter_test.test.ts
@@ -7,7 +7,7 @@ import { fsPath } from "../../../shared/utils/fs";
 import { waitFor } from "../../../shared/utils/promises";
 import { DartDebugClient } from "../../dart_debug_client";
 import { createDebugClient, killFlutterTester, startDebugger, waitAllThrowIfTerminates } from "../../debug_helpers";
-import { activate, captureDebugSessionCustomEvents, deferUntilLast, ensureArrayContainsArray, extApi, flutterHelloWorldCounterAppFile, flutterHelloWorldFolder, flutterIntegrationTestFile, flutterTestAnotherFile, flutterTestBrokenFile, flutterTestDriverAppFile, flutterTestDriverTestFile, flutterTestMainFile, flutterTestOtherFile, getCodeLens, getExpectedResults, getResolvedDebugConfiguration, makeTextTree, openFile, positionOf, setConfigForTest, waitForResult, watchPromise } from "../../helpers";
+import { activate, captureDebugSessionCustomEvents, deferUntilLast, ensureArrayContainsArray, extApi, flutterHelloWorldCounterAppFile, flutterHelloWorldFolder, flutterIntegrationTestFile, flutterTestAnotherFile, flutterTestBrokenFile, flutterTestDriverAppFile, flutterTestDriverTestFile, flutterTestMainFile, flutterTestOtherFile, getCodeLens, getExpectedResults, getResolvedDebugConfiguration, makeTestTextTree, openFile, positionOf, setConfigForTest, waitForResult, watchPromise } from "../../helpers";
 
 describe("flutter test debugger", () => {
 	beforeEach("activate flutterTestMainFile", () => activate(flutterTestMainFile));
@@ -238,7 +238,7 @@ describe("flutter test debugger", () => {
 		for (const file of testFiles) {
 			await openFile(file);
 			const expectedResults = getExpectedResults();
-			const actualResults = (await makeTextTree(file, extApi.testTreeProvider)).join("\n");
+			const actualResults = (await makeTestTextTree(file)).join("\n");
 
 			assert.ok(expectedResults);
 			assert.ok(actualResults);
@@ -395,7 +395,7 @@ test/widget_test.dart [2/2 passed, {duration}ms] (pass.svg)
 		`.trim();
 
 		// Get the actual tree, filtered only to those that ran in the last run.
-		const actualResults = (await makeTextTree(flutterTestMainFile, extApi.testTreeProvider, { onlyActive: true })).join("\n");
+		const actualResults = (await makeTestTextTree(flutterTestMainFile, { onlyActive: true })).join("\n");
 		assert.equal(actualResults, expectedResults);
 	});
 });

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -1086,7 +1086,18 @@ export function renderedItemLabel(item: vs.TreeItem): string {
 	return treeLabel(item) || path.basename(fsPath(item.resourceUri!));
 }
 
-export async function makeTextTree(parent: TreeNode | vs.Uri | undefined, provider: vs.TreeDataProvider<TreeNode>, { buffer = [], indent = 0, onlyFailures, onlyActive }: { buffer?: string[]; indent?: number, onlyFailures?: boolean, onlyActive?: boolean } = {}): Promise<string[]> {
+export async function makeTestTextTree(parent: TreeNode | vs.Uri | undefined, { buffer = [], indent = 0, onlyFailures, onlyActive }: { buffer?: string[]; indent?: number, onlyFailures?: boolean, onlyActive?: boolean } = {}): Promise<string[]> {
+	const result = vs.workspace.getConfiguration("dart").get("previewVsCodeTestRunner")
+		? await makeTextTreeUsingVsCodeTestController(parent, { buffer, indent, onlyFailures, onlyActive })
+		: await makeTextTreeUsingCustomTree(parent, extApi.testTreeProvider, { buffer, indent, onlyFailures, onlyActive });
+	return buffer;
+}
+
+export async function makeTextTreeUsingVsCodeTestController(parent: TreeNode | vs.Uri | undefined, { buffer = [], indent = 0, onlyFailures, onlyActive }: { buffer?: string[]; indent?: number, onlyFailures?: boolean, onlyActive?: boolean } = {}): Promise<string[]> {
+	throw Error("err");
+}
+
+export async function makeTextTreeUsingCustomTree(parent: TreeNode | vs.Uri | undefined, provider: vs.TreeDataProvider<TreeNode>, { buffer = [], indent = 0, onlyFailures, onlyActive }: { buffer?: string[]; indent?: number, onlyFailures?: boolean, onlyActive?: boolean } = {}): Promise<string[]> {
 	const parentNode = parent instanceof vs.Uri ? undefined : parent;
 	const parentResourceUri = parent instanceof vs.Uri ? parent : undefined;
 
@@ -1124,7 +1135,7 @@ export async function makeTextTree(parent: TreeNode | vs.Uri | undefined, provid
 			includeNode = false;
 		if (includeNode)
 			buffer.push(`${" ".repeat(indent * 4)}${expectedLabel}${expectedDesc} (${iconFile})`);
-		await makeTextTree(item, provider, { buffer, indent: indent + 1, onlyFailures, onlyActive });
+		await makeTestTextTree(item, { buffer, indent: indent + 1, onlyFailures, onlyActive });
 	}
 	return buffer;
 }

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -1135,7 +1135,7 @@ export async function makeTextTreeUsingCustomTree(parent: TreeNode | vs.Uri | un
 			includeNode = false;
 		if (includeNode)
 			buffer.push(`${" ".repeat(indent * 4)}${expectedLabel}${expectedDesc} (${iconFile})`);
-		await makeTestTextTree(item, { buffer, indent: indent + 1, onlyFailures, onlyActive });
+		await makeTextTreeUsingCustomTree(item, provider, { buffer, indent: indent + 1, onlyFailures, onlyActive });
 	}
 	return buffer;
 }


### PR DESCRIPTION
Currently behind a preview flag.

- [ ] ~Needs tests (should be able to test the data in the `controller.items`)~ to tackle in #3537

Fixes #3147.