### PR TITLE
Add `enableSearchInAnalysisOptionsExcludedFolders` config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -2810,6 +2810,12 @@
 						"description": "How many levels (including the workspace roots) down the workspace to search for Dart/Flutter projects. Increasing this number may help detect Flutter projects that are deeply nested in your workspace but slow down all operations that search for projects, including extension activation.",
 						"scope": "window"
 					},
+					"dart.enableSearchInAnalysisOptionsExcludedFolders": {
+						"type": "boolean",
+						"default": false,
+						"description": "Whether to search for Dart/Flutter projects in directories excluded in analysis_options.yaml. This can be useful if you have a mono-repo with multiple Dart/Flutter projects.",
+						"scope": "window"
+					},
 					"dart.env": {
 						"type": "object",
 						"default": {},

--- a/package.json
+++ b/package.json
@@ -2813,7 +2813,7 @@
 					"dart.enableSearchInAnalysisOptionsExcludedFolders": {
 						"type": "boolean",
 						"default": false,
-						"description": "Whether to search for Dart/Flutter projects in directories excluded in analysis_options.yaml. This can be useful if you have a mono-repo with multiple Dart/Flutter projects.",
+						"description": "Whether to search for Dart/Flutter projects in directories excluded in `analysis_options.yaml`. This can be useful if you have a monorepo with multiple Dart/Flutter projects. For example, if you have a `packages` directory excluded in `analysis_options.yaml`, enabling this setting will allow each Dart/Flutter project inside to be analyzed using its own `analysis_options.yaml` instead of the one from the root directory. Enabling this setting allows Dart Code to find projects in that directory, making it possible to, for example, select target platforms that are not defined in the root directory.",
 						"scope": "window"
 					},
 					"dart.env": {

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -110,6 +110,7 @@ class Config {
 	get enableSdkFormatter(): boolean { return this.getConfig<boolean>("enableSdkFormatter", true); }
 	get enableServerSnippets(): boolean { return this.getConfig<boolean>("enableServerSnippets", true); }
 	get enableSnippets(): boolean { return this.getConfig<boolean>("enableSnippets", true); }
+	get enableSearchInAnalysisOptionsExcludedFolders(): boolean { return this.getConfig<boolean>("enableSearchInAnalysisOptionsExcludedFolders", false); }
 	get env(): object { return this.getConfig<object>("env", {}); }
 	get evaluateToStringInDebugViews(): boolean { return this.getConfig<boolean>("evaluateToStringInDebugViews", true); }
 	get experimentalRefactors(): boolean { return this.getConfig<boolean>("experimentalRefactors", false); }

--- a/src/shared/vscode/utils.ts
+++ b/src/shared/vscode/utils.ts
@@ -150,8 +150,7 @@ export async function getAllProjectFoldersAndExclusions(
 		logger.info(`Took ${new Date().getTime() - startTimeMs}ms to search for projects (${options.searchDepth} levels)`);
 		startTimeMs = new Date().getTime();
 
-		// Filter out any folders excluded by analysis_options.
-
+		// Filter out any folders excluded by analysis_options if enableSearchInAnalysisOptionsExcludedFolders is set to false.
 		if (!config.enableSearchInAnalysisOptionsExcludedFolders) {
 			try {
 				const excludedFolders = getAnalysisOptionsExcludedFolders(logger, projectFolders);


### PR DESCRIPTION
Previously, folders excluded in `analysis_options.yaml` were also excluded from Dart/Flutter project searches. One case where this caused issues is explained in #5250. This PR introduces `enableSearchInAnalysisOptionsExcludedFolders`, a setting that controls whether folders excluded from analysis in `analysis_options.yaml` should be included in the project search. By default, this option is set to `false`, maintaining the extension’s previous behavior. This option may be essential for projects with a monorepo structure.