### PR TITLE
Pass automatic daemon port to debug config

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -297,7 +297,7 @@ export async function activate(context: vs.ExtensionContext, isRestart: boolean 
 
 		flutterDaemon = new FlutterDaemon(logger, workspaceContext as FlutterWorkspaceContext, flutterCapabilities, runIfNoDevices, portFromLocalExtension);
 
-		deviceManager = new FlutterDeviceManager(logger, flutterDaemon, config, workspaceContext, runIfNoDevices);
+		deviceManager = new FlutterDeviceManager(logger, flutterDaemon, config, workspaceContext, runIfNoDevices, portFromLocalExtension);
 
 		context.subscriptions.push(deviceManager);
 		context.subscriptions.push(flutterDaemon);

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -522,7 +522,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		debugConfig.additionalProjectPaths = debugConfig.additionalProjectPaths || vs.workspace.workspaceFolders?.map((wf) => fsPath(wf.uri));
 		debugConfig.args = debugConfig.args || [];
 		debugConfig.vmAdditionalArgs = debugConfig.vmAdditionalArgs || conf.vmAdditionalArgs;
-		debugConfig.toolArgs = await this.buildToolArgs(debugType, debugConfig, conf, deviceManager?.portFromLocalExtension);
+		debugConfig.toolArgs = await this.buildToolArgs(debugType, debugConfig, conf, deviceManager?.daemonPortOverride);
 		debugConfig.vmServicePort = debugConfig.vmServicePort ?? 0;
 		debugConfig.dartSdkPath = this.wsContext.sdks.dart!;
 		debugConfig.vmServiceLogFile = this.insertSessionName(debugConfig, debugConfig.vmServiceLogFile || conf.vmServiceLogFile);
@@ -585,7 +585,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 				args = args.concat(await this.buildDartTestToolArgs(debugConfig, conf));
 				break;
 			case DebuggerType.Flutter:
-				args = args.concat(await this.buildFlutterToolArgs(debugConfig, conf, portFromLocalExtension));
+				args = args.concat(await this.buildFlutterToolArgs(debugConfig, conf));
 				break;
 			case DebuggerType.FlutterTest:
 				args = args.concat(await this.buildFlutterTestToolArgs(debugConfig, conf));
@@ -630,7 +630,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		return args;
 	}
 
-	protected async buildFlutterToolArgs(debugConfig: DartVsCodeLaunchArgs, conf: ResourceConfig, portFromLocalExtension?: number): Promise<string[]> {
+	protected async buildFlutterToolArgs(debugConfig: DartVsCodeLaunchArgs, conf: ResourceConfig): Promise<string[]> {
 		const args: string[] = [];
 		const isDebug = debugConfig.noDebug !== true;
 		const isAttach = debugConfig.request === "attach";
@@ -680,10 +680,9 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 					this.addArgsIfNotExist(args, "--web-renderer", renderer);
 			}
 
-			if (this.wsContext.config.forceFlutterWorkspace && portFromLocalExtension) {
-				this.addArgsIfNotExist(args, "--daemon-connection-port", portFromLocalExtension.toString());
-			} else if (this.wsContext.config.forceFlutterWorkspace && conf.daemonPort) {
-				this.addArgsIfNotExist(args, "--daemon-connection-port", conf.daemonPort.toString());
+			const daemonPort = this.deviceManager?.daemonPortOverride ?? conf.daemonPort;
+			if (this.wsContext.config.forceFlutterWorkspace && daemonPort) {
+				this.addArgsIfNotExist(args, "--daemon-connection-port", daemonPort.toString());
 			}
 		}
 

--- a/src/shared/vscode/device_manager.ts
+++ b/src/shared/vscode/device_manager.ts
@@ -20,7 +20,7 @@ export class FlutterDeviceManager implements vs.Disposable {
 	private emulators: Emulator[] = [];
 	private readonly knownEmulatorNames: { [key: string]: string } = {};
 
-	constructor(private readonly logger: Logger, private daemon: IFlutterDaemon, private readonly config: { flutterCustomEmulators: CustomEmulatorDefinition[], flutterSelectDeviceWhenConnected: boolean, flutterShowEmulators: "local" | "always" | "never", projectSearchDepth: number }, private readonly workspaceContext: WorkspaceContext, runIfNoDevices?: () => void, readonly portFromLocalExtension?: number) {
+	constructor(private readonly logger: Logger, private daemon: IFlutterDaemon, private readonly config: { flutterCustomEmulators: CustomEmulatorDefinition[], flutterSelectDeviceWhenConnected: boolean, flutterShowEmulators: "local" | "always" | "never", projectSearchDepth: number }, private readonly workspaceContext: WorkspaceContext, runIfNoDevices?: () => void, readonly daemonPortOverride?: number) {
 		this.statusBarItem = vs.window.createStatusBarItem("dartStatusFlutterDevice", vs.StatusBarAlignment.Right, 1);
 		this.statusBarItem.name = "Flutter Device";
 		this.statusBarItem.tooltip = "Flutter";

--- a/src/shared/vscode/device_manager.ts
+++ b/src/shared/vscode/device_manager.ts
@@ -20,7 +20,7 @@ export class FlutterDeviceManager implements vs.Disposable {
 	private emulators: Emulator[] = [];
 	private readonly knownEmulatorNames: { [key: string]: string } = {};
 
-	constructor(private readonly logger: Logger, private daemon: IFlutterDaemon, private readonly config: { flutterCustomEmulators: CustomEmulatorDefinition[], flutterSelectDeviceWhenConnected: boolean, flutterShowEmulators: "local" | "always" | "never", projectSearchDepth: number }, private readonly workspaceContext: WorkspaceContext, runIfNoDevices?: () => void) {
+	constructor(private readonly logger: Logger, private daemon: IFlutterDaemon, private readonly config: { flutterCustomEmulators: CustomEmulatorDefinition[], flutterSelectDeviceWhenConnected: boolean, flutterShowEmulators: "local" | "always" | "never", projectSearchDepth: number }, private readonly workspaceContext: WorkspaceContext, runIfNoDevices?: () => void, readonly portFromLocalExtension?: number) {
 		this.statusBarItem = vs.window.createStatusBarItem("dartStatusFlutterDevice", vs.StatusBarAlignment.Right, 1);
 		this.statusBarItem.name = "Flutter Device";
 		this.statusBarItem.tooltip = "Flutter";


### PR DESCRIPTION
I forgot to pass the port from the local device extension to debug config (oops!). Is there a better way to pass this through these functions?