### PR TITLE
Don't infer cwd from workspace folder when there's an explicit program

### DIFF
--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -413,7 +413,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			}
 		}
 
-		// Convert to an absolute paths (if possible).
+		// Convert any relative paths to absolute paths (if possible).
 		if (defaultCwd && !path.isAbsolute(defaultCwd) && folder) {
 			debugConfig.cwd = path.join(fsPath(folder.uri), defaultCwd);
 			this.logger.info(`Converted defaultCwd to absolute path: ${defaultCwd}`);

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -414,12 +414,16 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		}
 
 		// Convert to an absolute paths (if possible).
-		if (debugConfig.cwd && !path.isAbsolute(debugConfig.cwd) && defaultCwd) {
-			debugConfig.cwd = path.join(defaultCwd, debugConfig.cwd);
+		if (defaultCwd && !path.isAbsolute(defaultCwd) && folder) {
+			debugConfig.cwd = path.join(fsPath(folder.uri), defaultCwd);
+			this.logger.info(`Converted defaultCwd to absolute path: ${defaultCwd}`);
+		}
+		if (debugConfig.cwd && !path.isAbsolute(debugConfig.cwd) && folder) {
+			debugConfig.cwd = path.join(fsPath(folder.uri), debugConfig.cwd);
 			this.logger.info(`Converted cwd to absolute path: ${debugConfig.cwd}`);
 		}
-		if (debugConfig.program && !path.isAbsolute(debugConfig.program) && (debugConfig.cwd || defaultCwd)) {
-			debugConfig.program = path.join(debugConfig.cwd || defaultCwd!, debugConfig.program);
+		if (debugConfig.program && !path.isAbsolute(debugConfig.program) && (debugConfig.cwd || folder)) {
+			debugConfig.program = path.join(debugConfig.cwd || fsPath(folder!.uri), debugConfig.program);
 			this.logger.info(`Converted program to absolute path: ${debugConfig.program}`);
 		}
 

--- a/src/test/dart_debug/debug/dart_cli.test.ts
+++ b/src/test/dart_debug/debug/dart_cli.test.ts
@@ -39,6 +39,26 @@ describe("dart cli debugger", () => {
 
 	describe("resolves the correct debug config", () => {
 
+		it("using users explicit cwd with an explicit program", async () => {
+			const resolvedConfig = await getResolvedDebugConfiguration({
+				cwd: "/foo",
+				program: fsPath(helloWorldMainFile),
+			})!;
+
+			assert.ok(resolvedConfig);
+			assert.equal(resolvedConfig.cwd, "/foo");
+			assert.equal(resolvedConfig.program, fsPath(helloWorldMainFile));
+		});
+
+		it("using open file", async () => {
+			await openFile(helloWorldMainFile);
+			const resolvedConfig = await getResolvedDebugConfiguration({})!;
+
+			assert.ok(resolvedConfig);
+			assert.equal(resolvedConfig.cwd, fsPath(helloWorldFolder));
+			assert.equal(resolvedConfig.program, fsPath(helloWorldMainFile));
+		});
+
 		it("passing launch.json's toolArgs to the VM", async () => {
 			const resolvedConfig = await getResolvedDebugConfiguration({
 				program: fsPath(helloWorldMainFile),

--- a/src/test/flutter_bazel/debug/flutter_run.test.ts
+++ b/src/test/flutter_bazel/debug/flutter_run.test.ts
@@ -5,7 +5,7 @@ import { DebuggerType } from "../../../shared/enums";
 import { fsPath } from "../../../shared/utils/fs";
 import { DartDebugClient } from "../../dart_debug_client";
 import { createDebugClient, flutterTestDeviceId, flutterTestDeviceIsWeb, killFlutterTester, startDebugger, waitAllThrowIfTerminates } from "../../debug_helpers";
-import { activate, ensureHasRunRecently, extApi, flutterBazelHelloWorldFolder, flutterBazelHelloWorldMainFile, flutterBazelRoot, getResolvedDebugConfiguration, prepareHasRunFile, watchPromise } from "../../helpers";
+import { activate, ensureHasRunRecently, extApi, flutterBazelHelloWorldMainFile, flutterBazelRoot, getResolvedDebugConfiguration, prepareHasRunFile, watchPromise } from "../../helpers";
 
 const deviceName = flutterTestDeviceIsWeb ? "Chrome" : "Flutter test device";
 
@@ -42,16 +42,9 @@ describe(`flutter run debugger`, () => {
 
 			assert.ok(resolvedConfig);
 			assert.equal(resolvedConfig.program, "//foo/bar");
-			// TODO(dantup): This is no longer our expectation, but it is what we get.
-			// When fixed, remove this condition and expect flutterBazelRoot, which is the
-			// common ancestor from our open workspace folders.
-			if (true) {
-				assert.equal(resolvedConfig.cwd, fsPath(flutterBazelHelloWorldFolder));
-			} else {
-				// Expect the bazel root, not the project folder, because this is the common ancestor of
-				// the two workspace folders we have open.
-				assert.equal(resolvedConfig.cwd, fsPath(flutterBazelRoot));
-			}
+			// Expect the bazel root, not the project folder, because this is the common ancestor of
+			// the two workspace folders we have open.
+			assert.equal(resolvedConfig.cwd, fsPath(flutterBazelRoot));
 		});
 	});
 


### PR DESCRIPTION
@helin24 does this solve the issue you had?

If there's a `program` we will try to infer a `cwd` from it, but if that fails, we should no longer use the workspace folder. We'll only use the workspace folder directly is there was no open file _or_ `program`.

Then, if we still don't have one (which we won't for a special `target` that doesn't have an enclosing `WorkspaceFolder`) we'll look for a common ancestor for all workspace folders.