### PR TITLE
Fix daemon not ending / restarting on user request

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -259,15 +259,20 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 
 	// Fire up Flutter daemon if required.
 	if (workspaceContext.hasAnyFlutterProjects && sdks.flutter) {
-		flutterDaemon = new FlutterDaemon(logger, workspaceContext as FlutterWorkspaceContext, flutterCapabilities);
-
 		let runIfNoDevices;
+		let hasRunNoDevicesMessage = false;
 		if (workspaceContext.config.forceFlutterWorkspace && workspaceContext.config.restartMacDaemonMessage) {
 			runIfNoDevices = () => {
-				const instruction = workspaceContext.config.restartMacDaemonMessage;
-				promptToReloadExtension(`${instruction} (Settings currently expect port: ${config.daemonPort}.)`, `Reopen this workspace`);
+				if (!hasRunNoDevicesMessage) {
+					const instruction = workspaceContext.config.restartMacDaemonMessage;
+					promptToReloadExtension(`${instruction} (Settings currently expect port: ${config.daemonPort}.)`, `Reopen this workspace`);
+					hasRunNoDevicesMessage = true;
+				}
 			};
 		}
+
+		flutterDaemon = new FlutterDaemon(logger, workspaceContext as FlutterWorkspaceContext, flutterCapabilities, runIfNoDevices);
+
 		deviceManager = new FlutterDeviceManager(logger, flutterDaemon, config, workspaceContext, runIfNoDevices);
 
 		context.subscriptions.push(deviceManager);

--- a/src/extension/flutter/flutter_daemon.ts
+++ b/src/extension/flutter/flutter_daemon.ts
@@ -26,7 +26,7 @@ export class FlutterDaemon extends StdIOService<UnknownNotification> implements 
 	private daemonStartedCompleter = new PromiseCompleter<void>();
 	public capabilities: DaemonCapabilities = DaemonCapabilities.empty;
 
-	constructor(logger: Logger, private readonly workspaceContext: FlutterWorkspaceContext, flutterCapabilities: FlutterCapabilities) {
+	constructor(logger: Logger, private readonly workspaceContext: FlutterWorkspaceContext, flutterCapabilities: FlutterCapabilities, private readonly runIfNoDevices?: () => void) {
 		super(new CategoryLogger(logger, LogCategory.FlutterDaemon), config.maxLogLineLength, true, true);
 
 		const folder = workspaceContext.sdks.flutter;
@@ -88,10 +88,14 @@ export class FlutterDaemon extends StdIOService<UnknownNotification> implements 
 
 	protected handleExit(code: number | null, signal: NodeJS.Signals | null) {
 		if (code && !this.hasShownTerminationError && !this.isShuttingDown) {
-			this.hasShownTerminationError = true;
-			const message = this.hasStarted ? "has terminated" : "failed to start";
-			// tslint:disable-next-line: no-floating-promises
-			promptToReloadExtension(`The Flutter Daemon ${message}.`, undefined, true);
+			if (this.runIfNoDevices) {
+				this.runIfNoDevices();
+			} else {
+				this.hasShownTerminationError = true;
+				const message = this.hasStarted ? "has terminated" : "failed to start";
+				// tslint:disable-next-line: no-floating-promises
+				promptToReloadExtension(`The Flutter Daemon ${message}.`, undefined, true);
+			}
 		}
 		super.handleExit(code, signal);
 	}

--- a/src/extension/flutter/flutter_daemon.ts
+++ b/src/extension/flutter/flutter_daemon.ts
@@ -248,7 +248,7 @@ export class FlutterDaemon extends StdIOService<UnknownNotification> implements 
 	}
 
 	public shutdown(): Thenable<void> {
-		return this.sendRequest("daemon.shutdown");
+		return this.hasStarted ? this.sendRequest("daemon.shutdown") : new Promise<void>((resolve) => resolve());
 	}
 
 	// Subscription methods.


### PR DESCRIPTION
We were previously always sending a daemon shutdown request, which would kill the shutdown process entirely if the daemon never started up.

This also shows the no devices message if the daemon doesn't start up for internal cases instead of the more generic daemon failed to start message.