### PR TITLE
Show a prompt to reopen the workspace if devices aren't found

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -265,7 +265,7 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 		if (workspaceContext.config.forceFlutterWorkspace && workspaceContext.config.restartMacDaemonMessage) {
 			runIfNoDevices = () => {
 				const instruction = workspaceContext.config.restartMacDaemonMessage;
-				promptToReloadExtension(`${instruction} (VSCode settings currently expects port: ${config.daemonPort}.)`, `Reopen this workspace`);
+				promptToReloadExtension(`${instruction} (Settings currently expect port: ${config.daemonPort}.)`, `Reopen this workspace`);
 			};
 		}
 		deviceManager = new FlutterDeviceManager(logger, flutterDaemon, config, workspaceContext, runIfNoDevices);

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -64,6 +64,8 @@ export interface WritableWorkspaceConfig {
 	skipFlutterInitialization?: boolean;
 	omitTargetFlag?: boolean;
 	defaultDartSdk?: string;
+	restartMacDaemonMessage?: string;
+	restartMacDaemonNoPortMessage?: string;
 }
 
 export type WorkspaceConfig = Readonly<WritableWorkspaceConfig>;

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -65,7 +65,6 @@ export interface WritableWorkspaceConfig {
 	omitTargetFlag?: boolean;
 	defaultDartSdk?: string;
 	restartMacDaemonMessage?: string;
-	restartMacDaemonNoPortMessage?: string;
 }
 
 export type WorkspaceConfig = Readonly<WritableWorkspaceConfig>;

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -43,6 +43,8 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 			testScript: string | undefined;
 			toolsScript: string | undefined;
 			defaultDartSdk: string | undefined;
+			restartMacDaemonMessage: string | undefined;
+			restartMacDaemonNoPortMessage: string | undefined;
 		};
 
 		function makeFullPath(relOrAbsolute: string | undefined): string | undefined {
@@ -80,6 +82,9 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 		// We should eventually change over the other scripts to use this one to reduce the number of scripts needed.
 		config.flutterToolsScript = makeScript(flutterConfig.toolsScript);
 		config.defaultDartSdk = makeFullPath(flutterConfig.defaultDartSdk);
+
+		config.restartMacDaemonMessage = flutterConfig.restartMacDaemonMessage;
+		config.restartMacDaemonNoPortMessage = flutterConfig.restartMacDaemonNoPortMessage;
 	} catch (e) {
 		logger.error(e);
 	}

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -44,7 +44,6 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 			toolsScript: string | undefined;
 			defaultDartSdk: string | undefined;
 			restartMacDaemonMessage: string | undefined;
-			restartMacDaemonNoPortMessage: string | undefined;
 		};
 
 		function makeFullPath(relOrAbsolute: string | undefined): string | undefined {
@@ -84,7 +83,6 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 		config.defaultDartSdk = makeFullPath(flutterConfig.defaultDartSdk);
 
 		config.restartMacDaemonMessage = flutterConfig.restartMacDaemonMessage;
-		config.restartMacDaemonNoPortMessage = flutterConfig.restartMacDaemonNoPortMessage;
 	} catch (e) {
 		logger.error(e);
 	}

