### PR TITLE
Add listener for copy events above the devtools frame

### DIFF
--- a/src/extension/sdk/dev_tools/embedded_view.ts
+++ b/src/extension/sdk/dev_tools/embedded_view.ts
@@ -35,6 +35,10 @@ window.addEventListener('message', (event) => {
 		case "launchUrl":
 			vscode.postMessage({command: 'launchUrl', data: message.data});
 			break;
+		case "clipboard-write":
+			const copyData = message.data;
+			navigator.clipboard.writeText(copyData);
+			break;
 	}
 });
 window.addEventListener('keydown', (event) => {
@@ -74,7 +78,7 @@ export class DevToolsEmbeddedView {
 			<script nonce="${scriptNonce}">${pageScript}</script>
 			<style nonce="${cssNonce}">#devToolsFrame { ${frameCss} }</style>
 			</head>
-			<body><iframe id="devToolsFrame" src="about:blank" frameborder="0"></iframe></body>
+			<body><iframe id="devToolsFrame" src="about:blank" frameborder="0" allow="clipboard-read; clipboard-write"></iframe></body>
 			</html>
 			`;
 


### PR DESCRIPTION
![](https://media.giphy.com/media/l2JHVUriDGEtWOx0c/giphy.gif)
This is to overcome [a bug with VSCode that isn't allowing Devtools to use the copy api.](https://github.com/flutter/devtools/issues/5775)

I've added the allow permissions to the iframe so that if VSCode ever fixes this issue, we should be able to just start utilizing the original copy method right away :)

The complementary code from Devtools can be found in this PR: https://github.com/flutter/devtools/pull/6598




