### PR TITLE
Updating markdown description of LogFiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -2347,7 +2347,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "The path to a log file for communication between Dart Code and the Analysis Server. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "The path to a log file for communication between Dart Code and the Analysis Server. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
 						"scope": "machine-overridable"
 					},
 					"dart.toolingDaemonLogFile": {
@@ -2356,7 +2356,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "The path to a log file for the `dart tooling-daemon` service, which coordinates between various Dart and Flutter tools and extensions. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "The path to a log file for the `dart tooling-daemon` service, which coordinates between various Dart and Flutter tools and extensions. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
 						"scope": "machine-overridable"
 					},
 					"dart.dapLogFile": {
@@ -2374,7 +2374,7 @@
 							"string"
 						],
 						"default": null,
-						"description": "The path to a low-traffic log file for the Dart DevTools service. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "The path to a low-traffic log file for the Dart DevTools service. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
 						"scope": "machine-overridable"
 					},
 					"dart.extensionLogFile": {
@@ -2383,7 +2383,7 @@
 							"string"
 						],
 						"default": null,
-						"description": "The path to a low-traffic log file for basic extension and editor issues. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "The path to a low-traffic log file for basic extension and editor issues. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
 						"scope": "machine-overridable"
 					},
 					"dart.flutterDaemonLogFile": {
@@ -2392,7 +2392,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "The path to a log file for the `flutter daemon` service, which provides information about connected devices accessible from the status bar. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "The path to a log file for the `flutter daemon` service, which provides information about connected devices accessible from the status bar. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
 						"scope": "machine-overridable"
 					},
 					"dart.maxLogLineLength": {
@@ -2872,7 +2872,6 @@
 						"markdownDescription": "**LEGACY SETTING: Disabling this may break functionality on modern SDKs.**\n\nWhether to pass `--track-widget-creation` to Flutter apps (required to support 'Inspect Widget'). This setting is always ignored when running in Profile or Release mode.",
 						"scope": "resource"
 					},
