### PR TITLE
Fix debug integration tests for uris

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,9 @@ jobs:
       - id: no_exclude
         name: Run all builds
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
-        run: echo "excludes=[]" >> $GITHUB_OUTPUT
+        # Exclude the non-LSP bots because we don't support legacy protocol for current stable or later, they will only be tested
+        # as part of the legacy build bots.
+        run: echo "excludes=[{\"build-version\":\"stable\",\"bot\":\"dart\"},{\"build-version\":\"stable\",\"bot\":\"flutter\"},{\"build-version\":\"beta\",\"bot\":\"dart\"},{\"build-version\":\"beta\",\"bot\":\"flutter\"}]" >> $GITHUB_OUTPUT
       - id: exclude
         name: Exclude some builds if not running on schedule
         if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && !startsWith(github.ref, 'refs/tags/')

--- a/src/extension/code_lens/flutter_dartpad_samples.ts
+++ b/src/extension/code_lens/flutter_dartpad_samples.ts
@@ -23,7 +23,12 @@ export class FlutterDartPadSamplesCodeLensProvider implements CodeLensProvider, 
 		this.disposables.push(commands.registerCommand("_dart.openDartPadSample", async (sample: DartPadSampleInfo) => {
 			// Link down to first code snippet.
 			const fragment = `#${sample.libraryName}.${sample.className}.1`;
-			const url = `https://api.flutter.dev/flutter/${sample.libraryName}/${sample.className}-class.html${fragment}`;
+			const suffix = sample.elementKind === "MIXIN"
+				? "mixin"
+				: sample.elementKind === "EXTENSION"
+					? "extension-type"
+					: "class";
+			const url = `https://api.flutter.dev/flutter/${sample.libraryName}/${sample.className}-${suffix}.html${fragment}`;
 			await envUtils.openInBrowser(url);
 		}));
 
@@ -75,6 +80,7 @@ export class FlutterDartPadSamplesCodeLensProvider implements CodeLensProvider, 
 export interface DartPadSampleInfo {
 	libraryName: string;
 	className: string;
+	elementKind: string;
 	offset: number;
 	length: number;
 }

--- a/src/shared/utils/outline_das.ts
+++ b/src/shared/utils/outline_das.ts
@@ -196,6 +196,7 @@ export class ClassOutlineVisitor extends OutlineVisitor {
 			className: outline.element.name,
 			codeLength: outline.codeLength,
 			codeOffset: outline.codeOffset,
+			elementKind: outline.element.kind,
 			length: outline.length,
 			offset: outline.offset,
 		});
