### PR TITLE
Prioritize using studio instead of studio.sh when opening Android Studio

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -20,7 +20,7 @@ export const dartPlatformName = isWin ? "win" : isMac ? "mac" : "linux";
 export const platformDisplayName = isWin ? "win" : isMac ? "mac" : isChromeOS ? "chromeos" : "linux";
 export const platformEol = isWin ? "\r\n" : "\n";
 
-export const androidStudioExecutableNames = isWin ? ["studio64.exe"] : ["studio.sh", "studio"];
+export const androidStudioExecutableNames = isWin ? ["studio64.exe"] : ["studio", "studio.sh"];
 export const executableNames = {
 	dart: isWin ? "dart.exe" : "dart",
 	dartdoc: isWin ? "dartdoc.bat" : "dartdoc",


### PR DESCRIPTION
Right now, when opening Android Studio from VSCode, the following is shown. The "Learn more" link goest to here: https://youtrack.jetbrains.com/articles/SUPPORT-A-56/How-to-handle-Switch-to-a-native-launcher-notification

![image](https://github.com/user-attachments/assets/3a196d98-b26e-4793-89c8-38653b4a887c)
