### PR TITLE
Spawn Flutter debug adapter directly with dart.exe

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -599,7 +599,7 @@ export async function activate(context: vs.ExtensionContext, isRestart = false) 
 	context.subscriptions.push(vs.debug.registerDebugAdapterTrackerFactory("dart", debugLogger));
 	const trackerFactories = [globalEvaluationContext, hexFormatter, forcedDebugMode, removeErrorShowUser, supportUris, launchStatus, debugLogger];
 
-	const debugAdapterDescriptorFactory = new DartDebugAdapterDescriptorFactory(analytics, sdks, logger, extContext, dartCapabilities, flutterCapabilities, workspaceContext, experiments);
+	const debugAdapterDescriptorFactory = new DartDebugAdapterDescriptorFactory(analytics, sdks, logger, extContext, dartCapabilities, flutterCapabilities, vsCodeVersion, workspaceContext, experiments);
 	context.subscriptions.push(vs.debug.registerDebugAdapterDescriptorFactory("dart", debugAdapterDescriptorFactory));
 	// Also the providers for the initial configs.
 	if (vs.DebugConfigurationProviderTriggerKind) { // Temporary workaround for GitPod/Theia not having this enum.

--- a/src/extension/providers/debug_adapter_descriptor_factory.ts
+++ b/src/extension/providers/debug_adapter_descriptor_factory.ts
@@ -2,7 +2,8 @@ import * as path from "path";
 import { DebugAdapterDescriptor, DebugAdapterDescriptorFactory, DebugAdapterExecutable, DebugAdapterExecutableOptions, DebugAdapterServer, DebugSession } from "vscode";
 import { DartCapabilities } from "../../shared/capabilities/dart";
 import { FlutterCapabilities } from "../../shared/capabilities/flutter";
-import { dartVMPath, debugAdapterPath, executableNames, flutterPath } from "../../shared/constants";
+import { CodeCapabilities } from "../../shared/capabilities/vscode";
+import { dartVMPath, debugAdapterPath, executableNames, flutterPath, isWin } from "../../shared/constants";
 import { DebuggerType } from "../../shared/enums";
 import { DartSdks, Logger } from "../../shared/interfaces";
 import { getDebugAdapterName, getDebugAdapterPort } from "../../shared/utils/debug";
@@ -16,7 +17,7 @@ import { KnownExperiments } from "../experiments";
 import { getToolEnv } from "../utils/processes";
 
 export class DartDebugAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
-	constructor(private readonly analytics: Analytics, private readonly sdks: DartSdks, private readonly logger: Logger, private readonly extensionContext: Context, private readonly dartCapabilities: DartCapabilities, private readonly flutterCapabilities: FlutterCapabilities, private readonly workspaceContext: WorkspaceContext, private readonly experiments: KnownExperiments) { }
+	constructor(private readonly analytics: Analytics, private readonly sdks: DartSdks, private readonly logger: Logger, private readonly extensionContext: Context, private readonly dartCapabilities: DartCapabilities, private readonly flutterCapabilities: FlutterCapabilities, private readonly codeCapabilities: CodeCapabilities, private readonly workspaceContext: WorkspaceContext, private readonly experiments: KnownExperiments) { }
 
 	public createDebugAdapterDescriptor(session: DebugSession, executable: DebugAdapterExecutable | undefined): DebugAdapterDescriptor {
 		return this.descriptorForType(session.configuration.debuggerType as DebuggerType, !!session.configuration.noDebug);
@@ -126,11 +127,11 @@ export class DartDebugAdapterDescriptorFactory implements DebugAdapterDescriptor
 			this.logger.info(`Running custom Flutter debugger using Dart VM with args ${args.join("    ")} and options ${JSON.stringify(executableOptions)}`);
 			return new DebugAdapterExecutable(path.join(this.sdks.dart, dartVMPath), args, executableOptions);
 		} else if (useSdkDap) {
-			const executable = isDartOrDartTest
+			let executable = isDartOrDartTest
 				? path.join(this.sdks.dart, dartVMPath)
 				: this.workspaceContext.config.flutterToolsScript?.script ?? (this.sdks.flutter ? path.join(this.sdks.flutter, flutterPath) : executableNames.flutter);
 
-			const args = ["debug_adapter"];
+			let args = ["debug_adapter"];
 			if (isDartTestOrFlutterTest)
 				args.push("--test");
 			if (isFlutterTest && this.flutterCapabilities.requiresDdsDisabledForSdkDapTestRuns)
@@ -138,6 +139,20 @@ export class DartDebugAdapterDescriptorFactory implements DebugAdapterDescriptor
 
 			if (this.workspaceContext.config.flutterSdkHome)
 				executableOptions.cwd = this.workspaceContext.config.flutterSdkHome;
+
+			const requiresBatWorkaround = isWin && !isDartOrDartTest && this.codeCapabilities.isUnableToRunBatDebugAdapters;
+			if (requiresBatWorkaround && this.sdks.flutter) {
+				this.logger.info(`Spawning debug adapter directly with dart.exe due to VS Code issue #224184`);
+				// From flutter.bat:
+				// "%dart%" --disable-dart-dev --packages="%flutter_tools_dir%\.dart_tool\package_config.json" %FLUTTER_TOOL_ARGS% "%snapshot_path%" %* & "%exit_with_errorlevel%"
+				executable = path.join(this.sdks.dart, dartVMPath);
+				args = [
+					"--disable-dart-dev",
+					`--packages=${path.join(this.sdks.flutter, ".dart_tool", "package_config.json")}`,
+					path.join(this.sdks.flutter, "bin", "cache", "flutter_tools.snapshot"),
+					...args,
+				];
+			}
 
 			this.logger.info(`Running SDK DAP Dart VM in ${executableOptions.cwd}: ${executable} ${args.join("    ")} and options ${JSON.stringify(executableOptions)}`);
 			logDebuggerStart(true);

--- a/src/shared/capabilities/vscode.ts
+++ b/src/shared/capabilities/vscode.ts
@@ -19,6 +19,10 @@ export class CodeCapabilities {
 	get supportsEmbeddedDevTools() { return !isKnownCloudIde(env.appName); }
 	get supportsDevTools() { return !isCloudShell(env.appName); } // Until DevTools can work without SSE, it will not work on Cloud Shell.
 	get editorConfigFolder() { return isTheia(env.appName) ? ".theia" : ".vscode"; }
+
+	// Whether this version of VS Code has the issue that we can't spawn .bat debug adapters.
+	// https://github.com/microsoft/vscode/issues/224184
+	get isUnableToRunBatDebugAdapters() { return versionIsAtLeast(this.version, "1.92.0-0"); }
 }
 
 export const vsCodeVersion = new CodeCapabilities(codeVersion);


### PR DESCRIPTION
This is a fix (workaround) for a potentially serious issue debugging Flutter on Windows with the incoming VS Code (editor) release. I plan to ship it a Dart-Code pre-release shortly (today) to get some testing and may ship in a stable release tomorrow or Thursday.

@andrewkolos @jwren @helin24 I would appreciate additional eyes over this change before the stable release if possible. It's not a particularly nice workaround but it's currently all I have.

A summary of the issue:

A recent breaking change in NodeJS means spawning a `.bat` shell script on Windows without explicitly setting `shell: true` will fail with an `EINVAL` error. The upcoming release of the VS Code editor (being prepared and likely to ship this or next week) updates to a version of NodeJS that includes that change. Our extension code has always used `shell: true` where necessary, however the Debug Adapter (`flutter debug_adapter`) is not started directly by us in the extension - instead, we pass a `executable: string, args: string[]` to the VS Code editor and it spawns the process. It does not provide the ability for us to tell it to use `shell: true`. I have filed https://github.com/microsoft/vscode/issues/224184 and (open a PR at https://github.com/microsoft/vscode/pull/224204 with a fix) however because it's close to release and my proposed fix was an API change, it will not be merged before the stable VS Code release.

If we do nothing, Windows users will be unable to launch Flutter debug sessions with the upcoming VS Code release (and this is already the case for those using Insider builds of VS Code).

As a workaround, when using the affected version of VS Code (on Windows), I am substituting `"sdk-path\bin\flutter.bat debug_adapter"` with the equivalent command that the shell script runs `"(sdk-path)\bin\cache\dart-sdk\bin\dart --packages="..." (tool-snapshot-path) debug_adapter`. This works for me locally in Insiders, and is passing all of the  (previously failing) CI tests run against insiders.

As I was writing this, VS Code devs agreed to look at another fix (https://github.com/microsoft/vscode/issues/224184#issuecomment-2258617405) so we might not need this - however I'm going to continue with putting this into a pre-release extension for additional testing so if they are unable to ship a fix, we have this to fall back on (and it isn't completely untested).

(I'm merging it so it can go into the pre-release so this PR will be closed, but if you have any feedback or concerns, please still leave them here and I will address).

Fixes https://github.com/Dart-Code/Dart-Code/issues/5183