### PR TITLE
Use a default Dart SDK for bazel projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -2325,7 +2325,7 @@
 					"dart.previewBazelWorkspaceCustomScripts": {
 						"type": "boolean",
 						"default": false,
-						"markdownDescription": "EXPERIMENTAL: Whether to look for custom script definitions at `dart/config/intellij-plugins/flutter.json` in Bazel workspaces. Currently supported for macOS and Linux only.",
+						"markdownDescription": "EXPERIMENTAL: Whether to look for custom script definitions at `dart/config/ide/flutter.json` in Bazel workspaces. Currently supported for macOS and Linux only.",
 						"scope": "window"
 					},
 					"dart.previewCommitCharacters": {

--- a/src/extension/sdk/utils.ts
+++ b/src/extension/sdk/utils.ts
@@ -304,13 +304,13 @@ export class SdkUtils {
 			fuchsiaRoot && path.join(fuchsiaRoot, "dart/tools/sdks", dartPlatformName, "dart-sdk"),
 			firstFlutterMobileProject && flutterSdkPath && path.join(flutterSdkPath, "bin/cache/dart-sdk"),
 			config.sdkPath,
-			workspaceConfig.defaultDartSdk,
 		].concat(paths)
 			// The above array only has the Flutter SDK	in the search path if we KNOW it's a flutter
 			// project, however this doesn't cover the activating-to-run-flutter.createProject so
 			// we need to always look in the flutter SDK, but only AFTER the users PATH so that
 			// we don't prioritise it over any real Dart versions.
 			.concat([flutterSdkPath && path.join(flutterSdkPath, "bin/cache/dart-sdk")])
+			.concat([workspaceConfig.defaultDartSdk])
 			.filter(notUndefined);
 
 		// Since we just blocked on a lot of sync FS, yield.

--- a/src/extension/sdk/utils.ts
+++ b/src/extension/sdk/utils.ts
@@ -304,6 +304,7 @@ export class SdkUtils {
 			fuchsiaRoot && path.join(fuchsiaRoot, "dart/tools/sdks", dartPlatformName, "dart-sdk"),
 			firstFlutterMobileProject && flutterSdkPath && path.join(flutterSdkPath, "bin/cache/dart-sdk"),
 			config.sdkPath,
+			workspaceConfig.defaultDartSdk,
 		].concat(paths)
 			// The above array only has the Flutter SDK	in the search path if we KNOW it's a flutter
 			// project, however this doesn't cover the activating-to-run-flutter.createProject so

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -62,6 +62,7 @@ export interface WritableWorkspaceConfig {
 	forceFlutterDebug?: boolean;
 	skipFlutterInitialization?: boolean;
 	omitTargetFlag?: boolean;
+	defaultDartSdk?: string;
 }
 
 export type WorkspaceConfig = Readonly<WritableWorkspaceConfig>;

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -39,7 +39,7 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 			devToolsScript: string | undefined;
 			doctorScript: string | undefined;
 			runScript: string | undefined;
-			sdkHome: string | undefined;
+			sdkHome: string | undefined; // Note: This refers to Flutter SDK home, not Dart.
 			syncScript: string | undefined;
 			testScript: string | undefined;
 			defaultDartSdk: string | undefined;

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -28,7 +28,7 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 		return;
 
 	try {
-		const flutterConfigPath = path.join(bazelWorkspaceRoot, "dart/config/intellij-plugins/flutter.json");
+		const flutterConfigPath = path.join(bazelWorkspaceRoot, "dart/config/ide/flutter.json");
 		if (!fs.existsSync(flutterConfigPath))
 			return;
 
@@ -42,6 +42,7 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 			sdkHome: string | undefined;
 			syncScript: string | undefined;
 			testScript: string | undefined;
+			defaultDartSdk: string | undefined;
 		};
 
 		function makeFullPath(relOrAbsolute: string | undefined): string | undefined {
@@ -74,6 +75,7 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 		config.flutterSdkHome = makeFullPath(flutterConfig.sdkHome);
 		config.flutterSyncScript = makeFullPath(flutterConfig.syncScript);
 		config.flutterTestScript = makeScript(flutterConfig.testScript);
+		config.defaultDartSdk = makeFullPath(flutterConfig.defaultDartSdk);
 	} catch (e) {
 		logger.error(e);
 	}

--- a/src/test/flutter_bazel/extension.test.ts
+++ b/src/test/flutter_bazel/extension.test.ts
@@ -44,6 +44,7 @@ describe("extension", () => {
 		assert.equal(workspaceContext.config?.skipFlutterInitialization, true);
 		assert.equal(workspaceContext.config?.omitTargetFlag, true);
 		assert.equal(workspaceContext.config?.startDevToolsServerEagerly, true);
+		assert.equal(workspaceContext.config?.defaultDartSdk, "/default/dart");
 		assert.deepStrictEqual(workspaceContext.config?.flutterDaemonScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_daemon.sh"), replacesArgs: 1 });
 		assert.deepStrictEqual(workspaceContext.config?.flutterDevToolsScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_devtools.sh"), replacesArgs: 1 });
 		assert.deepStrictEqual(workspaceContext.config?.flutterDoctorScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_doctor.sh"), replacesArgs: 1 });

--- a/src/test/test_projects/bazel_workspace/flutter_hello_world_bazel/dart/config/ide/flutter.json
+++ b/src/test/test_projects/bazel_workspace/flutter_hello_world_bazel/dart/config/ide/flutter.json
@@ -8,5 +8,6 @@
 	"sdkHome": "../my-flutter-sdk",
 	"requiredIJPluginID": "ij-plugin-id",
 	"requiredIJPluginMessage": "IJ plugin message",
-	"configWarningPrefix": "Configuration warning prefix"
+	"configWarningPrefix": "Configuration warning prefix",
+	"defaultDartSdk": "/default/dart"
 }


### PR DESCRIPTION
We want to avoid users needing to set their own SDK for bazel workspaces. Most users should be okay with the default SDK from our config file.

I was hoping to test that this default SDK doesn't override a user-set SDK, but there isn't currently an easy way to do this now. https://github.com/Dart-Code/Dart-Code/issues/4057