### PR TITLE
style: add return type of main

### DIFF
--- a/snippets/dart.json
+++ b/snippets/dart.json
@@ -4,7 +4,7 @@
 			"prefix": "main",
 			"description": "Insert a main function, used as an entry point.",
 			"body": [
-				"main(List<String> args) {",
+				"void main(List<String> args) {",
 				"  $0",
 				"}"
 			]


### PR DESCRIPTION
This could be subjective, but I think it's good to have a return type on every function. Every time I use the `main` snippet I find myself writing void anyway. You could also argue that I could make my own snippet, and that's true. But because dart is typed after all and `fun` uses void, why not?