### PR TITLE
[package.json] respect users editor.tabSize and related options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1362,9 +1362,6 @@
 		},
 		"configurationDefaults": {
 			"[dart]": {
-				"editor.tabSize": 2,
-				"editor.insertSpaces": true,
-				"editor.detectIndentation": false,
 				"editor.suggest.insertMode": "replace",
 				"editor.defaultFormatter": "Dart-Code.dart-code",
 				"editor.inlayHints.enabled": "offUnlessPressed"


### PR DESCRIPTION
Dart-Code needs to be very conservative when overriding user settings, as they *take precedence* over user settings. See https://github.com/Microsoft/vscode/issues/41542

> Here are some reasons why editor.tabSize might be not working for you:
> 
> You have installed an extension that uses VS Code API to tweak those settings at runtime. e.g. editorconfig extension. Try with disabling all extensions.

Without this change, a user must change the tabSize every time they open a Dart file. 

Considering we already have Dart Format, I see very little reason for overriding these.

Our organization has for 2 decades been standardized on a tabSize of 4 for _all_ programming languages, so this is very tedious.


