### PR TITLE
Translate folder paths for setting DevTools root

### DIFF
--- a/src/extension/commands/debug.ts
+++ b/src/extension/commands/debug.ts
@@ -62,7 +62,7 @@ export class DebugCommands implements IAmDisposable {
 	private suppressFlutterWidgetErrors = false;
 
 	constructor(private readonly logger: Logger, private context: Context, private workspaceContext: DartWorkspaceContext, readonly dartCapabilities: DartCapabilities, readonly flutterCapabilities: FlutterCapabilities, private readonly analytics: Analytics, pubGlobal: PubGlobal, flutterDaemon: IFlutterDaemon | undefined) {
-		this.vmServices = new VmServiceExtensions(logger, this);
+		this.vmServices = new VmServiceExtensions(logger, this, workspaceContext);
 		this.devTools = new DevToolsManager(logger, workspaceContext, this, analytics, pubGlobal, dartCapabilities, flutterCapabilities, flutterDaemon);
 		this.disposables.push(this.devTools);
 		this.debugOptions.name = "Dart Debug Options";
@@ -552,7 +552,7 @@ export class DebugCommands implements IAmDisposable {
 	}
 
 	private async handleCustomEventWithSession(session: DartDebugSessionInformation, e: vs.DebugSessionCustomEvent) {
-		this.vmServices.handleDebugEvent(session, e, this.workspaceContext.config.forceFlutterWorkspace)
+		this.vmServices.handleDebugEvent(session, e)
 			.catch((e) => this.logger.error(e));
 
 		if (e.event === "dart.webLaunchUrl") {

--- a/src/extension/commands/debug.ts
+++ b/src/extension/commands/debug.ts
@@ -61,7 +61,7 @@ export class DebugCommands implements IAmDisposable {
 	public readonly devTools: DevToolsManager;
 	private suppressFlutterWidgetErrors = false;
 
-	constructor(private readonly logger: Logger, private context: Context, workspaceContext: DartWorkspaceContext, readonly dartCapabilities: DartCapabilities, readonly flutterCapabilities: FlutterCapabilities, private readonly analytics: Analytics, pubGlobal: PubGlobal, flutterDaemon: IFlutterDaemon | undefined) {
+	constructor(private readonly logger: Logger, private context: Context, private workspaceContext: DartWorkspaceContext, readonly dartCapabilities: DartCapabilities, readonly flutterCapabilities: FlutterCapabilities, private readonly analytics: Analytics, pubGlobal: PubGlobal, flutterDaemon: IFlutterDaemon | undefined) {
 		this.vmServices = new VmServiceExtensions(logger, this);
 		this.devTools = new DevToolsManager(logger, workspaceContext, this, analytics, pubGlobal, dartCapabilities, flutterCapabilities, flutterDaemon);
 		this.disposables.push(this.devTools);
@@ -552,7 +552,7 @@ export class DebugCommands implements IAmDisposable {
 	}
 
 	private async handleCustomEventWithSession(session: DartDebugSessionInformation, e: vs.DebugSessionCustomEvent) {
-		this.vmServices.handleDebugEvent(session, e)
+		this.vmServices.handleDebugEvent(session, e, this.workspaceContext.config.forceFlutterWorkspace)
 			.catch((e) => this.logger.error(e));
 
 		if (e.event === "dart.webLaunchUrl") {

--- a/src/shared/utils/fs.ts
+++ b/src/shared/utils/fs.ts
@@ -192,13 +192,14 @@ export function resolveTildePaths<T extends string | undefined>(p: T): string | 
 // - have a pubspec.yaml
 // - have a project create trigger file
 // - are the Flutter repo root
-export async function findProjectFolders(logger: Logger, roots: string[], excludedFolders: string[], options: { sort?: boolean; requirePubspec?: boolean, searchDepth: number, forceFlutterWorkspace?: boolean }, token: MyCancellationToken): Promise<string[]> {
+export async function findProjectFolders(logger: Logger, roots: string[], excludedFolders: string[], options: { sort?: boolean; requirePubspec?: boolean, searchDepth: number, onlyWorkspaceRoots?: boolean }, token: MyCancellationToken): Promise<string[]> {
 	const dartToolFolderName = `${path.sep}.dart_tool${path.sep}`;
 
 	let previousLevelFolders = roots.slice();
 	let allPossibleFolders = previousLevelFolders.slice();
 	// Start at 1, as we already added the roots.
-	for (let i = 1; i < options.searchDepth; i++) {
+	const searchDepth = options.onlyWorkspaceRoots ? 1 : options.searchDepth;
+	for (let i = 1; i < searchDepth; i++) {
 		let nextLevelFolders: string[] = [];
 		for (const folder of previousLevelFolders) {
 			if (token.isCancellationRequested)
@@ -216,7 +217,7 @@ export async function findProjectFolders(logger: Logger, roots: string[], exclud
 	const projectFolderPromises = allPossibleFolders.map(async (folder) => ({
 		exists: options && options.requirePubspec
 			? await hasPubspecAsync(folder)
-			: options.forceFlutterWorkspace || await hasPubspecAsync(folder) || await hasCreateTriggerFileAsync(folder) || await isFlutterRepoAsync(folder),
+			: options.onlyWorkspaceRoots || await hasPubspecAsync(folder) || await hasCreateTriggerFileAsync(folder) || await isFlutterRepoAsync(folder),
 		folder,
 	}));
 	const projectFoldersChecks = await Promise.all(projectFolderPromises);

--- a/src/shared/utils/fs.ts
+++ b/src/shared/utils/fs.ts
@@ -192,7 +192,7 @@ export function resolveTildePaths<T extends string | undefined>(p: T): string | 
 // - have a pubspec.yaml
 // - have a project create trigger file
 // - are the Flutter repo root
-export async function findProjectFolders(logger: Logger, roots: string[], excludedFolders: string[], options: { sort?: boolean; requirePubspec?: boolean, searchDepth: number }, token: MyCancellationToken): Promise<string[]> {
+export async function findProjectFolders(logger: Logger, roots: string[], excludedFolders: string[], options: { sort?: boolean; requirePubspec?: boolean, searchDepth: number, forceFlutterWorkspace?: boolean }, token: MyCancellationToken): Promise<string[]> {
 	const dartToolFolderName = `${path.sep}.dart_tool${path.sep}`;
 
 	let previousLevelFolders = roots.slice();
@@ -216,7 +216,7 @@ export async function findProjectFolders(logger: Logger, roots: string[], exclud
 	const projectFolderPromises = allPossibleFolders.map(async (folder) => ({
 		exists: options && options.requirePubspec
 			? await hasPubspecAsync(folder)
-			: await hasPubspecAsync(folder) || await hasCreateTriggerFileAsync(folder) || await isFlutterRepoAsync(folder),
+			: options.forceFlutterWorkspace || await hasPubspecAsync(folder) || await hasCreateTriggerFileAsync(folder) || await isFlutterRepoAsync(folder),
 		folder,
 	}));
 	const projectFoldersChecks = await Promise.all(projectFolderPromises);

--- a/src/shared/vscode/utils.ts
+++ b/src/shared/vscode/utils.ts
@@ -72,6 +72,16 @@ export async function getAllProjectFolders(
 		return inProgressProjectFolderSearch;
 	}
 
+	// TODO(helin24): Use DDS for this translation.
+	const search = "/google3/";
+	if (workspaceFolders.every(((folder) => folder.uri.path.startsWith("/google") && folder.uri.path.includes(search)))) {
+		return workspaceFolders.map((folder) => {
+			const idx = folder.uri.path.indexOf(search);
+			const remainingPath = folder.uri.path.substring(idx + search.length);
+			return `google3:///${remainingPath}`;
+		});
+	}
+
 	const cacheKey = `folders_${workspaceFolders.map((f) => f.uri.toString()).join(path.sep)}`;
 	const cachedFolders = projectFolderCache.get(cacheKey);
 	if (cachedFolders) {

--- a/src/shared/vscode/utils.ts
+++ b/src/shared/vscode/utils.ts
@@ -62,7 +62,7 @@ function getAnalysisOptionsExcludedFolders(
 export async function getAllProjectFolders(
 	logger: Logger,
 	getExcludedFolders: ((f: WorkspaceFolder | undefined) => string[]) | undefined,
-	options: { sort?: boolean; requirePubspec?: boolean, searchDepth: number, workspaceFolders?: WorkspaceFolder[] },
+	options: { sort?: boolean; requirePubspec?: boolean, searchDepth: number, workspaceFolders?: WorkspaceFolder[], forceFlutterWorkspace?: boolean },
 ) {
 	const workspaceFolders = options.workspaceFolders ?? getDartWorkspaceFolders();
 
@@ -72,17 +72,7 @@ export async function getAllProjectFolders(
 		return inProgressProjectFolderSearch;
 	}
 
-	// TODO(helin24): Use DDS for this translation.
-	const search = "/google3/";
-	if (workspaceFolders.every(((folder) => folder.uri.path.startsWith("/google") && folder.uri.path.includes(search)))) {
-		return workspaceFolders.map((folder) => {
-			const idx = folder.uri.path.indexOf(search);
-			const remainingPath = folder.uri.path.substring(idx + search.length);
-			return `google3:///${remainingPath}`;
-		});
-	}
-
-	const cacheKey = `folders_${workspaceFolders.map((f) => f.uri.toString()).join(path.sep)}`;
+	const cacheKey = `folders_${workspaceFolders.map((f) => f.uri.toString()).join(path.sep)}_${options.forceFlutterWorkspace ? "true" : "false"}`;
 	const cachedFolders = projectFolderCache.get(cacheKey);
 	if (cachedFolders) {
 		logger.info(`Returning cached results for project search`);

--- a/src/shared/vscode/utils.ts
+++ b/src/shared/vscode/utils.ts
@@ -62,7 +62,7 @@ function getAnalysisOptionsExcludedFolders(
 export async function getAllProjectFolders(
 	logger: Logger,
 	getExcludedFolders: ((f: WorkspaceFolder | undefined) => string[]) | undefined,
-	options: { sort?: boolean; requirePubspec?: boolean, searchDepth: number, workspaceFolders?: WorkspaceFolder[], forceFlutterWorkspace?: boolean },
+	options: { sort?: boolean; requirePubspec?: boolean, searchDepth: number, workspaceFolders?: WorkspaceFolder[], onlyWorkspaceRoots?: boolean },
 ) {
 	const workspaceFolders = options.workspaceFolders ?? getDartWorkspaceFolders();
 
@@ -72,7 +72,7 @@ export async function getAllProjectFolders(
 		return inProgressProjectFolderSearch;
 	}
 
-	const cacheKey = `folders_${workspaceFolders.map((f) => f.uri.toString()).join(path.sep)}_${options.forceFlutterWorkspace ? "true" : "false"}`;
+	const cacheKey = `folders_${workspaceFolders.map((f) => f.uri.toString()).join(path.sep)}_${options.onlyWorkspaceRoots ? "true" : "false"}`;
 	const cachedFolders = projectFolderCache.get(cacheKey);
 	if (cachedFolders) {
 		logger.info(`Returning cached results for project search`);


### PR DESCRIPTION
The current project folder finding method does not work for internal projects that don't use pubspec files, but we need to return these folders with their relative paths for DevTools root to be set correctly. I think we could eventually do this in DDS, but this may be the best option to have this in the next release (I'm not sure and would be open to doing something less hard coded).