### PR TITLE
Remove workspaceConfig from DA, simplifying use of custom tools

### DIFF
--- a/src/debug/flutter_debug_impl.ts
+++ b/src/debug/flutter_debug_impl.ts
@@ -206,9 +206,9 @@ export class FlutterDebugSession extends DartDebugSession {
 			appArgs = appArgs.concat(args.toolArgs);
 
 		if (!isAttach || args.program) {
-			if (!args.workspaceConfig?.skipTargetFlag)
+			if (!args.omitTargetFlag)
 				appArgs.push("--target");
-			if (!!args.workspaceConfig?.nonMainTargetPrefix && args.program!.startsWith(args.workspaceConfig?.nonMainTargetPrefix)) {
+			if (args.program!.startsWith("//")) {
 				appArgs.push(args.program!);
 			} else {
 				appArgs.push(this.sourceFileForArgs(args));
@@ -218,7 +218,11 @@ export class FlutterDebugSession extends DartDebugSession {
 		if (args.args)
 			appArgs = appArgs.concat(args.args);
 
-		return new FlutterRun(isAttach ? RunMode.Attach : RunMode.Run, this.dartCapabilities, args.flutterSdkPath!, args.workspaceConfig, args.cwd, appArgs, { envOverrides: args.env, toolEnv: this.toolEnv }, args.flutterRunLogFile, logger, (url) => this.exposeUrl(url), this.maxLogLineLength);
+		const customTool = {
+			replacesArgs: args.customToolReplacesArgs,
+			script: args.customTool,
+		};
+		return new FlutterRun(isAttach ? RunMode.Attach : RunMode.Run, this.dartCapabilities, args.flutterSdkPath!, customTool, args.cwd, appArgs, { envOverrides: args.env, toolEnv: this.toolEnv }, args.flutterRunLogFile, logger, (url) => this.exposeUrl(url), this.maxLogLineLength);
 	}
 
 	private async connectToVmServiceIfReady() {

--- a/src/debug/flutter_run.ts
+++ b/src/debug/flutter_run.ts
@@ -2,13 +2,13 @@ import * as path from "path";
 import { DartCapabilities } from "../shared/capabilities/dart";
 import { flutterPath } from "../shared/constants";
 import { LogCategory } from "../shared/enums";
-import { Logger, WorkspaceConfig } from "../shared/interfaces";
+import { CustomScript, Logger } from "../shared/interfaces";
 import { CategoryLogger } from "../shared/logging";
 import { usingCustomScript } from "../shared/utils";
 import { RunDaemonBase, RunMode } from "./run_daemon_base";
 
 export class FlutterRun extends RunDaemonBase {
-	constructor(mode: RunMode, dartCapabilties: DartCapabilities, flutterSdkPath: string, wsConfig: WorkspaceConfig | undefined, projectFolder: string | undefined, args: string[], env: { envOverrides?: { [key: string]: string | undefined }, toolEnv: any }, logFile: string | undefined, logger: Logger, urlExposer: (url: string) => Promise<{ url: string }>, maxLogLineLength: number) {
+	constructor(mode: RunMode, dartCapabilties: DartCapabilities, flutterSdkPath: string, customTool: CustomScript | undefined, projectFolder: string | undefined, args: string[], env: { envOverrides?: { [key: string]: string | undefined }, toolEnv: any }, logFile: string | undefined, logger: Logger, urlExposer: (url: string) => Promise<{ url: string }>, maxLogLineLength: number) {
 		super(mode, dartCapabilties, logFile, new CategoryLogger(logger, LogCategory.FlutterRun), urlExposer, maxLogLineLength, true, true);
 
 		const command = mode === RunMode.Attach ? "attach" : "run";
@@ -16,7 +16,7 @@ export class FlutterRun extends RunDaemonBase {
 		const execution = usingCustomScript(
 			path.join(flutterSdkPath, flutterPath),
 			[command, "--machine"],
-			mode === RunMode.Run ? wsConfig?.flutterRunScript || wsConfig?.flutterScript : undefined ,
+			customTool,
 		);
 
 		this.createProcess(projectFolder, execution.executable, execution.args.concat(args), env);

--- a/src/debug/flutter_test_debug_impl.ts
+++ b/src/debug/flutter_test_debug_impl.ts
@@ -30,7 +30,10 @@ export class FlutterTestDebugSession extends DartTestDebugSession {
 		const execution = usingCustomScript(
 			path.join(args.flutterSdkPath!, flutterPath),
 			["test", "--machine"],
-			args.workspaceConfig?.flutterTestScript || args.workspaceConfig?.flutterScript,
+			{
+				replacesArgs: args.customToolReplacesArgs,
+				script: args.customTool,
+			}
 		);
 
 		const logger = new DebugAdapterLogger(this, LogCategory.FlutterTest);

--- a/src/extension/commands/flutter.ts
+++ b/src/extension/commands/flutter.ts
@@ -116,7 +116,7 @@ export class FlutterCommands extends BaseSdkCommands {
 		const tempDir = path.join(os.tmpdir(), "dart-code-cmd-run");
 		if (!fs.existsSync(tempDir))
 			fs.mkdirSync(tempDir);
-		return this.runFlutterInFolder(tempDir, ["doctor", "-v"], "flutter", true, this.workspace.config?.flutterDoctorScript || this.workspace.config?.flutterScript);
+		return this.runFlutterInFolder(tempDir, ["doctor", "-v"], "flutter", true, this.workspace.config?.flutterDoctorScript);
 	}
 
 	private async flutterUpgrade() {

--- a/src/extension/flutter/flutter_daemon.ts
+++ b/src/extension/flutter/flutter_daemon.ts
@@ -47,7 +47,7 @@ export class FlutterDaemon extends StdIOService<UnknownNotification> implements 
 		const execution = usingCustomScript(
 			path.join(workspaceContext.sdks.flutter, flutterPath),
 			["daemon"].concat(daemonArgs),
-			workspaceContext.config?.flutterDaemonScript || workspaceContext.config?.flutterScript,
+			workspaceContext.config?.flutterDaemonScript,
 		);
 
 		const flutterAdditionalArgs = config.for(vs.Uri.file(folder)).flutterAdditionalArgs;

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -524,8 +524,15 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 
 		if (isFlutter && this.wsContext.sdks.flutter) {
 			debugConfig.flutterSdkPath = this.wsContext.sdks.flutter;
+			debugConfig.omitTargetFlag = this.wsContext.config.omitTargetFlag;
 			debugConfig.useInspectorNotificationsForWidgetErrors = config.showInspectorNotificationsForWidgetErrors;
-			debugConfig.workspaceConfig = this.wsContext.config;
+			if (!isAttach) {
+				const customScript = isTest
+					? this.wsContext.config.flutterTestScript
+					: this.wsContext.config.flutterRunScript;
+				debugConfig.customTool = customScript?.script;
+				debugConfig.customToolReplacesArgs = customScript?.replacesArgs;
+			}
 			debugConfig.flutterRunLogFile = this.insertSessionName(debugConfig, debugConfig.flutterRunLogFile || conf.flutterRunLogFile);
 			debugConfig.flutterTestLogFile = this.insertSessionName(debugConfig, debugConfig.flutterTestLogFile || conf.flutterTestLogFile);
 			debugConfig.showMemoryUsage =

--- a/src/shared/debug/interfaces.ts
+++ b/src/shared/debug/interfaces.ts
@@ -1,10 +1,11 @@
-import { WorkspaceConfig } from "../interfaces";
 
 /// Launch arguments that are passed to (and understood by) the debug adapters.
 export interface DartLaunchArgs {
 	additionalProjectPaths?: string[];
 	args?: string[];
 	console?: "debugConsole" | "terminal" | "externalTerminal";
+	customTool?: string,
+	customToolReplacesArgs?: number,
 	cwd?: string;
 	dartSdkPath: string;
 	debugExternalPackageLibraries: boolean;
@@ -21,6 +22,7 @@ export interface DartLaunchArgs {
 	name: string;
 	noDebug?: boolean;
 	observatoryUri?: string; // For backwards compatibility
+	omitTargetFlag?: boolean; // Flutter Bazel
 	packages?: string;
 	program?: string;
 	pubTestLogFile?: string;
@@ -37,7 +39,6 @@ export interface DartLaunchArgs {
 	vmServicePort?: number;
 	vmServiceUri?: string;
 	webDaemonLogFile?: string;
-	workspaceConfig?: WorkspaceConfig;
 }
 
 /// Launch arguments that are valid in launch.json and map be mapped into

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -48,7 +48,6 @@ export interface WritableWorkspaceConfig {
 	flutterDaemonScript?: CustomScript;
 	flutterDoctorScript?: CustomScript;
 	flutterRunScript?: CustomScript;
-	flutterScript?: CustomScript;
 	flutterSdkHome?: string;
 	flutterSyncScript?: string;
 	flutterTestScript?: CustomScript;
@@ -58,14 +57,13 @@ export interface WritableWorkspaceConfig {
 	forceFlutterWorkspace?: boolean;
 	forceFlutterDebug?: boolean;
 	skipFlutterInitialization?: boolean;
-	skipTargetFlag?: boolean;
-	nonMainTargetPrefix?: string;
+	omitTargetFlag?: boolean;
 }
 
 export type WorkspaceConfig = Readonly<WritableWorkspaceConfig>;
 export interface CustomScript {
-	script: string;
-	replacesArgs: number;
+	script: string | undefined;
+	replacesArgs: number | undefined;
 }
 
 export interface DartProjectTemplate {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -120,9 +120,10 @@ export function isStableSdk(sdkVersion?: string): boolean {
 }
 
 export function usingCustomScript(binPath: string, binArgs: string[], customScript: CustomScript | undefined): ExecutionInfo {
-	if (customScript) {
+	if (customScript?.script) {
 		binPath = customScript.script;
-		binArgs = binArgs.slice(customScript.replacesArgs);
+		if (customScript.replacesArgs)
+			binArgs = binArgs.slice(customScript.replacesArgs);
 	}
 
 	return { executable: binPath, args: binArgs };

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -57,10 +57,9 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 		config.forceFlutterWorkspace = true;
 		config.forceFlutterDebug = true;
 		config.skipFlutterInitialization = true;
-		config.skipTargetFlag = true;
+		config.omitTargetFlag = true;
 		config.startDevToolsServerEagerly = true;
 		config.startDevToolsFromDaemon = true;
-		config.nonMainTargetPrefix = "//";
 		config.flutterVersion = MAX_VERSION;
 		config.flutterDaemonScript = makeScript(flutterConfig.daemonScript);
 		config.flutterDoctorScript = makeScript(flutterConfig.doctorScript);

--- a/src/test/flutter_bazel/extension.test.ts
+++ b/src/test/flutter_bazel/extension.test.ts
@@ -42,10 +42,9 @@ describe("extension", () => {
 		assert.equal(workspaceContext.config?.forceFlutterWorkspace, true);
 		assert.equal(workspaceContext.config?.forceFlutterDebug, true);
 		assert.equal(workspaceContext.config?.skipFlutterInitialization, true);
-		assert.equal(workspaceContext.config?.skipTargetFlag, true);
+		assert.equal(workspaceContext.config?.omitTargetFlag, true);
 		assert.equal(workspaceContext.config?.startDevToolsServerEagerly, true);
 		assert.equal(workspaceContext.config?.startDevToolsFromDaemon, true);
-		assert.equal(workspaceContext.config?.nonMainTargetPrefix, "//");
 		assert.deepStrictEqual(workspaceContext.config?.flutterDaemonScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_daemon.sh"), replacesArgs: 1 });
 		assert.deepStrictEqual(workspaceContext.config?.flutterDoctorScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_doctor.sh"), replacesArgs: 1 });
 		assert.deepStrictEqual(workspaceContext.config?.flutterRunScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_run.sh"), replacesArgs: 1 });

--- a/src/test/flutter_snap/extension.test.ts
+++ b/src/test/flutter_snap/extension.test.ts
@@ -33,8 +33,6 @@ describe("extension", () => {
 		assert.ok(workspaceContext.sdks.dart);
 		assert.equal(workspaceContext.sdks.flutter, `${path.join(os.homedir(), "/snap/flutter/common/flutter")}`);
 		assert.equal(workspaceContext.sdks.dart, `${path.join(os.homedir(), "/snap/flutter/common/flutter/bin/cache/dart-sdk")}`);
-		assert.ok(workspaceContext.config);
-		assert.equal(workspaceContext.config?.flutterScript, undefined);
 		logger.info("        " + JSON.stringify(workspaceContext, undefined, 8).trim().slice(1, -1).trim());
 	});
 });


### PR DESCRIPTION
The goal here is to push some of this complex logic back into the editor and out of the debug adapter. The reason for this is that the debug adapters are moving to the SDK and will be reused by other editors so I'd like to keep the interface/args to them as simple/generic as possible.

@helin24 this refactors some of the Bazel work slightly, moving some things out of the adapters (in `./debug/`) into the configuration created by the client (`debug_config_provider`) - mostly removing the `workspaceConfig` that was previously passed through for some simpler (flat) fields in `args`.

- `wsConfig.skipTargetFlag` -> `omitTargetFlag`
- `wsConfig.flutterXxxScript` -> `customTool` + `customToolReplacesArgs`
- remove `wsConfig.flutterScript` (was unused) 
- remove `wsConfig. nonMainTargetPrefix` and just always skip making paths relative if they start with `//` (it doesn't seem like these needs to be configurable so would like to avoid having to mirror this in the SDK DAP config)

The Bazel tests still pass, though I don't know how reflective of real world that is, so if you're able to test/confirm everything is good from source, that would help (I may merge this in the meantime if it's green so I can continue work on top of it - just let me know if there are issues).