### PR TITLE
Feature: Add command to get packages from all projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
 			},
 			{
 				"command": "pub.get.all",
-				"title": "Get Packages for all Projects",
+				"title": "Get Packages for All Projects",
 				"category": "Pub",
 				"icon": {
 					"light": "./media/commands/get.svg",
@@ -436,7 +436,7 @@
 			},
 			{
 				"command": "flutter.packages.get.all",
-				"title": "Get Packages for all Projects",
+				"title": "Get Packages for All Projects",
 				"category": "Flutter",
 				"icon": {
 					"light": "./media/commands/get.svg",

--- a/package.json
+++ b/package.json
@@ -190,8 +190,8 @@
 				}
 			},
 			{
-				"command": "pub.getFromAllProjects",
-				"title": "Get Packages From All Projects",
+				"command": "pub.get.all",
+				"title": "Get Packages for all Projects",
 				"category": "Pub",
 				"icon": {
 					"light": "./media/commands/get.svg",
@@ -435,8 +435,8 @@
 				}
 			},
 			{
-				"command": "flutter.packages.getFromAllProjects",
-				"title": "Get Packages From All Projects",
+				"command": "flutter.packages.get.all",
+				"title": "Get Packages for all Projects",
 				"category": "Flutter",
 				"icon": {
 					"light": "./media/commands/get.svg",
@@ -814,6 +814,10 @@
 					"when": "dart-code:anyProjectLoaded"
 				},
 				{
+					"command": "pub.get.all",
+					"when": "dart-code:anyProjectLoaded"
+				},
+				{
 					"command": "dart.task.dartdoc",
 					"when": "dart-code:anyProjectLoaded"
 				},
@@ -975,6 +979,10 @@
 				},
 				{
 					"command": "flutter.packages.get",
+					"when": "dart-code:anyFlutterProjectLoaded"
+				},
+				{
+					"command": "flutter.packages.get.all",
 					"when": "dart-code:anyFlutterProjectLoaded"
 				},
 				{

--- a/package.json
+++ b/package.json
@@ -190,6 +190,15 @@
 				}
 			},
 			{
+				"command": "pub.getFromAllProjects",
+				"title": "Get Packages From All Projects",
+				"category": "Pub",
+				"icon": {
+					"light": "./media/commands/get.svg",
+					"dark": "./media/commands/get-inverse.svg"
+				}
+			},
+			{
 				"command": "dart.task.dartdoc",
 				"title": "Generate Documentation",
 				"category": "Dart",
@@ -419,6 +428,15 @@
 			{
 				"command": "flutter.packages.get",
 				"title": "Get Packages",
+				"category": "Flutter",
+				"icon": {
+					"light": "./media/commands/get.svg",
+					"dark": "./media/commands/get-inverse.svg"
+				}
+			},
+			{
+				"command": "flutter.packages.getFromAllProjects",
+				"title": "Get Packages From All Projects",
 				"category": "Flutter",
 				"icon": {
 					"light": "./media/commands/get.svg",

--- a/src/extension/commands/packages.ts
+++ b/src/extension/commands/packages.ts
@@ -22,21 +22,21 @@ export class PackageCommands extends BaseSdkCommands {
 	constructor(logger: Logger, context: Context, workspace: DartWorkspaceContext, dartCapabilities: DartCapabilities) {
 		super(logger, context, workspace, dartCapabilities);
 		this.disposables.push(vs.commands.registerCommand("dart.getPackages", this.getPackages, this));
-		this.disposables.push(vs.commands.registerCommand("dart.getPackagesFromAllProjects", this.getPackagesFromAllProjects, this));
+		this.disposables.push(vs.commands.registerCommand("dart.getPackages.all", this.getPackagesForAllProjects, this));
 		this.disposables.push(vs.commands.registerCommand("dart.listOutdatedPackages", this.listOutdatedPackages, this));
 		this.disposables.push(vs.commands.registerCommand("dart.upgradePackages", this.upgradePackages, this));
 		this.disposables.push(vs.commands.registerCommand("dart.upgradePackages.majorVersions", this.upgradePackagesMajorVersions, this));
 
 		// Pub commands.
 		this.disposables.push(vs.commands.registerCommand("pub.get", (selection) => vs.commands.executeCommand("dart.getPackages", selection)));
-		this.disposables.push(vs.commands.registerCommand("pub.getFromAllProjects", (selection) => vs.commands.executeCommand("dart.getPackagesFromAllProjects", selection)));
+		this.disposables.push(vs.commands.registerCommand("pub.get.all", (selection) => vs.commands.executeCommand("dart.getPackages.all", selection)));
 		this.disposables.push(vs.commands.registerCommand("pub.upgrade", (selection) => vs.commands.executeCommand("dart.upgradePackages", selection)));
 		this.disposables.push(vs.commands.registerCommand("pub.upgrade.majorVersions", (selection) => vs.commands.executeCommand("dart.upgradePackages.majorVersions", selection)));
 		this.disposables.push(vs.commands.registerCommand("pub.outdated", (selection) => vs.commands.executeCommand("dart.listOutdatedPackages", selection)));
 
 		// Flutter commands.
 		this.disposables.push(vs.commands.registerCommand("flutter.packages.get", (selection) => vs.commands.executeCommand("dart.getPackages", selection)));
-		this.disposables.push(vs.commands.registerCommand("flutter.packages.getFromAllProjects", (selection) => vs.commands.executeCommand("dart.getPackagesFromAllProjects", selection)));
+		this.disposables.push(vs.commands.registerCommand("flutter.packages.get.all", (selection) => vs.commands.executeCommand("dart.getPackages.all", selection)));
 		this.disposables.push(vs.commands.registerCommand("flutter.packages.upgrade", (selection) => vs.commands.executeCommand("dart.upgradePackages", selection)));
 		this.disposables.push(vs.commands.registerCommand("flutter.packages.upgrade.majorVersions", (selection) => vs.commands.executeCommand("dart.upgradePackages.majorVersions", selection)));
 		this.disposables.push(vs.commands.registerCommand("flutter.packages.outdated", (selection) => vs.commands.executeCommand("dart.listOutdatedPackages", selection)));
@@ -75,7 +75,7 @@ export class PackageCommands extends BaseSdkCommands {
 		}
 	}
 
-	private async getPackagesFromAllProjects() {
+	private async getPackagesForAllProjects() {
 		const allFolders = await getAllProjectFolders(this.logger, getExcludedFolders, { requirePubspec: true, sort: true, searchDepth: config.projectSearchDepth });
 		const uriFolders = allFolders.map((f) => vs.Uri.file(f));
 		await vs.commands.executeCommand("dart.getPackages", uriFolders);

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -41,8 +41,11 @@ if (!ext) {
 const testFolder = path.join(ext.extensionPath, "src/test");
 export const testProjectsFolder = path.join(testFolder, "test_projects");
 
+const packageConfigPath = ".dart_tool/package_config.json";
+
 // Dart
 export const helloWorldFolder = vs.Uri.file(path.join(testProjectsFolder, "hello_world"));
+export const helloWorldPackageConfigFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), packageConfigPath));
 export const helloWorldMainFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "bin/main.dart"));
 export const helloWorldInspectionFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "bin/inspect.dart"));
 export const helloWorldLongRunningFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "bin/long_running.dart"));
