### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,6 +11,8 @@ jobs:
 
   build_exclusions:
 
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     outputs:
       excludes: ${{ join(steps.*.outputs.excludes) }}
@@ -220,6 +222,8 @@ jobs:
 
   notify_failure:
 
+    permissions:
+      contents: none
     name: Notify Discord of Failure
     needs: build
     if: failure() && github.event_name == 'push'

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -4,6 +4,9 @@ on:
   schedule:
      - cron: '0 7 * * 1-5'
 
+permissions:
+  contents: read
+
 jobs:
 
   build:
@@ -55,6 +58,8 @@ jobs:
 
   notify_failure:
 
+    permissions:
+      contents: none
     name: Notify Discord of Failure
     needs: build
     if: failure()

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,8 +4,14 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v3


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
