### PR TITLE
Use workspace tools script for debug

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -506,7 +506,7 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 	context.subscriptions.push(vs.debug.registerDebugConfigurationProvider("dart", debugProvider));
 	const debugLogger = new DartDebugAdapterLoggerFactory(logger);
 	context.subscriptions.push(vs.debug.registerDebugAdapterTrackerFactory("dart", debugLogger));
-	const debugAdapterDescriptorFactory = new DartDebugAdapterDescriptorFactory(sdks, logger, extContext, dartCapabilities, flutterCapabilities, workspaceContext.config.flutterToolsScript);
+	const debugAdapterDescriptorFactory = new DartDebugAdapterDescriptorFactory(sdks, logger, extContext, dartCapabilities, flutterCapabilities, workspaceContext.config.flutterToolsScript ?? undefined, workspaceContext.config.flutterSdkHome ?? undefined);
 	context.subscriptions.push(vs.debug.registerDebugAdapterDescriptorFactory("dart", debugAdapterDescriptorFactory));
 	// Also the providers for the initial configs.
 	if (vs.DebugConfigurationProviderTriggerKind) { // Temporary workaround for GitPod/Theia not having this enum.

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -506,7 +506,7 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 	context.subscriptions.push(vs.debug.registerDebugConfigurationProvider("dart", debugProvider));
 	const debugLogger = new DartDebugAdapterLoggerFactory(logger);
 	context.subscriptions.push(vs.debug.registerDebugAdapterTrackerFactory("dart", debugLogger));
-	const debugAdapterDescriptorFactory = new DartDebugAdapterDescriptorFactory(sdks, logger, extContext, dartCapabilities, flutterCapabilities);
+	const debugAdapterDescriptorFactory = new DartDebugAdapterDescriptorFactory(sdks, logger, extContext, dartCapabilities, flutterCapabilities, workspaceContext.config.flutterToolsScript);
 	context.subscriptions.push(vs.debug.registerDebugAdapterDescriptorFactory("dart", debugAdapterDescriptorFactory));
 	// Also the providers for the initial configs.
 	if (vs.DebugConfigurationProviderTriggerKind) { // Temporary workaround for GitPod/Theia not having this enum.

--- a/src/extension/providers/debug_adapter_descriptor_factory.ts
+++ b/src/extension/providers/debug_adapter_descriptor_factory.ts
@@ -10,7 +10,7 @@ import { Context } from "../../shared/vscode/workspace";
 import { config } from "../config";
 
 export class DartDebugAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
-	constructor(private readonly sdks: DartSdks, private readonly logger: Logger, private readonly extensionContext: Context, private readonly dartCapabilities: DartCapabilities, private readonly flutterCapabilities: FlutterCapabilities, private readonly flutterToolsScript?: CustomScript) { }
+	constructor(private readonly sdks: DartSdks, private readonly logger: Logger, private readonly extensionContext: Context, private readonly dartCapabilities: DartCapabilities, private readonly flutterCapabilities: FlutterCapabilities, private readonly flutterToolsScript?: CustomScript, private readonly cwd?: string) { }
 
 	public createDebugAdapterDescriptor(session: DebugSession, executable: DebugAdapterExecutable | undefined): DebugAdapterDescriptor {
 		return this.descriptorForType(session.configuration.debuggerType as DebuggerType);
@@ -53,7 +53,7 @@ export class DartDebugAdapterDescriptorFactory implements DebugAdapterDescriptor
 				args.push("--no-dds");
 
 			this.logger.info(`Running SDK DAP Dart VM: ${executable} ${args.join("    ")}`);
-			return new DebugAdapterExecutable(executable, args, {cwd: "/google/src/cloud/helinx/head/google3"});
+			return new DebugAdapterExecutable(executable, args, this.cwd ? {cwd: this.cwd} : {});
 		} else if (config.customDartDapPath && isDartOrDartTest) {
 			const args = [config.customDartDapPath, "debug_adapter"];
 			if (isDartTest)

--- a/src/extension/providers/debug_adapter_descriptor_factory.ts
+++ b/src/extension/providers/debug_adapter_descriptor_factory.ts
@@ -4,13 +4,13 @@ import { DartCapabilities } from "../../shared/capabilities/dart";
 import { FlutterCapabilities } from "../../shared/capabilities/flutter";
 import { dartVMPath, debugAdapterPath, executableNames, flutterPath } from "../../shared/constants";
 import { DebuggerType } from "../../shared/enums";
-import { DartSdks, Logger } from "../../shared/interfaces";
+import { CustomScript, DartSdks, Logger } from "../../shared/interfaces";
 import { getDebugAdapterName, getDebugAdapterPort } from "../../shared/utils/debug";
 import { Context } from "../../shared/vscode/workspace";
 import { config } from "../config";
 
 export class DartDebugAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
-	constructor(private readonly sdks: DartSdks, private readonly logger: Logger, private readonly extensionContext: Context, private readonly dartCapabilities: DartCapabilities, private readonly flutterCapabilities: FlutterCapabilities) { }
+	constructor(private readonly sdks: DartSdks, private readonly logger: Logger, private readonly extensionContext: Context, private readonly dartCapabilities: DartCapabilities, private readonly flutterCapabilities: FlutterCapabilities, private readonly flutterToolsScript?: CustomScript) { }
 
 	public createDebugAdapterDescriptor(session: DebugSession, executable: DebugAdapterExecutable | undefined): DebugAdapterDescriptor {
 		return this.descriptorForType(session.configuration.debuggerType as DebuggerType);
@@ -44,7 +44,7 @@ export class DartDebugAdapterDescriptorFactory implements DebugAdapterDescriptor
 		if (useSdkDap) {
 			const executable = isDartOrDartTest
 				? path.join(this.sdks.dart, dartVMPath)
-				: (this.sdks.flutter ? path.join(this.sdks.flutter, flutterPath) : executableNames.flutter);
+				: this.flutterToolsScript?.script ?? (this.sdks.flutter ? path.join(this.sdks.flutter, flutterPath) : executableNames.flutter);
 
 			const args = ["debug_adapter"];
 			if (isDartTestOrFlutterTest)
@@ -53,7 +53,7 @@ export class DartDebugAdapterDescriptorFactory implements DebugAdapterDescriptor
 				args.push("--no-dds");
 
 			this.logger.info(`Running SDK DAP Dart VM: ${executable} ${args.join("    ")}`);
-			return new DebugAdapterExecutable(executable, args);
+			return new DebugAdapterExecutable(executable, args, {cwd: "/google/src/cloud/helinx/head/google3"});
 		} else if (config.customDartDapPath && isDartOrDartTest) {
 			const args = [config.customDartDapPath, "debug_adapter"];
 			if (isDartTest)

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -55,6 +55,7 @@ export interface WritableWorkspaceConfig {
 	flutterSdkHome?: string;
 	flutterSyncScript?: string;
 	flutterTestScript?: CustomScript;
+	flutterToolsScript?: CustomScript;
 	flutterVersion?: string;
 	useLsp?: boolean;
 	useVmForTests?: boolean;

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -42,6 +42,7 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 			sdkHome: string | undefined; // Note: This refers to Flutter SDK home, not Dart.
 			syncScript: string | undefined;
 			testScript: string | undefined;
+			toolsScript: string | undefined;
 			defaultDartSdk: string | undefined;
 		};
 
@@ -75,6 +76,7 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 		config.flutterSdkHome = makeFullPath(flutterConfig.sdkHome);
 		config.flutterSyncScript = makeFullPath(flutterConfig.syncScript);
 		config.flutterTestScript = makeScript(flutterConfig.testScript);
+		config.flutterToolsScript = makeScript(flutterConfig.toolsScript);
 		config.defaultDartSdk = makeFullPath(flutterConfig.defaultDartSdk);
 	} catch (e) {
 		logger.error(e);

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -76,6 +76,9 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 		config.flutterSdkHome = makeFullPath(flutterConfig.sdkHome);
 		config.flutterSyncScript = makeFullPath(flutterConfig.syncScript);
 		config.flutterTestScript = makeScript(flutterConfig.testScript);
+
+		// TODO (helin24): This is a generic script that can be used with some of the Flutter commands, e.g. `debug_adapter`, `doctor`, and `daemon`.
+		// We should eventually change over the other scripts to use this one to reduce the number of scripts needed.
 		config.flutterToolsScript = makeScript(flutterConfig.toolsScript);
 		config.defaultDartSdk = makeFullPath(flutterConfig.defaultDartSdk);
 	} catch (e) {

--- a/src/test/flutter_bazel/extension.test.ts
+++ b/src/test/flutter_bazel/extension.test.ts
@@ -49,9 +49,10 @@ describe("extension", () => {
 		assert.deepStrictEqual(workspaceContext.config?.flutterDevToolsScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_devtools.sh"), replacesArgs: 1 });
 		assert.deepStrictEqual(workspaceContext.config?.flutterDoctorScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_doctor.sh"), replacesArgs: 1 });
 		assert.deepStrictEqual(workspaceContext.config?.flutterRunScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_run.sh"), replacesArgs: 1 });
+		assert.deepStrictEqual(workspaceContext.config?.flutterTestScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_test.sh"), replacesArgs: 1 });
+		assert.deepStrictEqual(workspaceContext.config?.flutterToolsScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_tools.sh"), replacesArgs: 1 });
 		assert.equal(workspaceContext.config?.flutterSdkHome, path.join(fsPath(flutterBazelRoot), "my-flutter-sdk"));
 		assert.equal(workspaceContext.config?.flutterSyncScript, path.join(fsPath(flutterBazelRoot), "scripts/custom_sync.sh"));
-		assert.deepStrictEqual(workspaceContext.config?.flutterTestScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_test.sh"), replacesArgs: 1 });
 		logger.info("        " + JSON.stringify(workspaceContext, undefined, 8).trim().slice(1, -1).trim());
 	});
 	// This test requires another clone of the SDK to verify the path (symlinks

--- a/src/test/test_projects/bazel_workspace/flutter_hello_world_bazel/dart/config/ide/flutter.json
+++ b/src/test/test_projects/bazel_workspace/flutter_hello_world_bazel/dart/config/ide/flutter.json
@@ -5,6 +5,7 @@
 	"testScript": "../scripts/custom_test.sh",
 	"runScript": "../scripts/custom_run.sh",
 	"syncScript": "../scripts/custom_sync.sh",
+	"toolsScript": "../scripts/custom_tools.sh",
 	"sdkHome": "../my-flutter-sdk",
 	"requiredIJPluginID": "ij-plugin-id",
 	"requiredIJPluginMessage": "IJ plugin message",

--- a/src/test/test_projects/bazel_workspace/scripts/custom_tools.sh
+++ b/src/test/test_projects/bazel_workspace/scripts/custom_tools.sh
@@ -1,0 +1,2 @@
+mkdir -p `dirname "$0"`/has_run && touch `dirname "$0"`/has_run/flutter_tools
+flutter "$@"


### PR DESCRIPTION
This adds a generic tools script that we can use to call `debug_adapter`. I'm not sure if the tests pass because I was having trouble running the bazel tests locally, but I'll look at them a bit more to see if I can fix that.