### PR TITLE
Fixing typo and consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -2872,7 +2872,6 @@
 						"markdownDescription": "**LEGACY SETTING: Disabling this may break functionality on modern SDKs.**\n\nWhether to pass `--track-widget-creation` to Flutter apps (required to support 'Inspect Widget'). This setting is always ignored when running in Profile or Release mode.",
 						"scope": "resource"
 					},
-
 					"dart.dartTestLogFile": {
 						"type": [
 							"null",
@@ -2915,7 +2914,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for communication between Dart Code and the webdev daemon. This is useful when trying to diagnose issues with launching web apps. Use `${name`} in the log file name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for communication between Dart Code and the webdev daemon. This is useful when trying to diagnose issues with launching web apps. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
 						"scope": "machine-overridable"
 					}
 				}


### PR DESCRIPTION
This PR only fixes a typo and adds more consistency between all descriptions of legacy log options that allow an entry of `${name}` in log file paths.