### PR TITLE
Add separate web renderer options for flutter-default and auto and set the default to flutter-default

### DIFF
--- a/package.json
+++ b/package.json
@@ -2319,16 +2319,18 @@
 					},
 					"dart.flutterWebRenderer": {
 						"enum": [
+							"flutter-default",
 							"canvaskit",
 							"html",
 							"auto"
 						],
 						"enumDescriptions": [
+							"Use the default renderer for Flutter Web apps",
 							"Always use the CanvasKit renderer",
 							"Always use the HTML renderer",
-							"Allow Flutter to pick the best renderer based on the users device"
+							"Use Flutter's \"auto\" renderer option to pick the best renderer based on the users device"
 						],
-						"default": "canvaskit",
+						"default": "flutter-default",
 						"markdownDescription": "Sets the [Web renderer](https://flutter.dev/docs/development/tools/web-renderers) used for Flutter web apps.",
 						"scope": "window"
 					}

--- a/package.json
+++ b/package.json
@@ -2319,16 +2319,16 @@
 					},
 					"dart.flutterWebRenderer": {
 						"enum": [
-							"auto",
+							"canvaskit",
 							"html",
-							"canvaskit"
+							"auto"
 						],
 						"enumDescriptions": [
-							"Allow Flutter to pick the best renderer based on the users device",
+							"Always use the CanvasKit renderer",
 							"Always use the HTML renderer",
-							"Always use the CanvasKit renderer"
+							"Allow Flutter to pick the best renderer based on the users device"
 						],
-						"default": "auto",
+						"default": "canvaskit",
 						"markdownDescription": "Sets the [Web renderer](https://flutter.dev/docs/development/tools/web-renderers) used for Flutter web apps.",
 						"scope": "window"
 					}

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -145,7 +145,7 @@ class Config {
 	get flutterShowEmulators(): "local" | "always" | "never" { return this.getConfig<"local" | "always" | "never">("flutterShowEmulators", "local"); }
 	get flutterShowWebServerDevice(): "remote" | "always" { return this.getConfig<"remote" | "always">("flutterShowWebServerDevice", "remote"); }
 	get flutterTestLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("flutterTestLogFile", null))); }