@@ -108,6 +111,7 @@ export const dartNested2Folder = vs.Uri.file(path.join(fsPath(dartNested1Folder)
 // Flutter
 export const flutterHelloWorldFolder = vs.Uri.file(path.join(testProjectsFolder, "flutter_hello_world"));
 export const flutterEmptyFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "lib/empty.dart"));
+export const flutterHelloWorldPackageConfigFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), packageConfigPath));
 export const flutterHelloWorldMainFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "lib/main.dart"));
 export const flutterHelloWorldReadmeFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "README.md"));
 export const flutterHelloWorldNavigateFromFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "lib/navigate_from.dart"));

--- a/src/test/multi_root/commands.test.ts
+++ b/src/test/multi_root/commands.test.ts
@@ -33,4 +33,18 @@ describe("dart.getPackages", () => {
 		// Verify the package config now exists.
 		await waitForResult(() => fs.existsSync(packageFile), ".dart_tool/package_config.json did not exist", 10000);
 	}).timeout(fiveMinutesInMs);
+
+	it("successfully fetches packages for all projects", async () => {
+		const packageFiles = [
+			fsPath(helloWorldPackageConfigFile),
+			fsPath(flutterHelloWorldPackageConfigFile),
+		];
+		packageFiles.forEach(deleteFileIfExists);
+
+		await activate();
+		await vs.commands.executeCommand("dart.getPackages.all");
+
+		// Verify the package config now exists.
+		await Promise.all(packageFiles.map((f) => waitForResult(() => fs.existsSync(f), `${f} did not exist`, 10000)));
+	}).timeout(fiveMinutesInMs);
 });

--- a/src/test/multi_root/extension.test.ts
+++ b/src/test/multi_root/extension.test.ts
@@ -40,7 +40,7 @@ describe("extension", () => {
 		const sdks: Sdks = extApi.workspaceContext.sdks;
 		assert.ok(sdks);
 		assert.ok(sdks.dart);
-		assert.notEqual(sdks.dart.indexOf("flutter"), -1);
+		assert.notEqual(sdks.dart.toLowerCase().indexOf("flutter"), -1);
 	});
 	it("resolves the correct debug config for a nested project", async () => {
 		await activateWithoutAnalysis();


### PR DESCRIPTION
This Pull Request adds a new command to the DartCode extension for Visual Studio Code, enabling users to `run pub get` for *all Dart projects* within the workspace. This feature streamlines the process of fetching dependencies for multiple projects, enhancing productivity and efficiency.

# Changes
- Added a new command dart.getAllPubGet to execute pub get for all projects.
- Updated the command palette to include the new command.
- Modified the extension activation logic to register the new command.