### PR TITLE
Add open in Xcode for macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1143,7 +1143,7 @@
 				},
 				{
 					"command": "flutter.openInXcode",
-					"when": "explorerResourceIsFolder && resourceFilename == ios && dart-code:anyFlutterProjectLoaded && dart-code:dartPlatformName == mac && dart-code:isRunningLocally",
+					"when": "explorerResourceIsFolder && resourceFilename == ios || resourceFilename == macos && dart-code:anyFlutterProjectLoaded && dart-code:dartPlatformName == mac && dart-code:isRunningLocally",
 					"group": "1.5_open_ext@1"
 				},
 				{

--- a/src/extension/commands/open_in_other_editors.ts
+++ b/src/extension/commands/open_in_other_editors.ts
@@ -53,7 +53,8 @@ export class OpenInOtherEditorCommands implements vs.Disposable {
 			.sort((f1, f2) => f1.name.endsWith(".xcworkspace") ? -1 : 1);
 
 		if (!files || !files.length) {
-			vs.window.showErrorMessage(`Unable to find an Xcode project in your 'ios' folder`);
+			const basename = path.basename(folder);
+			vs.window.showErrorMessage(`Unable to find an Xcode project in your '${basename}' folder`);
 			return;
 		}
 


### PR DESCRIPTION
Allows the `flutter.openInXcode` command on `macos` folders as well as `ios`.

<img width="285" alt="Screenshot 2022-02-06 at 11 30 06" src="https://user-images.githubusercontent.com/756862/152675072-7c98dff0-7e72-4691-a322-2b8d9fb26fe8.png">




Closes Dart-Code/Dart-Code#3817