### PR TITLE
Subscribe to navigation events on open files

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -332,7 +332,7 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 		context.subscriptions.push(new LspClosingLabelsDecorations(lspClient));
 
 	const completionItemProvider = isUsingLsp || !dasClient ? undefined : new DartCompletionItemProvider(logger, dasClient);
-	const referenceProvider = isUsingLsp || !dasClient ? undefined : new DartReferenceProvider(dasClient);
+	const referenceProvider = isUsingLsp || !dasClient || !dasAnalyzer ? undefined : new DartReferenceProvider(dasClient, dasAnalyzer.fileTracker);
 
 	const activeFileFilters: vs.DocumentFilter[] = [DART_MODE];
 


### PR DESCRIPTION
Use that to navigate if available, otherwise fall back to requesting navigation directly from the analysis server.