### PR TITLE
Provide server with useful diagnostic values to include in exportable reports

### DIFF
--- a/src/shared/vscode/analyzer_update_diagnostic_information.ts
+++ b/src/shared/vscode/analyzer_update_diagnostic_information.ts
@@ -1,0 +1,123 @@
+import { ConfigurationChangeEvent, workspace } from "vscode";
+import { ClientCapabilities, FeatureState, RequestType, StaticFeature } from "vscode-languageclient";
+import { LanguageClient } from "vscode-languageclient/node";
+import { IAmDisposable, Logger } from "../interfaces";
+import { disposeAll } from "../utils";
+import { hostKind } from "./utils";
+
+const interestingSettings: { [key: string]: string[] } = {
+	dart: [
+		"onlyAnalyzeProjectsWithOpenFiles",
+	],
+	editor: [
+		"formatOnSave",
+		"formatOnPaste",
+		"formatOnType",
+		"codeActionsOnSave",
+	],
+};
+
+export class AnalyzerUpdateDiagnosticInformationFeature implements IAmDisposable {
+	private disposables: IAmDisposable[] = [];
+	private isSupported = false;
+
+	constructor(private readonly logger: Logger, private readonly client: LanguageClient) {
+		this.disposables.push(workspace.onDidChangeConfiguration((e) => this.updateDiagnosticInformationIfRelevantConfigChanged(e)));
+	}
+
+	public get feature(): StaticFeature {
+		const disposables = this.disposables;
+		// eslint-disable-next-line @typescript-eslint/no-this-alias
+		const that = this;
+		return {
+			dispose() {
+				disposeAll(disposables);
+			},
+			fillClientCapabilities(capabilities: ClientCapabilities) { },
+			getState(): FeatureState {
+				return { kind: "static" };
+			},
+			initialize(serverCapabilities) {
+				that.isSupported = !!serverCapabilities.experimental?.updateDiagnosticInformation;
+			},
+		};
+	}
+
+	private async updateDiagnosticInformationIfRelevantConfigChanged(e: ConfigurationChangeEvent) {
+		if (!this.isSupported)
+			return;
+
+		let affected = false;
+
+		for (const section of Object.keys(interestingSettings)) {
+			affected ||= e.affectsConfiguration(section, { languageId: "dart" });
+		}
+		if (workspace.workspaceFolders) {
+			for (let i = 0; i < (workspace.workspaceFolders?.length ?? 0); i++) {
+				const folder = workspace.workspaceFolders[i];
+				for (const section of Object.keys(interestingSettings)) {
+					affected ||= e.affectsConfiguration(section, { uri: folder.uri, languageId: "dart" });
+				}
+			}
+		}
+
+		if (affected)
+			await this.updateDiagnosticInformationIfSupported();
+	}
+
+	public async updateDiagnosticInformationIfSupported(): Promise<void> {
+		if (!this.isSupported)
+			return;
+
+		try {
+			const diagnosticInfo = {
+				hostKind,
+				settings: this.getInterestingSettings(),
+			};
+			return await this.client.sendRequest(UpdateDiagnosticInformationRequest.type, diagnosticInfo);
+		} catch (error) {
+			this.logger.warn(`Failed to update diagnostic information on the server: ${error}`);
+		}
+	}
+
+	private getInterestingSettings() {
+		const results: any = {};
+
+		for (const section of Object.keys(interestingSettings)) {
+			const c = workspace.getConfiguration(section, { languageId: "dart" });
+			for (const setting of interestingSettings[section]) {
+				const v = c.get(setting);
+				if (v !== undefined) {
+					results.global ??= {};
+					results.global[`${section}.${setting}`] = v;
+				}
+			}
+		}
+		if (workspace.workspaceFolders) {
+			for (let i = 0; i < (workspace.workspaceFolders?.length ?? 0); i++) {
+				const folder = workspace.workspaceFolders[i];
+				for (const section of Object.keys(interestingSettings)) {
+					const c = workspace.getConfiguration(section, { uri: folder.uri, languageId: "dart" });
+					for (const setting of interestingSettings[section]) {
+						const vs = c.inspect(setting);
+						const v = vs?.workspaceFolderLanguageValue ?? vs?.workspaceFolderValue;
+						if (v !== undefined && v !== results.global[`${section}.${setting}`]) {
+							results[`folder_${i}`] ??= {};
+							results[`folder_${i}`][`${section}.${setting}`] = v;
+						}
+					}
+				}
+			}
+		}
+
+		return results;
+	}
+
+	public dispose(): any {
+		disposeAll(this.disposables);
+	}
+}
+
+export class UpdateDiagnosticInformationRequest {
+	public static type = new RequestType<object, void, void>("dart/updateDiagnosticInformation");
+}


### PR DESCRIPTION
These are sent once the server has started, and also if any config change affects any of the interesting sections (which are currently "dart" and "editor"). The reported config is scoped to Dart config (falling back to defaults if no Dart-specific config is set),  which means we can't tell if someone has `formatOnSave` set to something different for YAML files (for example), but if becomes useful, we could split this out to record multiple languages values.

This info is visible in the analyzer diagnostics pages as well as the exported report. For a sample workspace it looks like this:

![image](https://github.com/user-attachments/assets/3f48b17b-1319-486f-94c1-42a68b175d70)

For a single-root workspace, only the `global` section would be present. For a multi-root workspace, we'll add `folder_x` sections for any workspace folder that has settings that differ from the global one.


@bwilkerson @pq the settings included for now are below - let me know if you think there's anything else we should include (we can ofc update this over time). Additionally, I've included the "hostKind", which is a string that helps identify the environment being run in (for example Docker, WSL, Codespaces, or just native VS Code desktop).

```js
const interestingSettings: { [key: string]: string[] } = {
	dart: [
		"onlyAnalyzeProjectsWithOpenFiles", // This affects the analysis roots and whether we change them as files open/close which can affect perf
	],
	editor: [
		"formatOnSave",
		"formatOnPaste",
		"formatOnType",
		"codeActionsOnSave",
	],
};
```