-
 					"dart.dartTestLogFile": {
 						"type": [
 							"null",

--- a/package.json
+++ b/package.json
@@ -2338,7 +2338,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "The path to a log file for very detailed logging in the Dart Analysis Server that may be useful when trying to diagnose Analysis Server issues. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "The path to a log file for very detailed logging in the Dart Analysis Server that may be useful when trying to diagnose Analysis Server issues. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
 						"scope": "machine-overridable"
 					},
 					"dart.analyzerLogFile": {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -183,6 +183,7 @@ export async function activate(context: vs.ExtensionContext, isRestart = false) 
 	setupLog(config.analyzerLogFile, LogCategory.Analyzer);
 	setupLog(config.flutterDaemonLogFile, LogCategory.FlutterDaemon);
 	setupLog(config.toolingDaemonLogFile, LogCategory.DartToolingDaemon);
+	setupLog(config.dapLogFile, LogCategory.DAP);
 	setupLog(config.devToolsLogFile, LogCategory.DevTools);
 
 	if (!workspaceContextUnverified.sdks.dart || (workspaceContextUnverified.hasAnyFlutterProjects && !workspaceContextUnverified.sdks.flutter)) {

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -13,7 +13,7 @@ import { getFutterWebRenderer } from "../../shared/flutter/utils";
 import { DartWorkspaceContext, IFlutterDaemon, Logger } from "../../shared/interfaces";
 import { TestModel } from "../../shared/test/test_model";
 import { getPackageTestCapabilities } from "../../shared/test/version";
-import { isWebDevice } from "../../shared/utils";
+import { filenameSafe, isWebDevice } from "../../shared/utils";
 import { findCommonAncestorFolder, forceWindowsDriveLetterToUppercase, fsPath, isFlutterProjectFolder, isWithinPath } from "../../shared/utils/fs";
 import { getProgramPath } from "../../shared/utils/test";
 import { FlutterDeviceManager } from "../../shared/vscode/device_manager";
@@ -26,7 +26,7 @@ import { locateBestProjectRoot } from "../project";
 import { PubGlobal } from "../pub/global";
 import { WebDev } from "../pub/webdev";
 import { DevToolsManager } from "../sdk/dev_tools/manager";
-import { ensureDebugLaunchUniqueId, getExcludedFolders, hasTestFilter, insertSessionName, isInsideFolderNamed, isTestFileOrFolder, isTestFolder, isValidEntryFile, projectCanUsePackageTest } from "../utils";
+import { ensureDebugLaunchUniqueId, getExcludedFolders, hasTestFilter, isInsideFolderNamed, isTestFileOrFolder, isTestFolder, isValidEntryFile, projectCanUsePackageTest } from "../utils";
 import { getGlobalFlutterArgs, getToolEnv } from "../utils/processes";
 
 export class DebugConfigProvider implements DebugConfigurationProvider {
@@ -575,10 +575,10 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		debugConfig.toolArgs = await this.buildToolArgs(debugType, debugConfig, conf, deviceManager?.daemonPortOverride);
 		debugConfig.vmServicePort = debugConfig.vmServicePort ?? 0;
 		debugConfig.dartSdkPath = this.wsContext.sdks.dart!;
-		debugConfig.vmServiceLogFile = insertSessionName(debugConfig, debugConfig.vmServiceLogFile || conf.vmServiceLogFile);
-		debugConfig.webDaemonLogFile = insertSessionName(debugConfig, debugConfig.webDaemonLogFile || conf.webDaemonLogFile);
+		debugConfig.vmServiceLogFile = this.insertSessionName(debugConfig, debugConfig.vmServiceLogFile || conf.vmServiceLogFile);
+		debugConfig.webDaemonLogFile = this.insertSessionName(debugConfig, debugConfig.webDaemonLogFile || conf.webDaemonLogFile);
 		debugConfig.maxLogLineLength = debugConfig.maxLogLineLength || config.maxLogLineLength;
-		debugConfig.dartTestLogFile = insertSessionName(debugConfig, debugConfig.dartTestLogFile || conf.dartTestLogFile);
+		debugConfig.dartTestLogFile = this.insertSessionName(debugConfig, debugConfig.dartTestLogFile || conf.dartTestLogFile);
 		debugConfig.debugSdkLibraries = debugConfig.debugSdkLibraries !== undefined && debugConfig.debugSdkLibraries !== null
 			? debugConfig.debugSdkLibraries
 			: !!config.debugSdkLibraries;
@@ -607,8 +607,8 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 				debugConfig.customTool = customScript?.script;
 				debugConfig.customToolReplacesArgs = customScript?.replacesArgs;
 			}
-			debugConfig.flutterRunLogFile = insertSessionName(debugConfig, debugConfig.flutterRunLogFile || conf.flutterRunLogFile);
-			debugConfig.flutterTestLogFile = insertSessionName(debugConfig, debugConfig.flutterTestLogFile || conf.flutterTestLogFile);
+			debugConfig.flutterRunLogFile = this.insertSessionName(debugConfig, debugConfig.flutterRunLogFile || conf.flutterRunLogFile);
+			debugConfig.flutterTestLogFile = this.insertSessionName(debugConfig, debugConfig.flutterTestLogFile || conf.flutterTestLogFile);
 			debugConfig.showMemoryUsage =
 				debugConfig.showMemoryUsage || debugConfig.showMemoryUsage === false
 					? debugConfig.showMemoryUsage
@@ -774,6 +774,12 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		if (!args.includes(toAdd[0])) {
 			toAdd.forEach((s) => args.push(s));
 		}
+	}
+
+	private insertSessionName(args: { name: string }, logPath: string | undefined) {
+		return logPath
+			? logPath.replace(/\${name}/ig, filenameSafe(args.name || "unnamed-session"))
+			: logPath;
 	}
 }
 

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -48,12 +48,6 @@ export function resolvePaths<T extends string | undefined>(p: T): string | (unde
 	return p;
 }
 
-export function insertSessionName(args: { name: string }, logPath: string | undefined) {
-	return logPath
-		? logPath.replace(/\${name}/ig, filenameSafe(args.name || "unnamed-session"))
-		: logPath;
-}
-
 export function insertWorkspaceName<T extends string | undefined>(p: T): string | (undefined extends T ? undefined : never) {
 	if (typeof p !== "string")
 		return undefined as (undefined extends T ? undefined : never);

--- a/src/shared/logging.ts
+++ b/src/shared/logging.ts
@@ -6,7 +6,6 @@ import { platformEol } from "./constants";
 import { LogCategory, LogSeverity } from "./enums";
 import { IAmDisposable, LogMessage, Logger, SpawnedProcess } from "./interfaces";
 import { errorString } from "./utils";
-import { createFolderForFile } from "./utils/fs";
 
 class LogEmitter extends EventEmitter {
 	public fire(msg: LogMessage): void {
@@ -111,7 +110,6 @@ export function captureLogs(logger: EmittingLogger, file: string, header: string
 	if (!file || !path.isAbsolute(file))
 		throw new Error("Path passed to logTo must be an absolute path");
 	const time = (detailed = false) => detailed ? `[${(new Date()).toTimeString()}] ` : `[${(new Date()).toLocaleTimeString()}] `;
-	createFolderForFile(file);
 	let logStream: fs.WriteStream | undefined = fs.createWriteStream(file);
 	if (header)
 		logStream.write(header);

--- a/src/shared/utils/fs.ts
+++ b/src/shared/utils/fs.ts
@@ -377,12 +377,6 @@ export function createFolderForFile(file?: string): string | undefined {
 		if (!file || !path.isAbsolute(file))
 			return undefined;
 
-		// Skip creation of paths with variables, we'll rely on them
-		// being created after resolving.
-		if (file?.includes("${")) {
-			return file;
-		}
-
 		const folder = path.dirname(file);
 		if (!fs.existsSync(folder))
 			mkDirRecursive(folder);


### PR DESCRIPTION
This PR is to address the following part of a comment I made:

> Also, here are all the files I'm setting:
> 
> ![image](https://github.com/user-attachments/assets/01a4ef54-dc0a-4249-bbd8-787566c5a283)
> 
> Although some of the markdown hints you changed it so it would show that `${workspaceName}` would work, only flutterTestLogFile does show that we can also use `${name}`:
> 
> ![image](https://github.com/user-attachments/assets/f72b3112-55f4-4bbe-8e15-52f88409d126)
> 
> And the `extensionLogFile` shows neither.
> 
> ![image](https://github.com/user-attachments/assets/fa63a05e-9bea-46fb-a396-0e49503f02d5)
> 
Originally posted by @FMorschel in https://github.com/Dart-Code/Dart-Code/issues/5154#issuecomment-2228343112