--- a/src/shared/vscode/device_manager.ts
+++ b/src/shared/vscode/device_manager.ts
@@ -20,7 +20,7 @@ export class FlutterDeviceManager implements vs.Disposable {
 	private emulators: Emulator[] = [];
 	private readonly knownEmulatorNames: { [key: string]: string } = {};
 
-	constructor(private readonly logger: Logger, private daemon: IFlutterDaemon, private readonly config: { flutterCustomEmulators: CustomEmulatorDefinition[], flutterSelectDeviceWhenConnected: boolean, flutterShowEmulators: "local" | "always" | "never", projectSearchDepth: number, daemonPort: number | undefined }, private readonly workspaceContext: WorkspaceContext) {
+	constructor(private readonly logger: Logger, private daemon: IFlutterDaemon, private readonly config: { flutterCustomEmulators: CustomEmulatorDefinition[], flutterSelectDeviceWhenConnected: boolean, flutterShowEmulators: "local" | "always" | "never", projectSearchDepth: number, daemonPort: number | undefined }, private readonly workspaceContext: WorkspaceContext, runIfNoDevices?: () => void) {
 		this.statusBarItem = vs.window.createStatusBarItem("dartStatusFlutterDevice", vs.StatusBarAlignment.Right, 1);
 		this.statusBarItem.name = "Flutter Device";
 		this.statusBarItem.tooltip = "Flutter";
@@ -37,11 +37,10 @@ export class FlutterDeviceManager implements vs.Disposable {
 
 		daemon.registerForDeviceAdded(this.deviceAdded.bind(this));
 		daemon.registerForDeviceRemoved(this.deviceRemoved.bind(this));
-		if (workspaceContext.config.forceFlutterWorkspace && workspaceContext.config.restartMacDaemonMessage) {
+		if (runIfNoDevices) {
 			setTimeout(() => {
 				if (this.devices.length === 0) {
-					const instruction = workspaceContext.config.restartMacDaemonMessage;
-					vs.window.showWarningMessage(`${instruction} (VSCode settings currently expect port: ${config.daemonPort}.)`);
+					runIfNoDevices();
 				}
 			}, 10000);
 		}

--- a/src/shared/vscode/device_manager.ts
+++ b/src/shared/vscode/device_manager.ts
@@ -20,7 +20,7 @@ export class FlutterDeviceManager implements vs.Disposable {
 	private emulators: Emulator[] = [];
 	private readonly knownEmulatorNames: { [key: string]: string } = {};
 
-	constructor(private readonly logger: Logger, private daemon: IFlutterDaemon, private readonly config: { flutterCustomEmulators: CustomEmulatorDefinition[], flutterSelectDeviceWhenConnected: boolean, flutterShowEmulators: "local" | "always" | "never", projectSearchDepth: number }, private readonly workspaceContext: WorkspaceContext) {
+	constructor(private readonly logger: Logger, private daemon: IFlutterDaemon, private readonly config: { flutterCustomEmulators: CustomEmulatorDefinition[], flutterSelectDeviceWhenConnected: boolean, flutterShowEmulators: "local" | "always" | "never", projectSearchDepth: number, daemonPort: number | undefined }, private readonly workspaceContext: WorkspaceContext) {
 		this.statusBarItem = vs.window.createStatusBarItem("dartStatusFlutterDevice", vs.StatusBarAlignment.Right, 1);
 		this.statusBarItem.name = "Flutter Device";
 		this.statusBarItem.tooltip = "Flutter";
@@ -37,6 +37,14 @@ export class FlutterDeviceManager implements vs.Disposable {
 
 		daemon.registerForDeviceAdded(this.deviceAdded.bind(this));
 		daemon.registerForDeviceRemoved(this.deviceRemoved.bind(this));
+		if (workspaceContext.config.forceFlutterWorkspace && workspaceContext.config.restartMacDaemonMessage) {
+			setTimeout(() => {
+				if (this.devices.length === 0) {
+					const instruction = workspaceContext.config.restartMacDaemonMessage;
+					vs.window.showWarningMessage(`${instruction} (VSCode settings currently expect port: ${config.daemonPort}.)`);
+				}
+			}, 10000);
+		}
 	}
 
 	public dispose() {

--- a/src/shared/vscode/device_manager.ts
+++ b/src/shared/vscode/device_manager.ts
@@ -20,7 +20,7 @@ export class FlutterDeviceManager implements vs.Disposable {
 	private emulators: Emulator[] = [];
 	private readonly knownEmulatorNames: { [key: string]: string } = {};
 
-	constructor(private readonly logger: Logger, private daemon: IFlutterDaemon, private readonly config: { flutterCustomEmulators: CustomEmulatorDefinition[], flutterSelectDeviceWhenConnected: boolean, flutterShowEmulators: "local" | "always" | "never", projectSearchDepth: number, daemonPort: number | undefined }, private readonly workspaceContext: WorkspaceContext, runIfNoDevices?: () => void) {
+	constructor(private readonly logger: Logger, private daemon: IFlutterDaemon, private readonly config: { flutterCustomEmulators: CustomEmulatorDefinition[], flutterSelectDeviceWhenConnected: boolean, flutterShowEmulators: "local" | "always" | "never", projectSearchDepth: number }, private readonly workspaceContext: WorkspaceContext, runIfNoDevices?: () => void) {
 		this.statusBarItem = vs.window.createStatusBarItem("dartStatusFlutterDevice", vs.StatusBarAlignment.Right, 1);
 		this.statusBarItem.name = "Flutter Device";
 		this.statusBarItem.tooltip = "Flutter";


### PR DESCRIPTION
This is specifically for an internal project that requires users to start/restart a process on their local machine to expose devices.