### PR TITLE
Remove sync script

### DIFF
--- a/src/extension/commands/debug.ts
+++ b/src/extension/commands/debug.ts
@@ -17,7 +17,6 @@ import { locateBestProjectRoot } from "../project";
 import { PubGlobal } from "../pub/global";
 import { DevToolsManager } from "../sdk/dev_tools/manager";
 import { isDartFile, isValidEntryFile } from "../utils";
-import { runToolProcess } from "../utils/processes";
 import { DartDebugSessionInformation, ProgressMessage } from "../utils/vscode/debug";
 
 export const debugSessions: DartDebugSessionInformation[] = [];
@@ -142,9 +141,6 @@ export class DebugCommands implements IAmDisposable {
 				return;
 			const onlyDart = !!args?.onlyDart;
 			const onlyFlutter = !!args?.onlyFlutter;
-			if (!!workspaceContext.config?.flutterSyncScript && !onlyDart) {
-				await runToolProcess(logger, workspaceContext.sdks.flutter, workspaceContext.config.flutterSyncScript, []);
-			}
 			this.onWillHotReloadEmitter.fire();
 			await Promise.all(debugSessions.map(async (s) => {
 				const shouldReload = onlyDart
@@ -160,9 +156,6 @@ export class DebugCommands implements IAmDisposable {
 		this.disposables.push(vs.commands.registerCommand("flutter.hotRestart", async (args?: any) => {
 			if (!debugSessions.length)
 				return;
-			if (!!workspaceContext.config?.flutterSyncScript) {
-				await runToolProcess(logger, workspaceContext.sdks.flutter, workspaceContext.config.flutterSyncScript, []);
-			}
 			this.onWillHotRestartEmitter.fire();
 			await Promise.all(debugSessions.map((s) => s.session.customRequest("hotRestart", args)));
 			analytics.logDebuggerRestart();

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -53,7 +53,6 @@ export interface WritableWorkspaceConfig {
 	flutterDoctorScript?: CustomScript;
 	flutterRunScript?: CustomScript;
 	flutterSdkHome?: string;
-	flutterSyncScript?: string;
 	flutterTestScript?: CustomScript;
 	flutterToolsScript?: CustomScript;
 	flutterVersion?: string;

--- a/src/shared/utils/workspace.ts
+++ b/src/shared/utils/workspace.ts
@@ -39,7 +39,6 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 			doctorScript: string | undefined;
 			runScript: string | undefined;
 			sdkHome: string | undefined; // Note: This refers to Flutter SDK home, not Dart.
-			syncScript: string | undefined;
 			testScript: string | undefined;
 			toolsScript: string | undefined;
 			defaultDartSdk: string | undefined;
@@ -76,7 +75,6 @@ export function tryProcessBazelFlutterConfig(logger: Logger, config: WritableWor
 		config.flutterDoctorScript = makeScript(flutterConfig.doctorScript);
 		config.flutterRunScript = makeScript(flutterConfig.runScript);
 		config.flutterSdkHome = makeFullPath(flutterConfig.sdkHome);
-		config.flutterSyncScript = makeFullPath(flutterConfig.syncScript);
 		config.flutterTestScript = makeScript(flutterConfig.testScript);
 
 		// TODO (helin24): This is a generic script that can be used with some of the Flutter commands, e.g. `debug_adapter`, `doctor`, and `daemon`.

--- a/src/test/flutter_bazel/extension.test.ts
+++ b/src/test/flutter_bazel/extension.test.ts
@@ -56,7 +56,6 @@ describe("extension", () => {
 		assert.deepStrictEqual(workspaceContext.config?.flutterTestScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_test.sh"), replacesArgs: 1 });
 		assert.deepStrictEqual(workspaceContext.config?.flutterToolsScript, { script: path.join(fsPath(flutterBazelRoot), "scripts/custom_tools.sh"), replacesArgs: 1 });
 		assert.equal(workspaceContext.config?.flutterSdkHome, path.join(fsPath(flutterBazelRoot), "my-flutter-sdk"));
-		assert.equal(workspaceContext.config?.flutterSyncScript, path.join(fsPath(flutterBazelRoot), "scripts/custom_sync.sh"));
 		logger.info("        " + JSON.stringify(workspaceContext, undefined, 8).trim().slice(1, -1).trim());
 	});
 	// This test requires another clone of the SDK to verify the path (symlinks

--- a/src/test/test_projects/bazel_workspace/dart/config/ide/flutter.json
+++ b/src/test/test_projects/bazel_workspace/dart/config/ide/flutter.json
@@ -4,7 +4,6 @@
 	"doctorScript": "scripts/custom_doctor.sh",
 	"testScript": "scripts/custom_test.sh",
 	"runScript": "scripts/custom_run.sh",
-	"syncScript": "scripts/custom_sync.sh",
 	"toolsScript": "scripts/custom_tools.sh",
 	"sdkHome": "my-flutter-sdk",
 	"requiredIJPluginID": "ij-plugin-id",


### PR DESCRIPTION
This is no longer needed since we only support running VS Code on a remote machine. (the original purpose was to make sure remote changes were synced on a local machine)