### PR TITLE
Custom commands to obtain the Dart/Flutter SDK path 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2796,7 +2796,7 @@
 							"null",
 							"object"
 						],
-						"required": ["executable", "cwd"], 
+						"required": ["executable"], 
 						"additionalProperties": false,
 						"default": null,
 						"description": "Get the Flutter SDK path from a command. Useful when using tools such as direnv, asdf, mise...",
@@ -2807,11 +2807,45 @@
 							"args": {
 								"type": ["null", "array"],
 								"items": {
-								"type": "string"
+									"type": "string"
 								}
 							},
 							"cwd": {
+								"type": ["null", "string"],
+								"description": "The working directory of the command relative to the workspace file directory if any, or relative to the workspace folder."
+							},
+							"env": {
+								"type": "object",
+								"additionalProperties": {
+									"type": ["string", "null"]
+								},
+								"description": "Environment variables to use when running the command. Keys are variable names, and values are strings or null."
+							}
+						},
+						"scope": "machine-overridable"
+					},
+					"dart.getDartSdkCommand": {
+						"type": [
+							"null",
+							"object"
+						],
+						"required": ["executable"], 
+						"additionalProperties": false,
+						"default": null,
+						"description": "Get the Dart SDK path from a command. Useful when using tools such as direnv, asdf, mise...",
+						"properties": {
+							"executable": {
 								"type": "string"
+							},
+							"args": {
+								"type": ["null", "array"],
+								"items": {
+									"type": "string"
+								}
+							},
+							"cwd": {
+								"type": ["null", "string"],
+								"description": "The working directory of the command relative to the workspace file directory if any, or relative to the workspace folder."
 							},
 							"env": {
 								"type": "object",

--- a/package.json
+++ b/package.json
@@ -2796,7 +2796,9 @@
 							"null",
 							"object"
 						],
-						"required": ["executable"], 
+						"required": [
+							"executable"
+						],
 						"additionalProperties": false,
 						"default": null,
 						"description": "Get the Flutter SDK path from a command. Useful when using tools such as direnv, asdf, mise...",
@@ -2805,19 +2807,28 @@
 								"type": "string"
 							},
 							"args": {
-								"type": ["null", "array"],
+								"type": [
+									"null",
+									"array"
+								],
 								"items": {
 									"type": "string"
 								}
 							},
 							"cwd": {
-								"type": ["null", "string"],
+								"type": [
+									"null",
+									"string"
+								],
 								"description": "The working directory of the command relative to the workspace file directory if any, or relative to the workspace folder."
 							},
 							"env": {
 								"type": "object",
 								"additionalProperties": {
-									"type": ["string", "null"]
+									"type": [
+										"string",
+										"null"
+									]
 								},
 								"description": "Environment variables to use when running the command. Keys are variable names, and values are strings or null."
 							}
@@ -2829,7 +2840,9 @@
 							"null",
 							"object"
 						],
-						"required": ["executable"], 
+						"required": [
+							"executable"
+						],
 						"additionalProperties": false,
 						"default": null,
 						"description": "Get the Dart SDK path from a command. Useful when using tools such as direnv, asdf, mise...",
@@ -2838,19 +2851,28 @@
 								"type": "string"
 							},
 							"args": {
-								"type": ["null", "array"],
+								"type": [
+									"null",
+									"array"
+								],
 								"items": {
 									"type": "string"
 								}
 							},
 							"cwd": {
-								"type": ["null", "string"],
+								"type": [
+									"null",
+									"string"
+								],
 								"description": "The working directory of the command relative to the workspace file directory if any, or relative to the workspace folder."
 							},
 							"env": {
 								"type": "object",
 								"additionalProperties": {
-									"type": ["string", "null"]
+									"type": [
+										"string",
+										"null"
+									]
 								},
 								"description": "Environment variables to use when running the command. Keys are variable names, and values are strings or null."
 							}

--- a/package.json
+++ b/package.json
@@ -2801,7 +2801,7 @@
 						],
 						"additionalProperties": false,
 						"default": null,
