### PR TITLE
Nest `pubspec_overrides.yaml` under `pubspec.yaml`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1331,7 +1331,7 @@
 				"**/.dart_tool": true
 			},
 			"explorer.fileNesting.patterns": {
-				"pubspec.yaml": "pubspec.lock,.packages,.flutter-plugins,.flutter-plugins-dependencies,.metadata",
+				"pubspec.yaml": "pubspec.lock,pubspec_overrides.yaml,.packages,.flutter-plugins,.flutter-plugins-dependencies,.metadata",
 				"*.dart": "${capture}.g.dart"
 			}
 		},


### PR DESCRIPTION
[`pubspec_overrides.yaml`](https://github.com/dart-lang/pub/commit/7a6ea3964c4f11e611da3d8542f34c06731bdc37) is a relatively new file that is recognized by `pub`. At the moment only `dependency_overrides` can be overriden from `pubspec_overrides.yaml`. Usually this file is generated by a tool to override dependencies during development.