### PR TITLE
Fix resolvePaths to handle Windows paths with backslashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2347,7 +2347,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "The path to a log file for very detailed logging in the Dart Analysis Server that may be useful when trying to diagnose Analysis Server issues. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
+						"markdownDescription": "The path to a log file for very detailed logging in the Dart Analysis Server that may be useful when trying to diagnose Analysis Server issues. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory (the path should use `/` separators even on Windows). Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.analyzerLogFile": {
@@ -2356,7 +2356,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "The path to a log file for communication between Dart Code and the Analysis Server. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
+						"markdownDescription": "The path to a log file for communication between Dart Code and the Analysis Server. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory (the path should use `/` separators even on Windows). Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.toolingDaemonLogFile": {
@@ -2365,7 +2365,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "The path to a log file for the `dart tooling-daemon` service, which coordinates between various Dart and Flutter tools and extensions. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
+						"markdownDescription": "The path to a log file for the `dart tooling-daemon` service, which coordinates between various Dart and Flutter tools and extensions. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory (the path should use `/` separators even on Windows). Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.dapLogFile": {
@@ -2374,7 +2374,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "The path to a log file for communication with the DAP debug adapters. This is useful when trying to diagnose issues with debugging such as missed breakpoints. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `${kind}` to insert a description of the kind of debug session ('dart', 'dart_test', 'flutter' etc.). Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
+						"markdownDescription": "The path to a log file for communication with the DAP debug adapters. This is useful when trying to diagnose issues with debugging such as missed breakpoints. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `${kind}` to insert a description of the kind of debug session ('dart', 'dart_test', 'flutter' etc.). Use `~` to insert the user's home directory (the path should use `/` separators even on Windows). Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.devToolsLogFile": {
@@ -2383,7 +2383,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "The path to a low-traffic log file for the Dart DevTools service. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
+						"markdownDescription": "The path to a low-traffic log file for the Dart DevTools service. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory (the path should use `/` separators even on Windows). Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.extensionLogFile": {
@@ -2392,7 +2392,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "The path to a low-traffic log file for basic extension and editor issues. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
+						"markdownDescription": "The path to a low-traffic log file for basic extension and editor issues. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory (the path should use `/` separators even on Windows). Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.flutterDaemonLogFile": {
@@ -2401,7 +2401,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "The path to a log file for the `flutter daemon` service, which provides information about connected devices accessible from the status bar. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
+						"markdownDescription": "The path to a log file for the `flutter daemon` service, which provides information about connected devices accessible from the status bar. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory (the path should use `/` separators even on Windows). Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.maxLogLineLength": {
@@ -2887,7 +2887,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for Dart test runs. This is useful when trying to diagnose issues with unit test executions. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
+						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for Dart test runs. This is useful when trying to diagnose issues with unit test executions. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory (the path should use `/` separators even on Windows). Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.flutterRunLogFile": {
@@ -2896,7 +2896,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for `flutter run`, which is used to launch Flutter apps from VS Code. This is useful when trying to diagnose issues with apps launching (or failing to) on simulators and devices. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
+						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for `flutter run`, which is used to launch Flutter apps from VS Code. This is useful when trying to diagnose issues with apps launching (or failing to) on simulators and devices. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory (the path should use `/` separators even on Windows). Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.flutterTestLogFile": {
@@ -2905,7 +2905,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for `flutter test`, which is used to run unit tests from VS Code. This is useful when trying to diagnose issues with unit test executions. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
+						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for `flutter test`, which is used to run unit tests from VS Code. This is useful when trying to diagnose issues with unit test executions. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory (the path should use `/` separators even on Windows). Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.vmServiceLogFile": {
@@ -2914,7 +2914,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for communication between Dart Code and the VM service. This is useful when trying to diagnose issues with debugging such as missed breakpoints. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
+						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for communication between Dart Code and the VM service. This is useful when trying to diagnose issues with debugging such as missed breakpoints. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory (the path should use `/` separators even on Windows). Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.webDaemonLogFile": {
@@ -2923,7 +2923,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for communication between Dart Code and the webdev daemon. This is useful when trying to diagnose issues with launching web apps. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
+						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for communication between Dart Code and the webdev daemon. This is useful when trying to diagnose issues with launching web apps. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory (the path should use `/` separators even on Windows). Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					}
 				}

--- a/package.json
+++ b/package.json
@@ -2347,7 +2347,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "The path to a log file for very detailed logging in the Dart Analysis Server that may be useful when trying to diagnose Analysis Server issues. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "The path to a log file for very detailed logging in the Dart Analysis Server that may be useful when trying to diagnose Analysis Server issues. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.analyzerLogFile": {
@@ -2356,7 +2356,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "The path to a log file for communication between Dart Code and the Analysis Server. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "The path to a log file for communication between Dart Code and the Analysis Server. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.toolingDaemonLogFile": {
@@ -2365,7 +2365,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "The path to a log file for the `dart tooling-daemon` service, which coordinates between various Dart and Flutter tools and extensions. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "The path to a log file for the `dart tooling-daemon` service, which coordinates between various Dart and Flutter tools and extensions. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.dapLogFile": {
@@ -2374,7 +2374,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "The path to a log file for communication with the DAP debug adapters. This is useful when trying to diagnose issues with debugging such as missed breakpoints. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `${kind}` to insert a description of the kind of debug session ('dart', 'dart_test', 'flutter' etc.).",
+						"markdownDescription": "The path to a log file for communication with the DAP debug adapters. This is useful when trying to diagnose issues with debugging such as missed breakpoints. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `${kind}` to insert a description of the kind of debug session ('dart', 'dart_test', 'flutter' etc.). Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.devToolsLogFile": {
@@ -2383,7 +2383,7 @@
 							"string"
 						],
 						"default": null,
-						"description": "The path to a low-traffic log file for the Dart DevTools service. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "The path to a low-traffic log file for the Dart DevTools service. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.extensionLogFile": {
@@ -2392,7 +2392,7 @@
 							"string"
 						],
 						"default": null,
-						"description": "The path to a low-traffic log file for basic extension and editor issues. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "The path to a low-traffic log file for basic extension and editor issues. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.flutterDaemonLogFile": {
@@ -2401,7 +2401,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "The path to a log file for the `flutter daemon` service, which provides information about connected devices accessible from the status bar. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "The path to a log file for the `flutter daemon` service, which provides information about connected devices accessible from the status bar. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.maxLogLineLength": {
@@ -2887,7 +2887,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for Dart test runs. This is useful when trying to diagnose issues with unit test executions. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for Dart test runs. This is useful when trying to diagnose issues with unit test executions. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.flutterRunLogFile": {
@@ -2896,7 +2896,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for `flutter run`, which is used to launch Flutter apps from VS Code. This is useful when trying to diagnose issues with apps launching (or failing to) on simulators and devices. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for `flutter run`, which is used to launch Flutter apps from VS Code. This is useful when trying to diagnose issues with apps launching (or failing to) on simulators and devices. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.flutterTestLogFile": {
@@ -2905,7 +2905,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for `flutter test`, which is used to run unit tests from VS Code. This is useful when trying to diagnose issues with unit test executions. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for `flutter test`, which is used to run unit tests from VS Code. This is useful when trying to diagnose issues with unit test executions. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.vmServiceLogFile": {
@@ -2914,7 +2914,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for communication between Dart Code and the VM service. This is useful when trying to diagnose issues with debugging such as missed breakpoints. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for communication between Dart Code and the VM service. This is useful when trying to diagnose issues with debugging such as missed breakpoints. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					},
 					"dart.webDaemonLogFile": {
@@ -2923,7 +2923,7 @@
 							"string"
 						],
 						"default": null,
-						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for communication between Dart Code and the webdev daemon. This is useful when trying to diagnose issues with launching web apps. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path.",
+						"markdownDescription": "**LEGACY SETTING: Only applies when using the legacy debug adapters.**\n\nThe path to a log file for communication between Dart Code and the webdev daemon. This is useful when trying to diagnose issues with launching web apps. Use `${name}` in the log file name to insert the Debug Session name to prevent concurrent debug sessions overwriting each others logs. Use `${workspaceName}` to insert the name of the current workspace in the file path. Use `~` to insert the user's home directory. Only the noted substitutions are supported, others will stay as-is.",
 						"scope": "machine-overridable"
 					}
 				}

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -41,7 +41,7 @@ export function resolvePaths<T extends string | undefined>(p: T): string | (unde
 	if (typeof p !== "string")
 		return undefined as (undefined extends T ? undefined : never);
 
-	if (p.startsWith("~/") || p.startsWith("~\\"))
+	if (p.startsWith("~/"))
 		return path.join(os.homedir(), p.substr(2));
 	if (!path.isAbsolute(p) && workspace.workspaceFolders && workspace.workspaceFolders.length)
 		return path.join(fsPath(workspace.workspaceFolders[0].uri), p);

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -41,7 +41,7 @@ export function resolvePaths<T extends string | undefined>(p: T): string | (unde
 	if (typeof p !== "string")
 		return undefined as (undefined extends T ? undefined : never);
 
-	if (p.startsWith("~/"))
+	if (p.startsWith("~/") || p.startsWith("~\\"))
 		return path.join(os.homedir(), p.substr(2));
 	if (!path.isAbsolute(p) && workspace.workspaceFolders && workspace.workspaceFolders.length)
 		return path.join(fsPath(workspace.workspaceFolders[0].uri), p);


### PR DESCRIPTION
Adding the option to replace `~` for the home directory in paths that use backslashes.

Also, making clearer that only the noted substitutions are allowed and everything else will be left in the path as-is.