### PR TITLE
Replace 'dart:' prefix when calling setBreakpoints

### DIFF
--- a/src/debug/dart_debug_impl.ts
+++ b/src/debug/dart_debug_impl.ts
@@ -870,7 +870,13 @@ export class DartDebugSession extends DebugSession {
 		// Format the path correctly for the VM.
 		// TODO: The `|| source.name` stops a crash (#1566) but doesn't actually make
 		// the breakpoints work. This needs more work.
-		const uri = formatPathForVm(source.path || source.name!);
+		let uri = formatPathForVm(source.path || source.name!);
+
+		// Replace 'dart:' prefix to satisfy VMService lookup code (#3551)
+		// https://github.com/Dart-Code/Dart-Code/issues/3551
+		if (uri.startsWith("dart:")) {
+			uri = uri.replace("dart:", "/");
+		}
 
 		try {
 			const result = await this.threadManager.setBreakpoints(uri, breakpoints);

--- a/src/test/dart_debug/debug/dart_cli.test.ts
+++ b/src/test/dart_debug/debug/dart_cli.test.ts
@@ -302,6 +302,22 @@ describe("dart cli debugger", () => {
 		assert.equal(frames[0].source!.name, "dart:core/print.dart");
 	});
 
+	// Doesn't work for Dart app, works for Flutter app
+	// https://github.com/Dart-Code/Dart-Code/issues/3551
+	it.skip("stops at a breakpoint with 'dart:core/' prefix", async () => {
+		await openFile(helloWorldMainFile);
+		const config = await startDebugger(dc, helloWorldMainFile);
+		await dc.hitBreakpoint(
+			config,
+			{line: 11, path: "dart:core/print.dart"},
+			{line: 11}, // source.path not returned for SDK file
+		);
+		const stack = await dc.getStack();
+		const frames = stack.body.stackFrames;
+		assert.equal(frames[0].name, "print");
+		assert.equal(frames[0].source!.name, "dart:core/print.dart");
+	});
+
 	it("stops at a breakpoint in an external package", async () => {
 		await openFile(helloWorldHttpFile);
 		// Get location for `http.read`

--- a/src/test/flutter_debug/debug/flutter_run.test.ts
+++ b/src/test/flutter_debug/debug/flutter_run.test.ts
@@ -616,6 +616,24 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 	// Known not to work; https://github.com/Dart-Code/Dart-Code/issues/821
 	it.skip("stops at a breakpoint in the SDK");
 
+	it("stops at a breakpoint with 'dart:core/' prefix", async function() {
+		if (flutterTestDeviceIsWeb)
+			return this.skip();
+
+		await openFile(flutterHelloWorldMainFile);
+		const config = await startDebugger(dc, flutterHelloWorldMainFile, { debugSdkLibraries: true });
+		await dc.hitBreakpoint(
+			config,
+			{line: 11, path: "dart:core/print.dart"},
+			{line: 11}, // source.path not returned for SDK file
+		);
+
+		await waitAllThrowIfTerminates(dc,
+			dc.waitForEvent("terminated"),
+			dc.terminateRequest(),
+		);
+	});
+
 	it("stops at a breakpoint in an external package");
 
 	it("steps into the SDK if debugSdkLibraries is true", async function () {


### PR DESCRIPTION
A hack that enables putting breakpoints in SDK Code, see #3551 