### PR TITLE
adding wrap with expanded to flutter refactor commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -572,6 +572,11 @@
 				"category": "Flutter"
 			},
 			{
+				"command": "_flutter.outline.refactor.flutter.wrap.expanded",
+				"title": "Wrap with Expanded",
+				"category": "Flutter"
+			},
+			{
 				"command": "_flutter.outline.refactor.flutter.wrap.padding",
 				"title": "Wrap with Padding",
 				"category": "Flutter"
@@ -935,6 +940,10 @@
 				},
 				{
 					"when": "false",
+					"command": "_flutter.outline.refactor.flutter.wrap.expanded"
+				},
+				{
+					"when": "false",
 					"command": "_flutter.outline.refactor.flutter.wrap.padding"
 				},
 				{
@@ -1189,6 +1198,10 @@
 					"command": "_flutter.outline.refactor.flutter.wrap.center"
 				},
 				{
+					"when": "view == dartFlutterOutline && dart-code:widgetSupports:refactor.flutter.wrap.expanded",
+					"command": "_flutter.outline.refactor.flutter.wrap.expanded"
+				},
+				{
 					"when": "view == dartFlutterOutline && dart-code:widgetSupports:refactor.flutter.wrap.padding",
 					"command": "_flutter.outline.refactor.flutter.wrap.padding"
 				},
@@ -1226,6 +1239,10 @@
 				{
 					"when": "view == dartFlutterOutline && viewItem == dart-code:isSelectedWidget && dart-code:widgetSupports:refactor.flutter.wrap.center",
 					"command": "_flutter.outline.refactor.flutter.wrap.center"
+				},
+				{
+					"when": "view == dartFlutterOutline && viewItem == dart-code:isSelectedWidget && dart-code:widgetSupports:refactor.flutter.wrap.expanded",
+					"command": "_flutter.outline.refactor.flutter.wrap.expanded"
 				},
 				{
 					"when": "view == dartFlutterOutline && viewItem == dart-code:isSelectedWidget && dart-code:widgetSupports:refactor.flutter.wrap.padding",

--- a/src/extension/commands/flutter_outline.ts
+++ b/src/extension/commands/flutter_outline.ts
@@ -5,6 +5,7 @@ import { FlutterWidgetItem } from "../flutter/flutter_outline_view";
 
 export const flutterOutlineCommands = [
 	"refactor.flutter.wrap.center",
+	"refactor.flutter.wrap.expanded",
 	"refactor.flutter.wrap.padding",
 	"refactor.flutter.wrap.column",
 	"refactor.flutter.move.up",


### PR DESCRIPTION
I am constantly wrapping Flutter widgets with Expanded. I wouldn't be surprised if it is a more common action than wrapping with Centre. 

I'm mostly new to typescript and vscode extensions
I am not sure if these even works.

I was able to see debugging statements triggered when I executed commands like Flutter Doctor, but not any of the refactoring actions even though I could see that they were successfully registered in `Dart-Code/src/extension/commands/flutter_outline.ts`
I was hoping to get some guidance as to why this is the case (or if it is a known problem)

I am running 
2017 Macbook Pro Monterey 12.5.1
VSCode 1.72.2
NPM 8.19.2