### PR TITLE
Add Markdown support to Documentation Comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,9 @@
 				"path": "./syntaxes/dart.json",
 				"tokenTypes": {
 					"string.interpolated.expression.dart": "other"
+				},
+				"embeddedLanguages": {
+					"meta.embedded.markdown": "markdown"
 				}
 			}
 		],

--- a/syntaxes/dart.json
+++ b/syntaxes/dart.json
@@ -158,7 +158,7 @@
 		"comments-doc": {
 			"patterns": [
 				{
-					"name": "comment.block.documentation.dart",
+					"name": "meta.embedded.markdown comment.block.documentation.dart",
 					"begin": "///",
 					"while": "^\\s*///",
 					"patterns": [

--- a/syntaxes/dart.json
+++ b/syntaxes/dart.json
@@ -72,6 +72,9 @@
 		"dartdoc": {
 			"patterns": [
 				{
+					"include": "text.html.markdown"
+				},
+				{
 					"match": "(\\[.*?\\])",
 					"captures": {
 						"0": {


### PR DESCRIPTION
Fix https://github.com/Dart-Code/Dart-Code/issues/4925

![image](https://github.com/Dart-Code/Dart-Code/assets/33529441/4be8642f-b99e-45fd-84ba-16602b2e3ef5)


Simply just `#includes` Markdown

using `meta.embedded.markdown` with `"embeddedLanguages": { "meta.embedded.markdown": "markdown" }`
enables basic language feature support
like `blockComment` and `autoClosingPairs`