### PR TITLE
Remove preview bazel option

### DIFF
--- a/package.json
+++ b/package.json
@@ -2350,12 +2350,6 @@
 						"description": "Whether to normalize file casings before sending them to the LSP server. This may fix issues with file_names lints not disappearing after renaming a file if the VS Code API continues to use the original casing.",
 						"scope": "window"
 					},
-					"dart.previewBazelWorkspaceCustomScripts": {
-						"type": "boolean",
-						"default": false,
-						"markdownDescription": "EXPERIMENTAL: Whether to look for custom script definitions at `dart/config/ide/flutter.json` in Bazel workspaces. Currently supported for macOS and Linux only.",
-						"scope": "window"
-					},
 					"dart.daemonPort": {
 						"type": "number",
 						"default": false,

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -126,7 +126,6 @@ class Config {
 	get onlyAnalyzeProjectsWithOpenFiles(): boolean { return this.getConfig<boolean>("onlyAnalyzeProjectsWithOpenFiles", false); }
 	get openDevTools(): "never" | "flutter" | "always" { return this.getConfig<"never" | "flutter" | "always">("openDevTools", "never"); }
 	get openTestView(): Array<"testRunStart" | "testFailure"> { return this.getConfig<Array<"testRunStart" | "testFailure">>("openTestView", ["testRunStart"]); }
-	get previewBazelWorkspaceCustomScripts(): boolean { return this.getConfig<boolean>("previewBazelWorkspaceCustomScripts", false); }
 	get previewCommitCharacters(): boolean { return this.getConfig<boolean>("previewCommitCharacters", false); }
 	get previewFlutterUiGuides(): boolean { return this.getConfig<boolean>("previewFlutterUiGuides", false); }
 	get previewFlutterUiGuidesCustomTracking(): boolean { return this.getConfig<boolean>("previewFlutterUiGuidesCustomTracking", false); }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -893,7 +893,6 @@ function getSettingsThatRequireRestart() {
 		+ config.showMainCodeLens
 		+ config.showTestCodeLens
 		+ config.updateImportsOnRename
-		+ config.previewBazelWorkspaceCustomScripts
 		+ config.flutterOutline
 		+ config.flutterAdbConnectOnChromeOs;
 }

--- a/src/extension/sdk/utils.ts
+++ b/src/extension/sdk/utils.ts
@@ -231,8 +231,7 @@ export class SdkUtils {
 		};
 
 		await processWorkspaceType(findDartSdkRoot, processDartSdkRepository);
-		// TODO: Remove this lambda when the preview flag is removed.
-		await processWorkspaceType(findBazelWorkspaceRoot, (l, c, b) => processBazelWorkspace(l, c, b));
+		await processWorkspaceType(findBazelWorkspaceRoot, processBazelWorkspace);
 		const fuchsiaRoot = await processWorkspaceType(findFuchsiaRoot, processFuchsiaWorkspace);
 
 		if (fuchsiaRoot) {

--- a/src/extension/sdk/utils.ts
+++ b/src/extension/sdk/utils.ts
@@ -232,7 +232,7 @@ export class SdkUtils {
 
 		await processWorkspaceType(findDartSdkRoot, processDartSdkRepository);
 		// TODO: Remove this lambda when the preview flag is removed.
-		await processWorkspaceType(findBazelWorkspaceRoot, (l, c, b) => processBazelWorkspace(l, c, b, config.previewBazelWorkspaceCustomScripts));
+		await processWorkspaceType(findBazelWorkspaceRoot, (l, c, b) => processBazelWorkspace(l, c, b));
 		const fuchsiaRoot = await processWorkspaceType(findFuchsiaRoot, processFuchsiaWorkspace);
 
 		if (fuchsiaRoot) {

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -14,12 +14,11 @@ export function processFuchsiaWorkspace(logger: Logger, config: WritableWorkspac
 	config.disableSdkUpdateChecks = true;
 }
 
-export function processBazelWorkspace(logger: Logger, config: WritableWorkspaceConfig, bazelWorkspaceRoot: string, parseFlutterJson: boolean) {
+export function processBazelWorkspace(logger: Logger, config: WritableWorkspaceConfig, bazelWorkspaceRoot: string) {
 	config.disableAutomaticPackageGet = true;
 	config.disableSdkUpdateChecks = true;
 
-	if (parseFlutterJson)
-		tryProcessBazelFlutterConfig(logger, config, bazelWorkspaceRoot);
+	tryProcessBazelFlutterConfig(logger, config, bazelWorkspaceRoot);
 }
 
 export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWorkspaceConfig, bazelWorkspaceRoot: string) {

--- a/src/test/test_projects/bazel_workspace/flutter_hello_world_bazel/.vscode/settings.json
+++ b/src/test/test_projects/bazel_workspace/flutter_hello_world_bazel/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
 	"files.insertFinalNewline": true,
 	"dart.maxLogLineLength": 20000,
-	"dart.previewBazelWorkspaceCustomScripts": true
 }


### PR DESCRIPTION
Is it okay to remove this option entirely? It looks like checking for Fuchsia workspaces is similar, so hopefully it's not too much work to always check for a bazel workspace.