-						"description": "Get the Flutter SDK path from a command. Useful when using tools such as direnv, asdf, mise...",
+						"description": "Get the Flutter SDK path from a command. Useful when using tools such as direnv, asdf, mise... The command should exit with a 0 status code and it should print to the standard output just the path to the SDK. If the command fails (non zero exit or bad path), the extension will keep looking for other SDK paths. Some configuration examples can be found in: https://github.com/Dart-Code/Dart-Code/pull/5377",
 						"properties": {
 							"executable": {
 								"type": "string"
@@ -2845,7 +2845,7 @@
 						],
 						"additionalProperties": false,
 						"default": null,
-						"description": "Get the Dart SDK path from a command. Useful when using tools such as direnv, asdf, mise...",
+						"description": "Get the Dart SDK path from a command. Useful when using tools such as direnv, asdf, mise... The command should exit with a 0 status code and it should print to the standard output just the path to the SDK. If the command fails (non zero exit or bad path), the extension will keep looking for other SDK paths. Some configuration examples can be found in: https://github.com/Dart-Code/Dart-Code/pull/5377",
 						"properties": {
 							"executable": {
 								"type": "string"

--- a/package.json
+++ b/package.json
@@ -2790,6 +2790,38 @@
 						"default": true,
 						"markdownDescription": "Whether to add your selected Dart/Flutter SDK path to the `PATH` environment variable for the embedded terminal. This is useful when switching SDKs via `#dart.sdkPaths#` / `#dart.flutterSdkPaths#` to ensure commands run from the terminal are the same version as being used by the editor/debugger (requires restart).",
 						"scope": "window"
+					},
+					"dart.getFlutterSdkCommand": {
+						"type": [
+							"null",
+							"object"
+						],
+						"required": ["executable", "cwd"], 
+						"additionalProperties": false,
+						"default": null,
+						"description": "Get the Flutter SDK path from a command. Useful when using tools such as direnv, asdf, mise...",
+						"properties": {
+							"executable": {
+								"type": "string"
+							},
+							"args": {
+								"type": ["null", "array"],
+								"items": {
+								"type": "string"
+								}
+							},
+							"cwd": {
+								"type": "string"
+							},
+							"env": {
+								"type": "object",
+								"additionalProperties": {
+									"type": ["string", "null"]
+								},
+								"description": "Environment variables to use when running the command. Keys are variable names, and values are strings or null."
+							}
+						},
+						"scope": "machine-overridable"
 					}
 				}
 			},

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -1,5 +1,5 @@
 import { ConfigurationTarget, Uri, workspace, WorkspaceConfiguration } from "vscode";
-import { CustomDevToolsConfig } from "../shared/interfaces";
+import { CustomDevToolsConfig, GetSDKCommandConfig } from "../shared/interfaces";
 import { NullAsUndefined, nullToUndefined } from "../shared/utils";
 import { createFolderForFile } from "../shared/utils/fs";
 import { DevToolsLocation, DevToolsLocations } from "./sdk/dev_tools/manager";