@@ -204,6 +205,7 @@ export class ClassOutlineVisitor extends OutlineVisitor {
 
 export interface ClassInfo {
 	className: string;
+	elementKind: string;
 	offset: number;
 	length: number;
 	codeOffset: number;

--- a/src/test/dart/commands/go_to_augmentations.test.ts
+++ b/src/test/dart/commands/go_to_augmentations.test.ts
@@ -15,7 +15,7 @@ import augment 'lib_augmentation.dart';
 class A {}
 `;
 const augmentationContent = `
-library augment  'lib.dart';
+augment library 'lib.dart';
 
 augment class A {}
 `;

--- a/src/test/dart_debug/dart_cli.test.ts
+++ b/src/test/dart_debug/dart_cli.test.ts
@@ -323,7 +323,7 @@ void printSomething() {
 		const stack = await dc.getStack();
 		const frames = stack.body.stackFrames;
 		assert.equal(frames[0].name, "main");
-		assert.equal(frames[0].source!.path, fsPath(helloWorldMainFile));
+		dc.assertPath(frames[0].source!.path, fsPath(helloWorldMainFile));
 		assert.equal(frames[0].source!.name, path.relative(fsPath(helloWorldFolder), fsPath(helloWorldMainFile)));
 
 		await dc.terminateRequest();
@@ -352,7 +352,7 @@ void printSomething() {
 		const stack = await dc.getStack();
 		const frames = stack.body.stackFrames;
 		assert.equal(frames[0].name, "do_print");
-		assert.equal(frames[0].source!.path, fsPath(helloWorldPartFile));
+		dc.assertPath(frames[0].source!.path, fsPath(helloWorldPartFile));
 		assert.equal(frames[0].source!.name, "package:hello_world/part.dart");
 
 		await dc.terminateRequest();
@@ -368,7 +368,7 @@ void printSomething() {
 		const stack = await dc.getStack();
 		const frames = stack.body.stackFrames;
 		assert.equal(frames[0].name, "do_print");
-		assert.equal(frames[0].source!.path, fsPath(helloWorldDeferredScriptFile));
+		dc.assertPath(frames[0].source!.path, fsPath(helloWorldDeferredScriptFile));
 		assert.equal(frames[0].source!.name, "package:hello_world/deferred_script.dart");
 
 		await dc.terminateRequest();
@@ -384,7 +384,7 @@ void printSomething() {
 		const stack = await dc.getStack();
 		const frames = stack.body.stackFrames;
 		assert.equal(frames[0].name, "print");
-		assert.equal(frames[0].source!.path, fsPath(uriFor(def)));
+		dc.assertPath(frames[0].source!.path, fsPath(uriFor(def)));
 		assert.equal(frames[0].source!.name, "dart:core/print.dart");
 	});
 
@@ -397,7 +397,7 @@ void printSomething() {
 		const stack = await dc.getStack();
 		const frames = stack.body.stackFrames;
 		assert.equal(frames[0].name, "read");
-		assert.equal(frames[0].source!.path, fsPath(uriFor(def)));
+		dc.assertPath(frames[0].source!.path, fsPath(uriFor(def)));
 		assert.equal(frames[0].source!.name, "package:http/http.dart");
 
 		await dc.terminateRequest();
@@ -1443,7 +1443,7 @@ insp=<inspected variable>
 				dc.assertOutputContains("stderr", "#0      main")
 					.then((event) => {
 						assert.equal(event.body.source!.name, path.join("bin", "broken.dart"));
-						assert.equal(event.body.source!.path, fsPath(helloWorldBrokenFile));
+						dc.assertPath(event.body.source!.path, fsPath(helloWorldBrokenFile));
 						assert.equal(event.body.line, positionOf("^Oops").line + 1); // positionOf is 0-based, but seems to want 1-based
 						assert.equal(event.body.column, 3);
 					}),

--- a/src/test/dart_debug/dart_cli.test.ts
+++ b/src/test/dart_debug/dart_cli.test.ts
@@ -190,7 +190,7 @@ describe("dart cli debugger", () => {
 		// Stop at a breakpoint so the app won't quit while we're checking the terminal.
 		await dc.hitBreakpoint(config, {
 			line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-			path: fsPath(helloWorldMainFile),
+			path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 		});
 
 		// Ensure we have a terminal for it.
@@ -298,7 +298,7 @@ void printSomething() {
 		// Stop at a breakpoint so the app won't quit while we're verifying DevTools.
 		await dc.hitBreakpoint(config, {
 			line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-			path: fsPath(helloWorldMainFile),
+			path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 		});
 
 		const devTools = await vs.commands.executeCommand<{ url: string, dispose: () => void }>("dart.openDevTools");
@@ -318,7 +318,7 @@ void printSomething() {
 		const config = await startDebugger(dc, helloWorldMainFile);
 		await dc.hitBreakpoint(config, {
 			line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-			path: fsPath(helloWorldMainFile),
+			path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 		});
 		const stack = await dc.getStack();
 		const frames = stack.body.stackFrames;
@@ -337,7 +337,7 @@ void printSomething() {
 			dc.waitForEvent("terminated"),
 			dc.setBreakpointWithoutHitting(config, {
 				line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-				path: fsPath(helloWorldMainFile),
+				path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 			}),
 		);
 	});
@@ -347,7 +347,7 @@ void printSomething() {
 		const config = await startDebugger(dc, helloWorldPartEntryFile);
 		await dc.hitBreakpoint(config, {
 			line: positionOf("^// BREAKPOINT1").line,
-			path: fsPath(helloWorldPartFile),
+			path: dc.isUsingUris ? helloWorldPartFile.toString() : fsPath(helloWorldPartFile),
 		});
 		const stack = await dc.getStack();
 		const frames = stack.body.stackFrames;
@@ -363,7 +363,7 @@ void printSomething() {
 		const config = await startDebugger(dc, helloWorldDeferredEntryFile);
 		await dc.hitBreakpoint(config, {
 			line: positionOf("^// BREAKPOINT1").line,
-			path: fsPath(helloWorldDeferredScriptFile),
+			path: dc.isUsingUris ? helloWorldDeferredScriptFile.toString() : fsPath(helloWorldDeferredScriptFile),
 		});
 		const stack = await dc.getStack();
 		const frames = stack.body.stackFrames;
@@ -410,14 +410,14 @@ void printSomething() {
 		const config = await startDebugger(dc, helloWorldMainFile, { debugSdkLibraries: true });
 		await dc.hitBreakpoint(config, {
 			line: printCall.line + 1,
-			path: fsPath(helloWorldMainFile),
+			path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 		});
 		await waitAllThrowIfTerminates(dc,
 			dc.assertStoppedLocation("step", {}).then((response) => {
 				// Ensure the top stack frame matches
 				const frame = response.body.stackFrames[0];
 				assert.equal(frame.name, "print");
-				assert.equal(frame.source!.path, sdkPathForSdkDap(dc, "lib/core/print.dart"));
+				dc.assertPath(frame.source!.path, sdkPathForSdkDap(dc, "lib/core/print.dart"));
 				assert.equal(frame.source!.name, "dart:core/print.dart");
 			}),
 			dc.stepIn(),
@@ -433,7 +433,7 @@ void printSomething() {
 		const config = await startDebugger(dc, helloWorldMainFile, { debugSdkLibraries: false });
 		await dc.hitBreakpoint(config, {
 			line: printCall.line + 1,
-			path: fsPath(helloWorldMainFile),
+			path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 		});
 		await dc.customRequest("updateDebugOptions", { debugSdkLibraries: true });
 		await delay(100);
@@ -442,7 +442,7 @@ void printSomething() {
 				// Ensure the top stack frame matches
 				const frame = response.body.stackFrames[0];
 				assert.equal(frame.name, "print");
-				assert.equal(frame.source!.path, sdkPathForSdkDap(dc, "lib/core/print.dart"));
+				dc.assertPath(frame.source!.path, sdkPathForSdkDap(dc, "lib/core/print.dart"));
 				assert.equal(frame.source!.name, "dart:core/print.dart");
 			}),
 			dc.stepIn(),
@@ -458,12 +458,12 @@ void printSomething() {
 		const config = await startDebugger(dc, helloWorldMainFile, { debugSdkLibraries: false });
 		await dc.hitBreakpoint(config, {
 			line: printCall.line + 1,
-			path: fsPath(helloWorldMainFile),
+			path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 		});
 		await waitAllThrowIfTerminates(dc,
 			dc.assertStoppedLocation("step", {
 				// Ensure we stayed in the current file
-				path: fsPath(helloWorldMainFile),
+				path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 			}),
 			dc.stepIn(),
 		);
@@ -479,7 +479,7 @@ void printSomething() {
 		const config = await startDebugger(dc, helloWorldHttpFile, { debugExternalPackageLibraries: true });
 		await dc.hitBreakpoint(config, {
 			line: httpReadCall.line + 1,
-			path: fsPath(helloWorldHttpFile),
+			path: dc.isUsingUris ? helloWorldHttpFile.toString() : fsPath(helloWorldHttpFile),
 		});
 		await waitAllThrowIfTerminates(dc,
 			dc.assertStoppedLocation("step", {
@@ -489,7 +489,7 @@ void printSomething() {
 				// Ensure the top stack frame matches
 				const frame = response.body.stackFrames[0];
 				assert.equal(frame.name, "read");
-				assert.equal(frame.source!.path, fsPath(uriFor(httpReadDef)));
+				dc.assertPath(frame.source!.path, fsPath(uriFor(httpReadDef)));
 				assert.equal(frame.source!.name, "package:http/http.dart");
 			}),
 			dc.stepIn(),
@@ -513,12 +513,12 @@ void printSomething() {
 		);
 		await dc.hitBreakpoint(config, {
 			line: httpReadCall.line + 1, // vs.Position is 0-based, but DAP is 1-based.
-			path: fsPath(helloWorldHttpFile),
+			path: dc.isUsingUris ? helloWorldHttpFile.toString() : fsPath(helloWorldHttpFile),
 		});
 		await waitAllThrowIfTerminates(dc,
 			dc.assertStoppedLocation("step", {
 				// Ensure we stayed in the current file
-				path: fsPath(helloWorldHttpFile),
+				path: dc.isUsingUris ? helloWorldHttpFile.toString() : fsPath(helloWorldHttpFile),
 			}),
 			dc.stepIn(),
 		);
@@ -542,7 +542,7 @@ void printSomething() {
 		);
 		await dc.hitBreakpoint(config, {
 			line: printMyThingCall.line + 1,
-			path: fsPath(helloWorldLocalPackageFile),
+			path: dc.isUsingUris ? helloWorldLocalPackageFile.toString() : fsPath(helloWorldLocalPackageFile),
 		});
 		await waitAllThrowIfTerminates(dc,
 			dc.assertStoppedLocation("step", {
@@ -552,7 +552,7 @@ void printSomething() {
 				// Ensure the top stack frame matches
 				const frame = response.body.stackFrames[0];
 				assert.equal(frame.name, "printMyThing");
-				assert.equal(frame.source!.path, fsPath(uriFor(printMyThingDef)));
+				dc.assertPath(frame.source!.path, fsPath(uriFor(printMyThingDef)));
 				assert.equal(frame.source!.name, "package:my_package/my_thing.dart");
 			}),
 			dc.stepIn(),
@@ -667,7 +667,7 @@ void printSomething() {
 		const config = await startDebugger(dc, helloWorldStack60File);
 		await dc.hitBreakpoint(config, {
 			line: positionOf("^// BREAKPOINT1").line + 1,
-			path: fsPath(helloWorldStack60File),
+			path: dc.isUsingUris ? helloWorldStack60File.toString() : fsPath(helloWorldStack60File),
 		});
 
 		// Get the total stack size we should expect and ensure it's a little over the expected 60
@@ -741,7 +741,7 @@ void printSomething() {
 							condition,
 							line: positionOf("^// BREAKPOINT1").line,
 						}],
-						source: { path: fsPath(helloWorldMainFile) },
+						source: { path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile) },
 					}))
 					.then(() => dc.configurationDoneRequest()),
 				expectation,
@@ -774,7 +774,7 @@ void printSomething() {
 					// we have examples of both (as well as "escaped" brackets).
 					logMessage: '${s} The \\{year} is """{(new DateTime.now()).year}"""',
 				}],
-				source: { path: fsPath(helloWorldMainFile) },
+				source: { path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile) },
 			})).then((response) => dc.configurationDoneRequest()),
 			dc.waitForEvent("terminated"),
 			dc.assertOutputContains(consoleOutputCategory, `Hello! The {year} is """${(new Date()).getFullYear()}"""\n`),
@@ -787,7 +787,7 @@ void printSomething() {
 		const debugConfig = await startDebugger(dc, helloWorldMainFile);
 		await dc.hitBreakpoint(debugConfig, {
 			line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-			path: fsPath(helloWorldMainFile),
+			path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 		});
 
 		const variables = await dc.getTopFrameVariables("Locals");
@@ -869,7 +869,7 @@ void printSomething() {
 		const debugConfig = await startDebugger(dc, helloWorldMainFile);
 		await dc.hitBreakpoint(debugConfig, {
 			line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-			path: fsPath(helloWorldMainFile),
+			path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 		});
 
 		const variables = await dc.getTopFrameVariables("Locals");
@@ -886,7 +886,7 @@ void printSomething() {
 		const debugConfig = await startDebugger(dc, helloWorldMainFile);
 		await dc.hitBreakpoint(debugConfig, {
 			line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-			path: fsPath(helloWorldMainFile),
+			path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 		});
 
 		const variables = await dc.getTopFrameVariables("Locals");
@@ -904,7 +904,7 @@ void printSomething() {
 		const debugConfig = await startDebugger(dc, helloWorldMainFile);
 		await dc.hitBreakpoint(debugConfig, {
 			line: positionOf("^// BREAKPOINT2").line + 1, // positionOf is 0-based, but seems to want 1-based
-			path: fsPath(helloWorldMainFile),
+			path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 		});
 
 		const variables = await dc.getTopFrameVariables("Locals");
@@ -920,7 +920,7 @@ void printSomething() {
 		const config = await startDebugger(dc, helloWorldGettersFile);
 		await dc.hitBreakpoint(config, {
 			line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-			path: fsPath(helloWorldGettersFile),
+			path: dc.isUsingUris ? helloWorldGettersFile.toString() : fsPath(helloWorldGettersFile),
 		});
 
 		const variables = await dc.getTopFrameVariables("Locals");
@@ -946,7 +946,7 @@ void printSomething() {
 		const config = await startDebugger(dc, helloWorldGettersFile);
 		await dc.hitBreakpoint(config, {
 			line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-			path: fsPath(helloWorldGettersFile),
+			path: dc.isUsingUris ? helloWorldGettersFile.toString() : fsPath(helloWorldGettersFile),
 		});
 
 		const variables = await dc.getTopFrameVariables("Locals");
@@ -969,7 +969,7 @@ void printSomething() {
 		const config = await startDebugger(dc, helloWorldMainFile);
 		await dc.hitBreakpoint(config, {
 			line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-			path: fsPath(helloWorldMainFile),
+			path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 		});
 
 		const variables = await dc.getTopFrameVariables("Locals");
@@ -992,7 +992,7 @@ void printSomething() {
 		const config = await startDebugger(dc, helloWorldMainFile);
 		await dc.hitBreakpoint(config, {
 			line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-			path: fsPath(helloWorldMainFile),
+			path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 		});
 
 		const variables = await dc.getTopFrameVariables("Locals");
@@ -1029,7 +1029,7 @@ void printSomething() {
 			await waitAllThrowIfTerminates(dc,
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT1").line, // positionOf is 0-based, and seems to want 1-based, BUT comment is on next line!
-					path: fsPath(helloWorldMainFile),
+					path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 				}),
 			);
 
@@ -1050,7 +1050,7 @@ void printSomething() {
 			await waitAllThrowIfTerminates(dc,
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT1").line, // positionOf is 0-based, and seems to want 1-based, BUT comment is on next line!
-					path: fsPath(helloWorldMainFile),
+					path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 				}),
 			);
 
@@ -1067,7 +1067,7 @@ void printSomething() {
 			await waitAllThrowIfTerminates(dc,
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT1").line, // positionOf is 0-based, and seems to want 1-based, BUT comment is on next line!
-					path: fsPath(helloWorldMainFile),
+					path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 				}),
 			);
 
@@ -1085,7 +1085,7 @@ void printSomething() {
 			await waitAllThrowIfTerminates(dc,
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT1").line, // positionOf is 0-based, and seems to want 1-based, BUT comment is on next line!
-					path: fsPath(helloWorldMainFile),
+					path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 				}),
 			);
 
@@ -1104,7 +1104,7 @@ void printSomething() {
 			await waitAllThrowIfTerminates(dc,
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT2").line, // positionOf is 0-based, and seems to want 1-based, BUT comment is on next line!
-					path: fsPath(helloWorldMainFile),
+					path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 				}),
 			);
 
@@ -1122,7 +1122,7 @@ void printSomething() {
 			await waitAllThrowIfTerminates(dc,
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT2").line, // positionOf is 0-based, and seems to want 1-based, BUT comment is on next line!
-					path: fsPath(helloWorldMainFile),
+					path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 				}),
 			);
 
@@ -1140,7 +1140,7 @@ void printSomething() {
 			await waitAllThrowIfTerminates(dc,
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT2").line, // positionOf is 0-based, and seems to want 1-based, BUT comment is on next line!
-					path: fsPath(helloWorldMainFile),
+					path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 				}),
 			);
 
@@ -1157,7 +1157,7 @@ void printSomething() {
 			await waitAllThrowIfTerminates(dc,
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT2").line, // positionOf is 0-based, and seems to want 1-based, BUT comment is on next line!
-					path: fsPath(helloWorldMainFile),
+					path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 				}),
 			);
 
@@ -1327,7 +1327,7 @@ insp=<inspected variable>
 			dc.configurationSequence(),
 			dc.assertStoppedLocation("exception", {
 				line: positionOf("^throw").line + 1, // positionOf is 0-based, but seems to want 1-based
-				path: fsPath(helloWorldBrokenFile),
+				path: dc.isUsingUris ? helloWorldBrokenFile.toString() : fsPath(helloWorldBrokenFile),
 			}),
 			dc.launch(config),
 		);
@@ -1353,7 +1353,7 @@ insp=<inspected variable>
 			dc.configurationSequence(),
 			dc.assertStoppedLocation("exception", {
 				line: positionOf("^throw").line + 1, // TODO: This line seems to be one-based but position is zero-based?
-				path: fsPath(helloWorldBrokenFile),
+				path: dc.isUsingUris ? helloWorldBrokenFile.toString() : fsPath(helloWorldBrokenFile),
 				text: extApi.dartCapabilities.sdkDapProvidesExceptionText ? "_Exception (Exception: Oops)" : undefined,
 			}),
 			dc.launch(config),
@@ -1572,7 +1572,7 @@ insp=<inspected variable>
 			const config = await attachDebugger(observatoryUri);
 			await dc.hitBreakpoint(config, {
 				line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-				path: fsPath(helloWorldMainFile),
+				path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 			});
 
 			await dc.terminateRequest();
@@ -1585,7 +1585,7 @@ insp=<inspected variable>
 			const config = await attachDebugger(observatoryUri);
 			await dc.hitBreakpoint(config, {
 				line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-				path: fsPath(helloWorldMainFile),
+				path: dc.isUsingUris ? helloWorldMainFile.toString() : fsPath(helloWorldMainFile),
 			});
 			await dc.terminateRequest();
 

--- a/src/test/dart_debug/dart_test.test.ts
+++ b/src/test/dart_debug/dart_test.test.ts
@@ -180,7 +180,7 @@ describe("dart test debugger", () => {
 				const config = await startDebugger(dc, helloWorldTestMainFile);
 				await dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-					path: fsPath(helloWorldTestMainFile),
+					path: dc.isUsingUris ? helloWorldTestMainFile.toString() : fsPath(helloWorldTestMainFile),
 				});
 			});
 
@@ -203,7 +203,7 @@ describe("dart test debugger", () => {
 					dc.configurationSequence(),
 					dc.assertStoppedLocation("exception", {
 						line: positionOf("^expect(1, equals(2))").line + 1, // positionOf is 0-based, but seems to want 1-based
-						path: fsPath(helloWorldTestBrokenFile),
+						path: dc.isUsingUris ? helloWorldTestBrokenFile.toString() : fsPath(helloWorldTestBrokenFile),
 					}),
 					dc.launch(config),
 				);

--- a/src/test/dart_debug_client.ts
+++ b/src/test/dart_debug_client.ts
@@ -2,6 +2,7 @@ import { DebugProtocol } from "@vscode/debugprotocol";
 import { strict as assert } from "assert";
 import { Writable } from "stream";
 import { DebugAdapterTracker, DebugAdapterTrackerFactory, DebugSession, DebugSessionCustomEvent, window } from "vscode";
+import { DartCapabilities } from "../shared/capabilities/dart";
 import { tenMinutesInMs } from "../shared/constants";
 import { DartVsCodeLaunchArgs } from "../shared/debug/interfaces";
 import { TestSessionCoordinator } from "../shared/test/coordinator";
@@ -24,10 +25,12 @@ export class DartDebugClient extends DebugClient {
 	public hasStarted = false;
 	public hasTerminated = false;
 	public readonly isDartDap: boolean;
+	public readonly isUsingUris: boolean;
 
-	constructor(args: DebugClientArgs, private readonly debugCommands: DebugCommandHandler, readonly testCoordinator: TestSessionCoordinator | undefined, private readonly debugTrackerFactories: DebugAdapterTrackerFactory[]) {
+	constructor(args: DebugClientArgs, private readonly debugCommands: DebugCommandHandler, readonly testCoordinator: TestSessionCoordinator | undefined, private readonly debugTrackerFactories: DebugAdapterTrackerFactory[], private readonly dartCapabitilies: DartCapabilities) {
 		super(args.runtime, args.executable, args.args, "dart", { shell: args.runtime?.endsWith(".sh") ? true : undefined }, true);
 		this.isDartDap = args.runtime !== undefined && args.runtime !== "node";
+		this.isUsingUris = this.isDartDap && this.dartCapabitilies.supportsMacroGeneratedFiles;
 		this.port = args.port;
 
 		// HACK to handle incoming requests..

--- a/src/test/debug_helpers.ts
+++ b/src/test/debug_helpers.ts
@@ -33,7 +33,7 @@ export function createDebugClient(debugType: DebuggerType) {
 	const descriptor = extApi.debugAdapterDescriptorFactory.descriptorForType(debugType);
 	const trackerFactories = extApi.trackerFactories as DebugAdapterTrackerFactory[];
 	const dc = descriptor instanceof DebugAdapterServer
-		? new DartDebugClient({ port: descriptor.port }, extApi.debugCommands, extApi.testCoordinator, trackerFactories)
+		? new DartDebugClient({ port: descriptor.port }, extApi.debugCommands, extApi.testCoordinator, trackerFactories, extApi.dartCapabilities)
 		: descriptor instanceof DebugAdapterExecutable
 			? new DartDebugClient(
 				{
@@ -44,6 +44,7 @@ export function createDebugClient(debugType: DebuggerType) {
 				extApi.debugCommands,
 				extApi.testCoordinator,
 				trackerFactories,
+				extApi.dartCapabilities,
 			)
 			: undefined;
 	if (!dc)

--- a/src/test/flutter/providers/flutter_dartpad_samples_code_lens_provider.test.ts
+++ b/src/test/flutter/providers/flutter_dartpad_samples_code_lens_provider.test.ts
@@ -67,7 +67,7 @@ describe("test_flutter_dartpad_samples", () => {
 		const openBrowserCommand = sb.stub(extApi.envUtils, "openInBrowser").withArgs(sinon.match.any).resolves(true);
 		await vs.commands.executeCommand(codeLens.command.command, ...codeLens.command.arguments!); // eslint-disable-line @typescript-eslint/no-unsafe-argument
 		assert.ok(openBrowserCommand.calledOnce);
-		assert.ok(openBrowserCommand.calledWith(p.expectedUrl));
+		assert.equal(openBrowserCommand.args[0][0], p.expectedUrl);
 	}
 });
 

--- a/src/test/flutter_debug/flutter_run.test.ts
+++ b/src/test/flutter_debug/flutter_run.test.ts
@@ -1710,7 +1710,12 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		// Collect all output.
 		let allOutput = "";
 		const handleOutput = (event: DebugProtocol.OutputEvent) => {
-			allOutput += `${event.body.category}: ${event.body.output}`;
+			// We might have trailing newlines on events, so when we split to add prefixes, we should not
+			// add one to the end of the string.
+			const endsWithNewline = event.body.output.endsWith("\n");
+			allOutput += event.body.output.trimEnd().split("\n").map((l) => `${event.body.category}: ${l}`).join("\n");
+			if (endsWithNewline)
+				allOutput += "\n";
 		};
 		dc.on("output", handleOutput);
 		try {

--- a/src/test/flutter_debug/flutter_run.test.ts
+++ b/src/test/flutter_debug/flutter_run.test.ts
@@ -679,7 +679,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		const config = await startDebugger(dc, flutterHelloWorldMainFile);
 		const expectedLocation = {
 			line: positionOf("^// BREAKPOINT1").line, // positionOf is 0-based, and seems to want 1-based, BUT comment is on next line!
-			path: fsPath(flutterHelloWorldMainFile),
+			path: dc.isUsingUris ? flutterHelloWorldMainFile.toString() : fsPath(flutterHelloWorldMainFile),
 		};
 		await watchPromise("stops_at_a_breakpoint->hitBreakpoint", dc.hitBreakpoint(config, expectedLocation));
 		const stack = await dc.getStack();
@@ -748,7 +748,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 			dc.waitForEvent("terminated"),
 			dc.setBreakpointWithoutHitting(config, {
 				line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-				path: fsPath(flutterHelloWorldMainFile),
+				path: dc.isUsingUris ? flutterHelloWorldMainFile.toString() : fsPath(flutterHelloWorldMainFile),
 				// TODO: This should be false in noDebug mode in SDK DAPs too.
 				// verified: false,
 			})
@@ -776,11 +776,11 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		// Get location for `print`
 		const printCall = positionOf("pri^nt(");
 		const printDef = await getDefinition(printCall);
-		const expectedPrintDefinitionPath = dc.isDartDap ? fsPath(uriFor(printDef)) : undefined;
+		const expectedPrintDefinitionPath = dc.isUsingUris ? uriFor(printDef).toString() : dc.isDartDap ? fsPath(uriFor(printDef)) : undefined;
 		const config = await startDebugger(dc, flutterHelloWorldMainFile, { debugSdkLibraries: true });
 		await dc.hitBreakpoint(config, {
 			line: printCall.line + 1,
-			path: fsPath(flutterHelloWorldMainFile),
+			path: dc.isUsingUris ? flutterHelloWorldMainFile.toString() : fsPath(flutterHelloWorldMainFile),
 		});
 		await waitAllThrowIfTerminates(dc,
 			dc.assertStoppedLocation("step", {
@@ -789,7 +789,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 				// Ensure the top stack frame matches
 				const frame = response.body.stackFrames[0];
 				assert.equal(frame.name, "print");
-				assert.equal(frame.source!.path, expectedPrintDefinitionPath);
+				dc.assertPath(frame.source!.path, expectedPrintDefinitionPath);
 				assert.equal(frame.source!.name, "dart:core/print.dart");
 			}),
 			dc.stepIn(),
@@ -811,12 +811,12 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		const config = await startDebugger(dc, flutterHelloWorldMainFile, { debugSdkLibraries: false });
 		await dc.hitBreakpoint(config, {
 			line: printCall.line + 1,
-			path: fsPath(flutterHelloWorldMainFile),
+			path: dc.isUsingUris ? flutterHelloWorldMainFile.toString() : fsPath(flutterHelloWorldMainFile),
 		});
 		await waitAllThrowIfTerminates(dc,
 			dc.assertStoppedLocation("step", {
 				// Ensure we stayed in the current file
-				path: fsPath(flutterHelloWorldMainFile),
+				path: dc.isUsingUris ? flutterHelloWorldMainFile.toString() : fsPath(flutterHelloWorldMainFile),
 			}),
 			dc.stepIn(),
 		);
@@ -838,17 +838,17 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		const config = await startDebugger(dc, flutterHelloWorldHttpFile, { debugExternalPackageLibraries: true });
 		await dc.hitBreakpoint(config, {
 			line: httpReadCall.line + 1,
-			path: fsPath(flutterHelloWorldHttpFile),
+			path: dc.isUsingUris ? flutterHelloWorldHttpFile.toString() : fsPath(flutterHelloWorldHttpFile),
 		});
 		await waitAllThrowIfTerminates(dc,
 			dc.assertStoppedLocation("step", {
 				// Ensure we stepped into the external file
-				path: fsPath(uriFor(httpReadDef)),
+				path: dc.isUsingUris ? uriFor(httpReadDef).toString() : fsPath(uriFor(httpReadDef)),
 			}).then((response) => {
 				// Ensure the top stack frame matches
 				const frame = response.body.stackFrames[0];
 				assert.equal(frame.name, "read");
-				assert.equal(frame.source!.path, fsPath(uriFor(httpReadDef)));
+				dc.assertPath(frame.source!.path, fsPath(uriFor(httpReadDef)));
 				assert.equal(frame.source!.name, "package:http/http.dart");
 			}),
 			dc.stepIn(),
@@ -870,12 +870,12 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		const config = await startDebugger(dc, flutterHelloWorldHttpFile, { debugExternalPackageLibraries: false });
 		await dc.hitBreakpoint(config, {
 			line: httpReadCall.line,
-			path: fsPath(flutterHelloWorldHttpFile),
+			path: dc.isUsingUris ? flutterHelloWorldHttpFile.toString() : fsPath(flutterHelloWorldHttpFile),
 		});
 		await waitAllThrowIfTerminates(dc,
 			dc.assertStoppedLocation("step", {
 				// Ensure we stayed in the current file
-				path: fsPath(flutterHelloWorldHttpFile),
+				path: dc.isUsingUris ? flutterHelloWorldHttpFile.toString() : fsPath(flutterHelloWorldHttpFile),
 			}),
 			dc.stepIn(),
 		);
@@ -901,17 +901,17 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		});
 		await dc.hitBreakpoint(config, {
 			line: printMyThingCall.line + 1,
-			path: fsPath(flutterHelloWorldLocalPackageFile),
+			path: dc.isUsingUris ? flutterHelloWorldLocalPackageFile.toString() : fsPath(flutterHelloWorldLocalPackageFile),
 		});
 		await waitAllThrowIfTerminates(dc,
 			dc.assertStoppedLocation("step", {
 				// Ensure we stepped into the external file
-				path: fsPath(uriFor(printMyThingDef)),
+				path: dc.isUsingUris ? uriFor(printMyThingDef).toString() : fsPath(uriFor(printMyThingDef)),
 			}).then((response) => {
 				// Ensure the top stack frame matches
 				const frame = response.body.stackFrames[0];
 				assert.equal(frame.name, "printMyThing");
-				assert.equal(frame.source!.path, fsPath(uriFor(printMyThingDef)));
+				dc.assertPath(frame.source!.path, fsPath(uriFor(printMyThingDef)));
 				assert.equal(frame.source!.name, "package:my_package/my_thing.dart");
 			}),
 			dc.stepIn(),
@@ -1043,7 +1043,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		const config = await startDebugger(dc, flutterHelloWorldStack60File);
 		await dc.hitBreakpoint(config, {
 			line: positionOf("^// BREAKPOINT1").line + 1,
-			path: fsPath(flutterHelloWorldStack60File),
+			path: dc.isUsingUris ? flutterHelloWorldStack60File.toString() : fsPath(flutterHelloWorldStack60File),
 		});
 
 		// Get the total stack size we should expect and ensure it's a little over the expected current 560
@@ -1187,7 +1187,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		const debugConfig = await startDebugger(dc, flutterHelloWorldMainFile);
 		await dc.hitBreakpoint(debugConfig, {
 			line: positionOf("^// BREAKPOINT1").line,
-			path: fsPath(flutterHelloWorldMainFile),
+			path: dc.isUsingUris ? flutterHelloWorldMainFile.toString() : fsPath(flutterHelloWorldMainFile),
 		});
 
 		const variables = await dc.getTopFrameVariables("Locals");
@@ -1277,7 +1277,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		const debugConfig = await startDebugger(dc, flutterHelloWorldMainFile);
 		await dc.hitBreakpoint(debugConfig, {
 			line: positionOf("^// BREAKPOINT2").line, // positionOf is 0-based, but seems to want 1-based
-			path: fsPath(flutterHelloWorldMainFile),
+			path: dc.isUsingUris ? flutterHelloWorldMainFile.toString() : fsPath(flutterHelloWorldMainFile),
 		});
 
 		const variables = await dc.getTopFrameVariables("Locals");
@@ -1299,7 +1299,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		const config = await startDebugger(dc, flutterHelloWorldGettersFile);
 		await dc.hitBreakpoint(config, {
 			line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-			path: fsPath(flutterHelloWorldGettersFile),
+			path: dc.isUsingUris ? flutterHelloWorldGettersFile.toString() : fsPath(flutterHelloWorldGettersFile),
 		});
 
 		const variables = await dc.getTopFrameVariables("Locals");
@@ -1331,7 +1331,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		const config = await startDebugger(dc, flutterHelloWorldGettersFile);
 		await dc.hitBreakpoint(config, {
 			line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-			path: fsPath(flutterHelloWorldGettersFile),
+			path: dc.isUsingUris ? flutterHelloWorldGettersFile.toString() : fsPath(flutterHelloWorldGettersFile),
 		});
 
 		const variables = await dc.getTopFrameVariables("Locals");
@@ -1359,7 +1359,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		const config = await startDebugger(dc, flutterHelloWorldMainFile);
 		await dc.hitBreakpoint(config, {
 			line: positionOf("^// BREAKPOINT1").line,
-			path: fsPath(flutterHelloWorldMainFile),
+			path: dc.isUsingUris ? flutterHelloWorldMainFile.toString() : fsPath(flutterHelloWorldMainFile),
 		});
 
 		const variables = await dc.getTopFrameVariables("Locals");
@@ -1385,7 +1385,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 		const config = await startDebugger(dc, flutterHelloWorldMainFile);
 		await dc.hitBreakpoint(config, {
 			line: positionOf("^// BREAKPOINT1").line,
-			path: fsPath(flutterHelloWorldMainFile),
+			path: dc.isUsingUris ? flutterHelloWorldMainFile.toString() : fsPath(flutterHelloWorldMainFile),
 		});
 
 		const variables = await dc.getTopFrameVariables("Locals");
@@ -1425,7 +1425,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 			await waitAllThrowIfTerminates(dc,
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT1").line,
-					path: fsPath(flutterHelloWorldMainFile),
+					path: dc.isUsingUris ? flutterHelloWorldMainFile.toString() : fsPath(flutterHelloWorldMainFile),
 				}),
 			);
 
@@ -1446,7 +1446,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 			await waitAllThrowIfTerminates(dc,
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT1").line,
-					path: fsPath(flutterHelloWorldMainFile),
+					path: dc.isUsingUris ? flutterHelloWorldMainFile.toString() : fsPath(flutterHelloWorldMainFile),
 				}),
 			);
 
@@ -1467,7 +1467,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 			await waitAllThrowIfTerminates(dc,
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT1").line,
-					path: fsPath(flutterHelloWorldMainFile),
+					path: dc.isUsingUris ? flutterHelloWorldMainFile.toString() : fsPath(flutterHelloWorldMainFile),
 				}),
 			);
 
@@ -1489,7 +1489,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 			await waitAllThrowIfTerminates(dc,
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT2").line,
-					path: fsPath(flutterHelloWorldMainFile),
+					path: dc.isUsingUris ? flutterHelloWorldMainFile.toString() : fsPath(flutterHelloWorldMainFile),
 				}),
 			);
 
@@ -1586,7 +1586,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 			dc.configurationSequence(),
 			dc.assertStoppedLocation("exception", {
 				line: positionOf("^Oops").line + 1, // positionOf is 0-based, but seems to want 1-based
-				path: fsPath(flutterHelloWorldBrokenFile),
+				path: dc.isUsingUris ? flutterHelloWorldBrokenFile.toString() : fsPath(flutterHelloWorldBrokenFile),
 			}),
 			dc.launch(config),
 		);
@@ -1631,7 +1631,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 			dc.configurationSequence(),
 			dc.assertStoppedLocation("exception", {
 				line: positionOf("^won't find this").line + 1, // positionOf is 0-based, but seems to want 1-based
-				path: fsPath(flutterHelloWorldBrokenFile),
+				path: dc.isUsingUris ? flutterHelloWorldBrokenFile.toString() : fsPath(flutterHelloWorldBrokenFile),
 			}),
 			dc.launch(config),
 		);

--- a/src/test/flutter_debug/flutter_run.test.ts
+++ b/src/test/flutter_debug/flutter_run.test.ts
@@ -1104,7 +1104,7 @@ describe(`flutter run debugger (launch on ${flutterTestDeviceId})`, () => {
 
 			let expectation: Promise<any> = resolvedPromise;
 			if (shouldStop)
-				expectation = expectation.then(() => dc.waitForStop("stopped"));
+				expectation = expectation.then(() => dc.waitForStop());
 
 			if (expectedError)
 				expectation = expectation.then(() => dc.assertOutputContains("console", expectedError));

--- a/src/test/flutter_test_debug/debug/flutter_test.test.ts
+++ b/src/test/flutter_test_debug/debug/flutter_test.test.ts
@@ -417,7 +417,7 @@ describe("flutter test debugger", () => {
 				const config = await startDebugger(dc, flutterTestMainFile);
 				await dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT1").line + 1, // positionOf is 0-based, but seems to want 1-based
-					path: fsPath(flutterTestMainFile),
+					path: dc.isUsingUris ? flutterTestMainFile.toString() : fsPath(flutterTestMainFile),
 				});
 			});
 
@@ -440,7 +440,7 @@ describe("flutter test debugger", () => {
 					dc.configurationSequence(),
 					dc.assertStoppedLocation("exception", {
 						line: positionOf("^won't find this").line + 1, // positionOf is 0-based, but seems to want 1-based
-						path: fsPath(flutterTestBrokenFile),
+						path: dc.isUsingUris ? flutterTestBrokenFile.toString() : fsPath(flutterTestBrokenFile),
 					}),
 					dc.launch(config),
 				);
@@ -527,7 +527,7 @@ describe("flutter test debugger", () => {
 				await waitAllThrowIfTerminates(dc,
 					dc.hitBreakpoint(config, {
 						line: positionOf("^// BREAKPOINT1").line,
-						path: fsPath(flutterIntegrationTestFile),
+						path: dc.isUsingUris ? flutterIntegrationTestFile.toString() : fsPath(flutterIntegrationTestFile),
 					}),
 				);
 			});
@@ -542,7 +542,7 @@ describe("flutter test debugger", () => {
 				await waitAllThrowIfTerminates(dc,
 					dc.hitBreakpoint(config, {
 						line: positionOf("^// BREAKPOINT1").line,
-						path: fsPath(flutterHelloWorldCounterAppFile),
+						path: dc.isUsingUris ? flutterHelloWorldCounterAppFile.toString() : fsPath(flutterHelloWorldCounterAppFile),
 					}),
 				);
 			});

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -680,13 +680,6 @@ export async function getDefinition(position: vs.Position): Promise<vs.Location 
 	return defs[0];
 }
 
-export function breakpointFor(def: vs.Location | vs.DefinitionLink) {
-	return {
-		line: rangeFor(def).start.line + 1,
-		path: fsPath(uriFor(def)),
-	};
-}
-
 export function uriFor(def: vs.Location | vs.DefinitionLink) {
 	return "uri" in def ? def.uri : def.targetUri;
 }

--- a/src/test/web_debug/debug/web.test.ts
+++ b/src/test/web_debug/debug/web.test.ts
@@ -411,7 +411,7 @@ describe("web debugger", () => {
 					.then((event) => {
 						assert.equal(event.body.output.indexOf("package:broken/main.dart"), -1);
 						assert.equal(event.body.source!.name, "package:broken/main.dart");
-						dc.assertPath(event.body.source!.path, fsPath(webBrokenMainFile));
+						dc.assertPath(event.body.source!.path, dc.isUsingUris ? webBrokenMainFile.toString() : fsPath(webBrokenMainFile));
 						assert.equal(event.body.line, positionOf("^Oops").line + 1); // positionOf is 0-based, but seems to want 1-based
 						assert.equal(event.body.column, 5);
 					}),

--- a/src/test/web_debug/debug/web.test.ts
+++ b/src/test/web_debug/debug/web.test.ts
@@ -231,7 +231,7 @@ describe("web debugger", () => {
 		// const stack = await dc.getStack();
 		// const frames = stack.body.stackFrames;
 		// assert.equal(frames[0].name, "main");
-		// assert.equal(frames[0].source!.path, expectedLocation.path);
+		// dc.assertPath(frames[0].source!.path, expectedLocation.path);
 		// assert.equal(frames[0].source!.name, "package:hello_world/main.dart");
 
 		await watchPromise("stops_at_a_breakpoint->resume", dc.resume());
@@ -256,7 +256,7 @@ describe("web debugger", () => {
 						// const stack = await watchPromise(`stops_at_a_breakpoint->reload:${i}->getStack`, dc.getStack());
 						// const frames = stack.body.stackFrames;
 						// assert.equal(frames[0].name, "MyHomePage.build");
-						// assert.equal(frames[0].source!.path, expectedLocation.path);
+						// dc.assertPath(frames[0].source!.path, expectedLocation.path);
 						// assert.equal(frames[0].source!.name, "package:hello_world/main.dart");
 					})
 					.then(() => watchPromise(`stops_at_a_breakpoint->reload:${i}->resume`, dc.resume())),
@@ -411,7 +411,7 @@ describe("web debugger", () => {
 					.then((event) => {
 						assert.equal(event.body.output.indexOf("package:broken/main.dart"), -1);
 						assert.equal(event.body.source!.name, "package:broken/main.dart");
-						assert.equal(event.body.source!.path, fsPath(webBrokenMainFile));
+						dc.assertPath(event.body.source!.path, fsPath(webBrokenMainFile));
 						assert.equal(event.body.line, positionOf("^Oops").line + 1); // positionOf is 0-based, but seems to want 1-based
 						assert.equal(event.body.column, 5);
 					}),

--- a/src/test/web_debug/debug/web.test.ts
+++ b/src/test/web_debug/debug/web.test.ts
@@ -222,7 +222,7 @@ describe("web debugger", () => {
 		const config = await startDebugger(dc, webHelloWorldIndexFile);
 		const expectedLocation = {
 			line: positionOf("^// BREAKPOINT1").line,
-			path: fsPath(webHelloWorldMainFile),
+			path: dc.isUsingUris ? webHelloWorldMainFile.toString() : fsPath(webHelloWorldMainFile),
 		};
 		// TODO: Remove the last parameter here (and the other things below) when we are mapping breakpoints in org-dartland-app
 		// URIs back to the correct file system paths.
@@ -272,7 +272,7 @@ describe("web debugger", () => {
 			await waitAllThrowIfTerminates(dc,
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT1").line, // positionOf is 0-based, and seems to want 1-based, BUT comment is on next line!
-					path: fsPath(webHelloWorldMainFile),
+					path: dc.isUsingUris ? webHelloWorldMainFile.toString() : fsPath(webHelloWorldMainFile),
 				}, {}),
 			);
 
@@ -288,7 +288,7 @@ describe("web debugger", () => {
 			await waitAllThrowIfTerminates(dc,
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT1").line, // positionOf is 0-based, and seems to want 1-based, BUT comment is on next line!
-					path: fsPath(webHelloWorldMainFile),
+					path: dc.isUsingUris ? webHelloWorldMainFile.toString() : fsPath(webHelloWorldMainFile),
 				}, {}),
 			);
 
@@ -304,7 +304,7 @@ describe("web debugger", () => {
 			await waitAllThrowIfTerminates(dc,
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT1").line, // positionOf is 0-based, and seems to want 1-based, BUT comment is on next line!
-					path: fsPath(webHelloWorldMainFile),
+					path: dc.isUsingUris ? webHelloWorldMainFile.toString() : fsPath(webHelloWorldMainFile),
 				}, {}),
 			);
 
@@ -321,7 +321,7 @@ describe("web debugger", () => {
 			await waitAllThrowIfTerminates(dc,
 				dc.hitBreakpoint(config, {
 					line: positionOf("^// BREAKPOINT2").line,
-					path: fsPath(webHelloWorldMainFile),
+					path: dc.isUsingUris ? webHelloWorldMainFile.toString() : fsPath(webHelloWorldMainFile),
 				}, {}),
 			);
 
@@ -342,7 +342,7 @@ describe("web debugger", () => {
 			dc.configurationSequence(),
 			dc.assertStoppedLocation("exception", {
 				line: positionOf("^Oops").line + 1, // positionOf is 0-based, but seems to want 1-based
-				path: fsPath(webBrokenMainFile),
+				path: dc.isUsingUris ? webBrokenMainFile.toString() : fsPath(webBrokenMainFile),
 			}),
 			dc.launch(config),
 		);
@@ -358,7 +358,7 @@ describe("web debugger", () => {
 			dc.configurationSequence(),
 			dc.assertStoppedLocation("exception", {
 				line: positionOf("^Oops").line + 1, // positionOf is 0-based, but seems to want 1-based
-				path: fsPath(webBrokenMainFile),
+				path: dc.isUsingUris ? webBrokenMainFile.toString() : fsPath(webBrokenMainFile),
 			}),
 			dc.launch(config),
 		);


### PR DESCRIPTION
Fixes a number of issues with debugger tests, some related to the debug adapter now using URIs and some just differences in behaviour (such as always getting a stop-on-entry at the start before the debug adapter resumes).

Full test run that includes beta is here:

https://github.com/Dart-Code/Dart-Code/actions/runs/9779733837