### PR TITLE
Migrate to super-initializer parameters

### DIFF
--- a/snippets/flutter.json
+++ b/snippets/flutter.json
@@ -5,7 +5,7 @@
 			"description": "Insert a StatelessWidget",
 			"body": [
 				"class $1 extends StatelessWidget {",
-				"  const $1({ Key? key }) : super(key: key);",
+				"  const $1({super.key});",
 				"",
 				"  @override",
 				"  Widget build(BuildContext context) {",
@@ -21,7 +21,7 @@
 			"description": "Insert a StatefulWidget",
 			"body": [
 				"class $1 extends StatefulWidget {",
-				"  const $1({ Key? key }) : super(key: key);",
+				"  const $1({super.key});",
 				"",
 				"  @override",
 				"  State<$1> createState() => _$1State();",
@@ -42,7 +42,7 @@
 			"description": "Insert a StatefulWidget with an AnimationController",
 			"body": [
 				"class $1 extends StatefulWidget {",
-				"  const $1({ Key? key }) : super(key: key);",
+				"  const $1({super.key});",
 				"",
 				"  @override",
 				"  State<$1> createState() => _$1State();",

--- a/src/test/flutter/refactors/extract_widget.test.ts
+++ b/src/test/flutter/refactors/extract_widget.test.ts
@@ -36,8 +36,8 @@ class MyWidget extends StatelessWidget {
 
 class MyNewWidget extends StatelessWidget {
   const MyNewWidget({
-    Key? key,
-  }) : super(key: key);
+  	super.key,
+    });
 
   @override
   Widget build(BuildContext context) {
@@ -165,9 +165,9 @@ class MyWidget extends StatelessWidget {
 }
 
 class MyWidget extends StatelessWidget {
-  const MyWidget({
-    Key? key,
-  }) : super(key: key);
+  const MyNewWidget({
+  	super.key,
+    });
 
   @override
   Widget build(BuildContext context) {

--- a/src/test/test_projects/bazel_workspace/flutter_hello_world_bazel/lib/main.dart
+++ b/src/test/test_projects/bazel_workspace/flutter_hello_world_bazel/lib/main.dart
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  MyHomePage({Key? key}) : super(key: key);
+  MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/src/test/test_projects/flutter_hello_world/lib/broken.dart
+++ b/src/test/test_projects/flutter_hello_world/lib/broken.dart
@@ -14,7 +14,7 @@ class MyBrokenApp extends StatelessWidget {
 }
 
 class MyBrokenHomePage extends StatelessWidget {
-  MyBrokenHomePage({Key? key}) : super(key: key);
+  MyBrokenHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/src/test/test_projects/flutter_hello_world/lib/counter.dart
+++ b/src/test/test_projects/flutter_hello_world/lib/counter.dart
@@ -13,7 +13,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key? key, required this.title}) : super(key: key);
+  MyHomePage({super.key, required this.title});
 
   final String title;
 

--- a/src/test/test_projects/flutter_hello_world/lib/getters.dart
+++ b/src/test/test_projects/flutter_hello_world/lib/getters.dart
@@ -30,7 +30,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  MyHomePage({Key? key}) : super(key: key);
+  MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/src/test/test_projects/flutter_hello_world/lib/http.dart
+++ b/src/test/test_projects/flutter_hello_world/lib/http.dart
@@ -21,7 +21,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  MyHomePage({Key? key}) : super(key: key);
+  MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/src/test/test_projects/flutter_hello_world/lib/local_package.dart
+++ b/src/test/test_projects/flutter_hello_world/lib/local_package.dart
@@ -19,7 +19,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  MyHomePage({Key? key}) : super(key: key);
+  MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/src/test/test_projects/flutter_hello_world/lib/main.dart
+++ b/src/test/test_projects/flutter_hello_world/lib/main.dart
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  MyHomePage({Key? key}) : super(key: key);
+  MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/src/test/test_projects/flutter_hello_world/lib/stack60.dart
+++ b/src/test/test_projects/flutter_hello_world/lib/stack60.dart
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  MyHomePage({Key? key}) : super(key: key);
+  MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/src/test/test_projects/flutter_hello_world/lib/throw_in_external_package.dart
+++ b/src/test/test_projects/flutter_hello_world/lib/throw_in_external_package.dart
@@ -21,7 +21,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  MyHomePage({Key? key}) : super(key: key);
+  MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/src/test/test_projects/flutter_hello_world/lib/throw_in_local_package.dart
+++ b/src/test/test_projects/flutter_hello_world/lib/throw_in_local_package.dart
@@ -19,7 +19,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  MyHomePage({Key? key}) : super(key: key);
+  MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/src/test/test_projects/flutter_hello_world/lib/throw_in_sdk_code.dart
+++ b/src/test/test_projects/flutter_hello_world/lib/throw_in_sdk_code.dart
@@ -18,7 +18,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  MyHomePage({Key? key}) : super(key: key);
+  MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Dart 2.17 now supports [super-initializer parameters](https://dart.dev/guides/language/language-tour#super-parameters). 
```dart
  const HomePage({
    Key? key,
  }) : super(key: key);
```
becomes
```dart
  const HomePage({super.key});
```
This will help reduce boilerplate.