### PR TITLE
Add the ability to show notifications when the current SDK is unsupported (or will be soon)

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -765,7 +765,7 @@ export async function activate(context: vs.ExtensionContext, isRestart = false) 
 
 	// Prompt user for any special config we might want to set.
 	if (!isRestart)
-		void showUserPrompts(logger, extContext, webClient, analytics, workspaceContext, extensionRecommendations);
+		void showUserPrompts(logger, extContext, webClient, analytics, workspaceContext, dartCapabilities, extensionRecommendations);
 
 	// Turn on all the commands.
 	setCommandVisiblity(true, workspaceContext);

--- a/src/shared/capabilities/dart.ts
+++ b/src/shared/capabilities/dart.ts
@@ -21,8 +21,14 @@ export class DartCapabilities {
 			return versionIsAtLeast(this.version, "2.18.0-0");
 	}
 	get hasLspInsertTextModeSupport() { return versionIsAtLeast(this.version, "2.13.0-0"); }
+
+	// No SDKs are currently unsupported.
 	get isUnsupportedNow() { return false; }
-	get isUnsupportedSoon() { return false; }
+
+	// SDKs older than 3.0 are deprecated as of the release of Dart 3.6.
+	// https://groups.google.com/g/flutter-announce/c/JQHzM3FbBGI
+	get isUnsupportedSoon() { return !versionIsAtLeast(this.version, "3.0.0"); }
+
 	get supportsSnippetTextEdits() { return versionIsAtLeast(this.version, "2.13.0-150"); }
 	get supportsRefactorValidate() { return versionIsAtLeast(this.version, "2.17.0"); }
 	get supportsWriteServiceInfo() { return versionIsAtLeast(this.version, "2.7.1"); }

