### PR TITLE
Round corner for flutter guides

### DIFF
--- a/src/extension/decorations/flutter_ui_guides_decorations.ts
+++ b/src/extension/decorations/flutter_ui_guides_decorations.ts
@@ -6,7 +6,7 @@ import { config } from "../config";
 const nonBreakingSpace = "\xa0";
 const verticalLine = "│";
 const horizontalLine = "─";
-const bottomCorner = "└";
+const bottomCorner = "╰";
 const middleCorner = "├";
 
 export abstract class FlutterUiGuideDecorations implements vs.Disposable {


### PR DESCRIPTION
Today I finally discovered that these flutter guides are a beta preview ! and so I enabled them and thought, why not having round corner? So this is the tiniest PR possible :) making only a simple change that makes these guides a little bit prettier hopefully...

<img width="213" src="https://user-images.githubusercontent.com/2157285/232258043-54ee02ad-6d8b-455b-b82f-67fa45f473ae.png">

<img width="697" src="https://user-images.githubusercontent.com/2157285/232258035-f9b44179-ff7e-44cc-ac6d-c828f3d31b51.png">
