### PR TITLE
Use empty folder path for bazel workspaces during device check

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -259,7 +259,7 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 	// Fire up Flutter daemon if required.
 	if (workspaceContext.hasAnyFlutterProjects && sdks.flutter) {
 		flutterDaemon = new FlutterDaemon(logger, workspaceContext as FlutterWorkspaceContext, flutterCapabilities);
-		deviceManager = new FlutterDeviceManager(logger, flutterDaemon, config);
+		deviceManager = new FlutterDeviceManager(logger, flutterDaemon, config, workspaceContext);
 
 		context.subscriptions.push(deviceManager);
 		context.subscriptions.push(flutterDaemon);

--- a/src/shared/vscode/device_manager.ts
+++ b/src/shared/vscode/device_manager.ts
@@ -289,6 +289,7 @@ export class FlutterDeviceManager implements vs.Disposable {
 		}
 
 		this.shortCacheForSupportedPlatforms = new Promise(async (resolve) => {
+			// An internal workspace that we assume to be Flutter will not generate project folders, but the daemon will respond to an empty path.
 			const projectFolders = this.workspaceContext.config.forceFlutterWorkspace ? [""] : await getAllProjectFolders(this.logger, undefined, { requirePubspec: true, searchDepth: this.config.projectSearchDepth });
 			this.logger.info(`Checking ${projectFolders.length} projects for supported platforms`);
 

--- a/src/shared/vscode/device_manager.ts
+++ b/src/shared/vscode/device_manager.ts
@@ -9,6 +9,7 @@ import { logProcess } from "../logging";
 import { safeSpawn } from "../processes";
 import { unique } from "../utils/array";
 import { resolveTildePaths } from "../utils/fs";
+import { WorkspaceContext } from "../workspace";
 import { isRunningLocally } from "./utils";
 
 export class FlutterDeviceManager implements vs.Disposable {
@@ -19,7 +20,7 @@ export class FlutterDeviceManager implements vs.Disposable {
 	private emulators: Emulator[] = [];
 	private readonly knownEmulatorNames: { [key: string]: string } = {};
 
-	constructor(private readonly logger: Logger, private daemon: IFlutterDaemon, private readonly config: { flutterCustomEmulators: CustomEmulatorDefinition[], flutterSelectDeviceWhenConnected: boolean, flutterShowEmulators: "local" | "always" | "never", projectSearchDepth: number }) {
+	constructor(private readonly logger: Logger, private daemon: IFlutterDaemon, private readonly config: { flutterCustomEmulators: CustomEmulatorDefinition[], flutterSelectDeviceWhenConnected: boolean, flutterShowEmulators: "local" | "always" | "never", projectSearchDepth: number }, private readonly workspaceContext: WorkspaceContext) {
 		this.statusBarItem = vs.window.createStatusBarItem("dartStatusFlutterDevice", vs.StatusBarAlignment.Right, 1);
 		this.statusBarItem.name = "Flutter Device";
 		this.statusBarItem.tooltip = "Flutter";
@@ -288,7 +289,7 @@ export class FlutterDeviceManager implements vs.Disposable {
 		}
 
 		this.shortCacheForSupportedPlatforms = new Promise(async (resolve) => {
-			const projectFolders = await getAllProjectFolders(this.logger, undefined, { requirePubspec: true, searchDepth: this.config.projectSearchDepth });
+			const projectFolders = this.workspaceContext.config.forceFlutterWorkspace ? [""] : await getAllProjectFolders(this.logger, undefined, { requirePubspec: true, searchDepth: this.config.projectSearchDepth });
 			this.logger.info(`Checking ${projectFolders.length} projects for supported platforms`);
 
 			const getPlatformPromises = projectFolders.map((folder) => this.daemon.getSupportedPlatforms(folder));

--- a/src/test/flutter/device_manager.test.ts
+++ b/src/test/flutter/device_manager.test.ts
@@ -6,7 +6,7 @@ import * as f from "../../shared/flutter/daemon_interfaces";
 import { CustomEmulatorDefinition, IAmDisposable, IFlutterDaemon } from "../../shared/interfaces";
 import { UnknownResponse } from "../../shared/services/interfaces";
 import { FlutterDeviceManager, PickableDevice } from "../../shared/vscode/device_manager";
-import { logger, sb } from "../helpers";
+import { extApi, logger, sb } from "../helpers";
 import { FakeProcessStdIOService } from "../services/fake_stdio_service";
 import sinon = require("sinon");
 
@@ -17,7 +17,7 @@ describe("device_manager", () => {
 	beforeEach(() => {
 		daemon = new FakeFlutterDaemon();
 		// TODO: Tests for custom emulators.
-		dm = new FlutterDeviceManager(logger, daemon, { flutterCustomEmulators: customEmulators, flutterSelectDeviceWhenConnected: true, flutterShowEmulators: "local", projectSearchDepth: 3 });
+		dm = new FlutterDeviceManager(logger, daemon, { flutterCustomEmulators: customEmulators, flutterSelectDeviceWhenConnected: true, flutterShowEmulators: "local", projectSearchDepth: 3 }, extApi.workspaceContext);
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
We aren't able to find project folders for workspaces with `forceFlutterWorkspace`, but we still want to request platforms from the daemon.