-	get flutterWebRenderer(): "canvaskit" | "html" | "auto" { return this.getConfig<"canvaskit" | "html" | "auto">("flutterWebRenderer", "canvaskit"); }
+	get flutterWebRenderer(): "flutter-default" | "canvaskit" | "html" | "auto" { return this.getConfig<"flutter-default" | "canvaskit" | "html" | "auto">("flutterWebRenderer", "flutter-default"); }
 	get hotReloadOnSave(): "never" | "manual" | "manualIfDirty" | "all" | "allIfDirty" {
 		const value = this.getConfig<"never" | "manual" | "manualIfDirty" | "all" | "allIfDirty" | "always">("hotReloadOnSave", "never");
 		if (value === "always")

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -145,7 +145,7 @@ class Config {
 	get flutterShowEmulators(): "local" | "always" | "never" { return this.getConfig<"local" | "always" | "never">("flutterShowEmulators", "local"); }
 	get flutterShowWebServerDevice(): "remote" | "always" { return this.getConfig<"remote" | "always">("flutterShowWebServerDevice", "remote"); }
 	get flutterTestLogFile(): undefined | string { return createFolderForFile(resolvePaths(this.getConfig<null | string>("flutterTestLogFile", null))); }
-	get flutterWebRenderer(): "auto" | "html" | "canvaskit" { return this.getConfig<"auto" | "html" | "canvaskit">("flutterWebRenderer", "auto"); }
+	get flutterWebRenderer(): "canvaskit" | "html" | "auto" { return this.getConfig<"canvaskit" | "html" | "auto">("flutterWebRenderer", "canvaskit"); }
 	get hotReloadOnSave(): "never" | "manual" | "manualIfDirty" | "all" | "allIfDirty" {
 		const value = this.getConfig<"never" | "manual" | "manualIfDirty" | "all" | "allIfDirty" | "always">("hotReloadOnSave", "never");
 		if (value === "always")

--- a/src/shared/flutter/utils.ts
+++ b/src/shared/flutter/utils.ts
@@ -1,10 +1,10 @@
 import { FlutterCapabilities } from "../capabilities/flutter";
 
-export function getFutterWebRenderer(flutterCapabilities: FlutterCapabilities, renderer: "canvaskit" | "html" | "auto") {
+export function getFutterWebRenderer(flutterCapabilities: FlutterCapabilities, renderer: "flutter-default" | "canvaskit" | "html" | "auto") {
 	if (!flutterCapabilities.supportsWebRendererOption)
 		return;
 
-	if (!renderer)
+	if (!renderer || renderer === "flutter-default")
 		return;
 
 	return renderer;

--- a/src/shared/flutter/utils.ts
+++ b/src/shared/flutter/utils.ts
@@ -1,10 +1,10 @@
 import { FlutterCapabilities } from "../capabilities/flutter";
 
-export function getFutterWebRenderer(flutterCapabilities: FlutterCapabilities, renderer: "auto" | "html" | "canvaskit") {
+export function getFutterWebRenderer(flutterCapabilities: FlutterCapabilities, renderer: "canvaskit" | "html" | "auto") {
 	if (!flutterCapabilities.supportsWebRendererOption)
 		return;
 
-	if (!renderer || renderer === "auto")
+	if (!renderer)
 		return;
 
 	return renderer;

--- a/src/test/flutter_debug/flutter_run.test.ts
+++ b/src/test/flutter_debug/flutter_run.test.ts
@@ -78,6 +78,15 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 			ensureArrayContainsArray(resolvedConfig.toolArgs!, ["--web-server-debug-injected-client-protocol", "ws"]);
 		});
 
+		it("when web renderer is not set", async () => {
+			const resolvedConfig = await getResolvedDebugConfiguration({
+				deviceId: "web-server",
+				program: fsPath(flutterHelloWorldMainFile),
+			});
+
+			ensureArrayContainsArray(resolvedConfig.toolArgs!, ["--web-renderer", "canvaskit"]);
+		});
+
 		it("when web renderer is set", async () => {
 			await setConfigForTest("dart", "flutterWebRenderer", "html");
 			const resolvedConfig = await getResolvedDebugConfiguration({

--- a/src/test/flutter_debug/flutter_run.test.ts
+++ b/src/test/flutter_debug/flutter_run.test.ts
@@ -87,7 +87,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 
 			assert.ok(
 				!resolvedConfig.toolArgs!.includes("--web-renderer"),
-				'By default, the `--web-renderer` argument should not be set',
+				"By default, the `--web-renderer` argument should not be set",
 			);
 		});
 

--- a/src/test/flutter_debug/flutter_run.test.ts
+++ b/src/test/flutter_debug/flutter_run.test.ts
@@ -78,13 +78,17 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 			ensureArrayContainsArray(resolvedConfig.toolArgs!, ["--web-server-debug-injected-client-protocol", "ws"]);
 		});
 
-		it("when web renderer is not set", async () => {
+		it('when web renderer is set to "flutter-default"', async () => {
+			await setConfigForTest("dart", "flutterWebRenderer", "flutter-default");
 			const resolvedConfig = await getResolvedDebugConfiguration({
 				deviceId: "web-server",
 				program: fsPath(flutterHelloWorldMainFile),
 			});
 
-			ensureArrayContainsArray(resolvedConfig.toolArgs!, ["--web-renderer", "canvaskit"]);
+			assert.ok(
+				!resolvedConfig.toolArgs!.includes("--web-renderer"),
+				'By default, the `--web-renderer` argument should not be set',
+			);
 		});
 
 		it("when web renderer is set", async () => {


### PR DESCRIPTION
We are changing the default for `--web-renderer` in the flutter tool ([issue](https://github.com/flutter/flutter/issues/149826)). This PR is doing the same thing in the VSCode extension.

**_Question to reviewers:_**
I prefer to not hardcode a default value here, and instead omit the `--web-renderer` argument by default. That way, we let the flutter tool decide what's the default. Is there a way to make the `dart.flutterWebRenderer` enum nullable?