@@ -148,6 +148,7 @@ class Config {
 	get flutterShowWebServerDevice(): "remote" | "always" { return this.getConfig<"remote" | "always">("flutterShowWebServerDevice", "remote"); }
 	get flutterTestLogFile(): undefined | string { return createFolderForFile(insertWorkspaceName(resolvePaths(this.getConfig<null | string>("flutterTestLogFile", null)))); }
 	get flutterWebRenderer(): "flutter-default" | "canvaskit" | "html" | "auto" { return this.getConfig<"flutter-default" | "canvaskit" | "html" | "auto">("flutterWebRenderer", "flutter-default"); }
+	get getFlutterSdkCommand(): undefined | GetSDKCommandConfig { return this.getConfig<null | GetSDKCommandConfig>("getFlutterSdkCommand", null); }
 	get hotReloadOnSave(): "never" | "manual" | "manualIfDirty" | "all" | "allIfDirty" {
 		const value = this.getConfig<"never" | "manual" | "manualIfDirty" | "all" | "allIfDirty" | "always">("hotReloadOnSave", "never");
 		if (value === "always")

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -213,6 +213,8 @@ class Config {
 
 	get workspaceSdkPath(): undefined | string { return resolvePaths(this.getWorkspaceConfig<null | string>("sdkPath")); }
 	get workspaceFlutterSdkPath(): undefined | string { return resolvePaths(this.getWorkspaceConfig<null | string>("flutterSdkPath")); }
+	get workspaceGetDartSdkCommand(): undefined | GetSDKCommandConfig { return this.getWorkspaceConfig<null | GetSDKCommandConfig>("getDartSdkCommand"); }
+	get workspaceGetFlutterSdkCommand(): undefined | GetSDKCommandConfig { return this.getWorkspaceConfig<null | GetSDKCommandConfig>("getFlutterSdkCommand"); }
 
 	get hasExplicitShowTodosSetting(): boolean {
 		return this.hasExplicitSetting("showTodos");

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -148,6 +148,7 @@ class Config {
 	get flutterShowWebServerDevice(): "remote" | "always" { return this.getConfig<"remote" | "always">("flutterShowWebServerDevice", "remote"); }
 	get flutterTestLogFile(): undefined | string { return createFolderForFile(insertWorkspaceName(resolvePaths(this.getConfig<null | string>("flutterTestLogFile", null)))); }
 	get flutterWebRenderer(): "flutter-default" | "canvaskit" | "html" | "auto" { return this.getConfig<"flutter-default" | "canvaskit" | "html" | "auto">("flutterWebRenderer", "flutter-default"); }
+	get getDartSdkCommand(): undefined | GetSDKCommandConfig { return this.getConfig<null | GetSDKCommandConfig>("getDartSdkCommand", null); }
 	get getFlutterSdkCommand(): undefined | GetSDKCommandConfig { return this.getConfig<null | GetSDKCommandConfig>("getFlutterSdkCommand", null); }
 	get hotReloadOnSave(): "never" | "manual" | "manualIfDirty" | "all" | "allIfDirty" {
 		const value = this.getConfig<"never" | "manual" | "manualIfDirty" | "all" | "allIfDirty" | "always">("hotReloadOnSave", "never");

--- a/src/extension/sdk/utils.ts
+++ b/src/extension/sdk/utils.ts
@@ -565,6 +565,10 @@ export class SdkUtils {
 			}
 			const sdkPath = commandResult.stdout.trim();
 
+			if (!sdkPath) {
+				throw new Error("No output from command");
+			}
+
 			// Check if the path exists
 			if (!fs.existsSync(sdkPath)) {
 				throw new Error(`Path does not exist: ${sdkPath}`);

--- a/src/extension/sdk/utils.ts
+++ b/src/extension/sdk/utils.ts
@@ -401,10 +401,8 @@ export class SdkUtils {
 			hasAnyFlutterProject = true;
 			flutterSdkPath = workspaceConfig?.flutterSdkHome;
 		} else {
-			const configWorkspaceFlutterSdkPath = !!config.workspaceFlutterSdkPath;
-
 			// User provided custom command to obtain the sdk path
-			const flutterSdkPathFromCommand: string | undefined = config.getFlutterSdkCommand && await this.runCustomGetSDKCommand(config.getFlutterSdkCommand, "dart.getFlutterSdkCommand", configWorkspaceFlutterSdkPath);
+			const flutterSdkPathFromCommand: string | undefined = config.getFlutterSdkCommand && await this.runCustomGetSDKCommand(config.getFlutterSdkCommand, "dart.getFlutterSdkCommand", !!config.workspaceGetFlutterSdkCommand);
 
 			const flutterSdkSearchPaths = [
 				config.flutterSdkPath,
@@ -435,7 +433,7 @@ export class SdkUtils {
 			}
 
 			if (hasAnyFlutterProject) {
-				void this.warnIfBadConfigSdk(config.flutterSdkPath, flutterSdkResult, "dart.flutterSdkPath", configWorkspaceFlutterSdkPath);
+				void this.warnIfBadConfigSdk(config.flutterSdkPath, flutterSdkResult, "dart.flutterSdkPath", !!config.workspaceFlutterSdkPath);
 			}
 
 			flutterSdkPath = flutterSdkResult.sdkPath;
@@ -458,10 +456,8 @@ export class SdkUtils {
 			}
 		}
 
-		const configWorkspaceDartSdkPath = !!config.workspaceSdkPath;
-
 		// User provided custom command to obtain the sdk path
-		const dartSdkPathFromCommand: string | undefined = config.getDartSdkCommand && await this.runCustomGetSDKCommand(config.getDartSdkCommand, "dart.getDartSdkCommand", configWorkspaceDartSdkPath);
+		const dartSdkPathFromCommand: string | undefined = config.getDartSdkCommand && await this.runCustomGetSDKCommand(config.getDartSdkCommand, "dart.getDartSdkCommand", !!config.workspaceGetDartSdkCommand);
 
 		const dartSdkSearchPaths = [
 			// TODO: These could move into processFuchsiaWorkspace and be set on the config?
@@ -487,7 +483,7 @@ export class SdkUtils {
 		const dartSdkResult = this.findDartSdk(dartSdkSearchPaths);
 
 		if (!hasAnyFlutterProject && !fuchsiaRoot && !firstFlutterProject && !workspaceConfig.forceFlutterWorkspace) {
-			void this.warnIfBadConfigSdk(config.sdkPath, dartSdkResult, "dart.sdkPath", configWorkspaceDartSdkPath);
+			void this.warnIfBadConfigSdk(config.sdkPath, dartSdkResult, "dart.sdkPath", !!config.workspaceSdkPath);
 		}
 
 		let dartSdkPath = dartSdkResult.sdkPath;

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -289,6 +289,6 @@ export interface ExtensionConfig {
 export interface GetSDKCommandConfig {
 	executable: string;
 	args?: string[];
-	cwd: string,
+	cwd?: string,
 	env?: { [key: string]: string };
 }

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -285,3 +285,10 @@ export interface CustomDevToolsConfig {
 export interface ExtensionConfig {
 	get experimentalTestRunnerInSdk(): boolean;
 }
+
+export interface GetSDKCommandConfig {
+	executable: string;
+	args?: string[];
+	cwd: string,
+	env?: { [key: string]: string };
+}


### PR DESCRIPTION
Fixes #5334 and #5117

Adds 2 configurations, "getDartSdkCommand" and "getFlutterSdkCommand".

Here are a few examples on how can it be used:

```json5
// Use the where option in mise
"dart.getFlutterSdkCommand": {
    "executable": "mise",
    "args": ["where", "flutter"],
}

// Custom script in the project
"dart.getFlutterSdkCommand": {
    "executable": "tool/get_flutter_sdk.sh",
}

// Cross platform script in the project using Dart
"dart.getFlutterSdkCommand": {
    "executable": "dart",
    "args": ["tool/get_flutter_sdk.dart"],
}

// Bash command that concatenates the output of the Flutter SDK to get the Dart SDK
"dart.getDartSdkCommand": {
    "executable": "bash",
    "args": ["-c", "sdk=$(mise where flutter) || exit 1; echo \"$sdk/bin/cache/dart-sdk\""],
}
```