--- a/src/shared/capabilities/dart.ts
+++ b/src/shared/capabilities/dart.ts
@@ -27,7 +27,7 @@ export class DartCapabilities {
 
 	// SDKs older than 3.0 are deprecated as of the release of Dart 3.6.
 	// https://groups.google.com/g/flutter-announce/c/JQHzM3FbBGI
-	get isUnsupportedSoon() { return !versionIsAtLeast(this.version, "3.0.0"); }
+	get isUnsupportedSoon() { return false; /* return !versionIsAtLeast(this.version, "3.0.0"); */ }
 
 	get supportsSnippetTextEdits() { return versionIsAtLeast(this.version, "2.13.0-150"); }
 	get supportsRefactorValidate() { return versionIsAtLeast(this.version, "2.17.0"); }

--- a/src/shared/capabilities/dart.ts
+++ b/src/shared/capabilities/dart.ts
@@ -21,6 +21,8 @@ export class DartCapabilities {
 			return versionIsAtLeast(this.version, "2.18.0-0");
 	}
 	get hasLspInsertTextModeSupport() { return versionIsAtLeast(this.version, "2.13.0-0"); }
+	get isUnsupportedNow() { return false; }
+	get isUnsupportedSoon() { return false; }
 	get supportsSnippetTextEdits() { return versionIsAtLeast(this.version, "2.13.0-150"); }
 	get supportsRefactorValidate() { return versionIsAtLeast(this.version, "2.17.0"); }
 	get supportsWriteServiceInfo() { return versionIsAtLeast(this.version, "2.7.1"); }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -143,6 +143,8 @@ export const tryAgainAction = "Try Again";
 export const vmServiceListeningBannerPattern = new RegExp("(?:Observatory|Dart VM [Ss]ervice) .* (?:listening on|available at:) (http:.+)");
 export const vmServiceHttpLinkPattern = new RegExp("(http://[\\d\\.:]+/)");
 
+export const sdkDeprecationInformationUrl = "https://TODO/";
+
 /// Constants used in reporting of where commands are executed from.
 ///
 /// Used in DevTools querystring, so do not change.

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -143,7 +143,7 @@ export const tryAgainAction = "Try Again";
 export const vmServiceListeningBannerPattern = new RegExp("(?:Observatory|Dart VM [Ss]ervice) .* (?:listening on|available at:) (http:.+)");
 export const vmServiceHttpLinkPattern = new RegExp("(http://[\\d\\.:]+/)");
 
-export const sdkDeprecationInformationUrl = "https://TODO/";
+export const sdkDeprecationInformationUrl = "https://dartcode.org/sdk-version-compatibility/";
 
 /// Constants used in reporting of where commands are executed from.
 ///

--- a/src/shared/vscode/workspace.ts
+++ b/src/shared/vscode/workspace.ts
@@ -6,23 +6,11 @@ export class Context {
 	}
 
 	// Helper we can manually call in the constructor when testing.
-	public clear(): void {
-		const clearableKeys = [
-			"devToolsNotificationLastShown",
-			"devToolsNotificationDoNotShowAgain",
-			"breakpointInNonDebuggableFileDoNotShowAgain",
-			"hasWarnedAboutFormatterSyntaxLimitation",
-			"hasWarnedAboutPubUpgradeMajorVersionsPubpecMutation",
-			"hasNotifiedAboutProfileModeDefaultConfiguration",
-			"lastSeenVersion",
-			"lastUsedNewProjectPath",
-			"ignoredExtensionRecommendations",
-			"workspaceLastFlutterDeviceId",
-		];
-		for (const clearableKey of clearableKeys) {
-			void this.context.globalState.update(clearableKey, undefined);
-			void this.context.workspaceState.update(clearableKey, undefined);
-		}
+	public async clear(): Promise<void> {
+		for (const clearableKey of this.context.globalState.keys())
+			await this.context.globalState.update(clearableKey, undefined);
+		for (const clearableKey of this.context.workspaceState.keys())
+			await this.context.workspaceState.update(clearableKey, undefined);
 	}
 
 	public static for(context: ExtensionContext, workspaceContext: DartWorkspaceContext): Context {
@@ -43,6 +31,8 @@ export class Context {
 	public setFlutterSurveyNotificationLastShown(id: string, value: number | undefined) { void this.context.globalState.update(`flutterSurvey${id}NotificationLastShown`, value); }
 	public getFlutterSurveyNotificationDoNotShow(id: string): boolean | undefined { return !!this.context.globalState.get(`flutterSurvey${id}NotificationDoNotShowAgain`); }
 	public setFlutterSurveyNotificationDoNotShow(id: string, value: boolean | undefined) { void this.context.globalState.update(`flutterSurvey${id}NotificationDoNotShowAgain`, value); }
+	public getSdkDeprecationNoticeDoNotShow(dartSdkVersion: string): boolean | undefined { return !!this.context.globalState.get(`dartSdk${dartSdkVersion}DeprecationNotificationDoNotShowAgain`); }
+	public setSdkDeprecationNoticeDoNotShow(dartSdkVersion: string, value: boolean | undefined) { void this.context.globalState.update(`dartSdk${dartSdkVersion}DeprecationNotificationDoNotShowAgain`, value); }
 	get hasWarnedAboutFormatterSyntaxLimitation(): boolean { return !!this.context.globalState.get("hasWarnedAboutFormatterSyntaxLimitation"); }
 	set hasWarnedAboutFormatterSyntaxLimitation(value: boolean) { void this.context.globalState.update("hasWarnedAboutFormatterSyntaxLimitation", value); }
 	get hasWarnedAboutPubUpgradeMajorVersionsPubpecMutation(): boolean { return !!this.context.globalState.get("hasWarnedAboutPubUpgradeMajorVersionsPubpecMutation"); }

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -1261,15 +1261,8 @@ export async function addLaunchConfigsForTest(workspaceUri: vs.Uri, configs: any
 	});
 }
 
-export function clearAllContext(context: Context): Promise<void> {
-	context.devToolsNotificationLastShown = undefined;
-	context.devToolsNotificationDoNotShow = undefined;
-	context.setFlutterSurveyNotificationLastShown(flutterTestSurveyID, undefined);
-	context.setFlutterSurveyNotificationDoNotShow(flutterTestSurveyID, undefined);
-
-	// HACK: Updating context is async, but since we use setters we can't easily wait
-	// and this is only test code...
-	return new Promise((resolve) => setTimeout(resolve, 50));
+export async function clearAllContext(context: Context): Promise<void> {
+	await context.clear();
 }
 
 export function ensurePackageTreeNode(items: vs.TreeItem[] | undefined | null, nodeContext: string, label: string, description?: string): vs.TreeItem {


### PR DESCRIPTION
This adds two new fields to `DartCapabilities` for `isUnsupportedNow` and `isUnsupportedSoon` to determine whether to warn the user about unsupported SDKs. This is a necessary step before we can remove any legacy code (such as the legacy analysis server integration, or activating DevTools from pub!).

We always do the SDK check against the Dart SDK version, but if the current Dart SDK comes from Flutter, we will reference "Flutter" and its SDK version in the user-facing messages.

"Unsupported now" messages will always be shown as the intention is that the user will either upgrade their SDK or switch to an older extension.. this may seem annoying, but the extension will be broken in many ways when using an SDK that triggers this, so ignoring it is not an option - you must upgrade SDK or switch to an older extension.

"Unsupported soon" messages will be shown only until dismissed the first time (clicking "More Info" counts as dismissing), but this is tracked by major+minor versions, so dismissing for Dart 2.0 would not prevent seeing the message again in future for 3.0.

Currently looks like this (version number is just the SDK I was testing with, ofc):

![Screenshot 2024-09-10 175404](https://github.com/user-attachments/assets/8d6b3ec9-7fa2-4496-b4ab-8c70969fa564)

![Screenshot 2024-09-10 175318](https://github.com/user-attachments/assets/f182dadb-1b7e-4743-b327-f313ff39fdc2)

Where it says "Flutter SDK" and shows a Flutter SDK version number will be "Dart SDK" if the selected SDK is a standalone Dart SDK.

## TODO Before Merging

- [x] agree specific text for each message
- [ ] ~~update extension on https://dartcode.org/sdk-version-compatibility/~~ moved to https://github.com/Dart-Code/Dart-Code/issues/5304
- [x] agree specific SDK version that will become "unsupported soon"
- [x] agree which Dart-Code release this will first ship in
- [x] agree a URL to link to for the "More Info" button
- [x] add a matrix of supported extension / SDK versions (on dartcode.org, or the dart.dev site?)

@jwren @helin24 @itsjustkevin