### PR TITLE
[experimental] Add support for advertising the Dart SDK MCP server

### DIFF
--- a/package.json
+++ b/package.json
@@ -797,7 +797,8 @@
 				"inputSchema": {
 					"type": "object",
 					"properties": {}
-				}
+				},
+				"when": "config.dart.experimentalMcpServer"
 			}
 		],
 		"menus": {

--- a/package.json
+++ b/package.json
@@ -786,6 +786,20 @@
 				"label": "Dart SDK MCP Servers"
 			}
 		],
+		"languageModelTools": [
+			{
+				"name": "get_dart_tooling_daemon_dtd_uri",
+				"displayName": "Get the Dart Tooling Daemon (DTD) URI",
+				"userDescription": "Gets the URI to connect to the Dart Tooling Daemon (DTD).",
+				"modelDescription": "Gets the URI to connect to the Dart Tooling Daemon (DTD).",
+				"canBeReferencedInPrompt": true,
+				"toolReferenceName": "dtdUri",
+				"inputSchema": {
+					"type": "object",
+					"properties": {}
+				}
+			}
+		],
 		"menus": {
 			"commandPalette": [
 				{

--- a/package.json
+++ b/package.json
@@ -780,6 +780,12 @@
 				"key": "ctrl+alt+d"
 			}
 		],
+		"mcpServerDefinitionProviders": [
+			{
+				"id": "dart-sdk-mcp-servers",
+				"label": "Dart SDK MCP Servers"
+			}
+		],
 		"menus": {
 			"commandPalette": [
 				{

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -113,6 +113,7 @@ class Config {
 	get enableSnippets(): boolean { return this.getConfig<boolean>("enableSnippets", true); }
 	get env(): object { return this.getConfig<object>("env", {}); }
 	get evaluateToStringInDebugViews(): boolean { return this.getConfig<boolean>("evaluateToStringInDebugViews", true); }
+	get experimentalMcpServer(): boolean { return this.getConfig<boolean>("experimentalMcpServer", false); }
 	get experimentalRefactors(): boolean { return this.getConfig<boolean>("experimentalRefactors", false); }
 	get extensionLogFile(): undefined | string { return createFolderForFile(insertWorkspaceName(resolvePaths(this.getConfig<null | string>("extensionLogFile", null)))); }
 	get flutterAdbConnectOnChromeOs(): boolean { return this.getConfig<boolean>("flutterAdbConnectOnChromeOs", false); }

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -113,7 +113,10 @@ class Config {
 	get enableSnippets(): boolean { return this.getConfig<boolean>("enableSnippets", true); }
 	get env(): object { return this.getConfig<object>("env", {}); }
 	get evaluateToStringInDebugViews(): boolean { return this.getConfig<boolean>("evaluateToStringInDebugViews", true); }
+
+	/// When removing `config.experimentalMcpServer`, be sure to remove "when" clause in package.json!
 	get experimentalMcpServer(): boolean { return this.getConfig<boolean>("experimentalMcpServer", false); }
+
 	get experimentalRefactors(): boolean { return this.getConfig<boolean>("experimentalRefactors", false); }
 	get extensionLogFile(): undefined | string { return createFolderForFile(insertWorkspaceName(resolvePaths(this.getConfig<null | string>("extensionLogFile", null)))); }
 	get flutterAdbConnectOnChromeOs(): boolean { return this.getConfig<boolean>("flutterAdbConnectOnChromeOs", false); }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -556,6 +556,15 @@ export async function activate(context: vs.ExtensionContext, isRestart = false) 
 		const mcpServerProvider = new DartMcpServerDefinitionProvider(sdks, dartCapabilities);
 		context.subscriptions.push(mcpServerProvider);
 		context.subscriptions.push(vs.lm.registerMcpServerDefinitionProvider("dart-sdk-mcp-servers", mcpServerProvider));
+
+		context.subscriptions.push(vs.lm.registerTool("get_dart_tooling_daemon_dtd_uri", {
+			invoke: async () => {
+				const dtdUri = await dartToolingDaemon?.dtdUri;
+				return dtdUri
+					? new vs.LanguageModelToolResult([new vs.LanguageModelTextPart(dtdUri)])
+					: undefined;
+			},
+		}));
 	}
 
 	if (dartToolingDaemon && (dartCapabilities.supportsDevToolsPropertyEditor || config.experimentalPropertyEditor)) {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -556,7 +556,8 @@ export async function activate(context: vs.ExtensionContext, isRestart = false) 
 		const mcpServerProvider = new DartMcpServerDefinitionProvider(sdks, dartCapabilities);
 		context.subscriptions.push(mcpServerProvider);
 		context.subscriptions.push(vs.lm.registerMcpServerDefinitionProvider("dart-sdk-mcp-servers", mcpServerProvider));
-
+	}
+	if (vs.lm.registerTool) {
 		context.subscriptions.push(vs.lm.registerTool("get_dart_tooling_daemon_dtd_uri", {
 			invoke: async () => {
 				if (!dartCapabilities.supportsToolingDaemon)

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -559,6 +559,8 @@ export async function activate(context: vs.ExtensionContext, isRestart = false) 
 
 		context.subscriptions.push(vs.lm.registerTool("get_dart_tooling_daemon_dtd_uri", {
 			invoke: async () => {
+				if (!dartCapabilities.supportsToolingDaemon)
+					throw new Error("DTD is not available for this version of Flutter/Dart, please upgrade.");
 				const dtdUri = await dartToolingDaemon?.dtdUri;
 				return dtdUri
 					? new vs.LanguageModelToolResult([new vs.LanguageModelTextPart(dtdUri)])

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -75,6 +75,7 @@ import { DartDebugAdapterLoggerFactory } from "./providers/debug_adapter_logger_
 import { DartDebugAdapterRemoveErrorShowUserFactory } from "./providers/debug_adapter_remove_error_showUser_factory";
 import { DartDebugAdapterSupportsUrisFactory } from "./providers/debug_adapter_support_uris_factory";
 import { DebugConfigProvider, DynamicDebugConfigProvider, InitialLaunchJsonDebugConfigProvider } from "./providers/debug_config_provider";
+import { DartMcpServerDefinitionProvider } from "./providers/mcp_server_definition_provider";
 import { RankingCodeActionProvider } from "./providers/ranking_code_action_provider";
 import { SnippetCompletionItemProvider } from "./providers/snippet_completion_item_provider";
 import { PubGlobal } from "./pub/global";
@@ -551,6 +552,11 @@ export async function activate(context: vs.ExtensionContext, isRestart = false) 
 	else
 		context.subscriptions.push(new FlutterPostMessageSidebar(devTools, deviceManager, dartCapabilities));
 
+	if (vs.lm.registerMcpServerDefinitionProvider) {
+		const mcpServerProvider = new DartMcpServerDefinitionProvider(sdks, dartCapabilities);
+		context.subscriptions.push(mcpServerProvider);
+		context.subscriptions.push(vs.lm.registerMcpServerDefinitionProvider("dart-sdk-mcp-servers", mcpServerProvider));
+	}
 
 	if (dartToolingDaemon && (dartCapabilities.supportsDevToolsPropertyEditor || config.experimentalPropertyEditor)) {
 		void vs.commands.executeCommand("setContext", FLUTTER_PROPERTY_EDITOR_SUPPORTED_CONTEXT, true);

--- a/src/extension/future_vs_code_api/mcp.d.ts
+++ b/src/extension/future_vs_code_api/mcp.d.ts
@@ -1,0 +1,34 @@
+// MCP definitions were only finalized in VS Code 1.101 but to keep compatibility with other editors that lag behind
+// (such as Firebase Studio), we haven't bumped the minimum version in package.json. So instead, we provide definitions
+// for the MCP parts here so we can use them if they exist while still being compatible with other editors.
+//
+// https://github.com/microsoft/vscode/pull/248244/files
+
+declare module "vscode" {
+	export class McpStdioServerDefinition {
+		readonly label: string;
+		cwd?: Uri;
+		command: string;
+		args: string[];
+		env: Record<string, string | number | null>;
+		version?: string;
+
+		constructor(label: string, command: string, args?: string[], env?: Record<string, string | number | null>, version?: string);
+	}
+
+	export type McpServerDefinition = McpStdioServerDefinition;
+
+	export interface McpServerDefinitionProvider<T extends McpServerDefinition = McpServerDefinition> {
+		readonly onDidChangeMcpServerDefinitions?: Event<void>;
+		provideMcpServerDefinitions(token: CancellationToken): ProviderResult<T[]>;
+		resolveMcpServerDefinition?(server: T, token: CancellationToken): ProviderResult<T>;
+	}
+
+	export namespace lm {
+		// We define this with `| undefined` because that's what it will be for
+		// older versions of VS Code. We want to force testing for it before trying to
+		// call it so that we don't throw in older VS Code versions.
+		export const registerMcpServerDefinitionProvider: ((id: string, provider: McpServerDefinitionProvider) => Disposable) | undefined;
+	}
+
+}

--- a/src/extension/providers/mcp_server_definition_provider.ts
+++ b/src/extension/providers/mcp_server_definition_provider.ts
@@ -1,0 +1,50 @@
+import * as path from "path";
+import * as vs from "vscode";
+import { DartCapabilities } from "../../shared/capabilities/dart";
+import { dartVMPath } from "../../shared/constants";
+import { DartSdks, IAmDisposable } from "../../shared/interfaces";
+import { disposeAll } from "../../shared/utils";
+import { config } from "../config";
+
+export class DartMcpServerDefinitionProvider implements vs.McpServerDefinitionProvider, IAmDisposable {
+	private readonly disposables: IAmDisposable[] = [];
+
+	private onDidChangeMcpServerDefinitionsEmitter: vs.EventEmitter<void> = new vs.EventEmitter<void>();
+	public readonly onDidChangeMcpServerDefinitions: vs.Event<void> = this.onDidChangeMcpServerDefinitionsEmitter.event;
+
+	constructor(private readonly sdks: DartSdks, private readonly dartCapabilities: DartCapabilities) {
+		// Inform VS Code the MCP Server list changed if the experiment flag changes.
+		this.disposables.push(vs.workspace.onDidChangeConfiguration((e) => {
+			if (e.affectsConfiguration("dart.experimentalMcpServer")) {
+				this.onDidChangeMcpServerDefinitionsEmitter.fire();
+			}
+		}));
+	}
+
+	public async provideMcpServerDefinitions(token: vs.CancellationToken): Promise<vs.McpServerDefinition[]> {
+		// Dart SDK doesn't support it.
+		if (!this.dartCapabilities.supportsMcpServer)
+			return [];
+
+		// Not opted-in to experiment.
+		if (!config.experimentalMcpServer)
+			return [];
+
+
+		const binPath = path.join(this.sdks.dart, dartVMPath);
+		const args = ["mcp-server"];
+		if (this.dartCapabilities.mcpServerRequiresExperimentalFlag)
+			args.push("--experimental-mcp-server");
+		// TODO(dantup): Pass DTD here or provide another mechanism for it to be requested
+		//  (so that if we restart DTD, the same running MCP server can re-request the updated
+		//  URI).
+
+		return [
+			new vs.McpStdioServerDefinition("Dart SDK MCP Server", binPath, args),
+		];
+	}
+
+	public dispose(): any {
+		disposeAll(this.disposables);
+	}
+}

--- a/src/extension/providers/mcp_server_definition_provider.ts
+++ b/src/extension/providers/mcp_server_definition_provider.ts
@@ -35,9 +35,6 @@ export class DartMcpServerDefinitionProvider implements vs.McpServerDefinitionPr
 		const args = ["mcp-server"];
 		if (this.dartCapabilities.mcpServerRequiresExperimentalFlag)
 			args.push("--experimental-mcp-server");
-		// TODO(dantup): Pass DTD here or provide another mechanism for it to be requested
-		//  (so that if we restart DTD, the same running MCP server can re-request the updated
-		//  URI).
 
 		return [
 			new vs.McpStdioServerDefinition("Dart SDK MCP Server", binPath, args),

--- a/src/shared/capabilities/dart.ts
+++ b/src/shared/capabilities/dart.ts
@@ -31,6 +31,11 @@ export class DartCapabilities {
 	get supportsDevToolsPropertyEditor() { return versionIsAtLeast(this.version, "3.8.0-171.2"); }
 	get supportsLspOverDtd() { return versionIsAtLeast(this.version, "3.8.0-0"); }
 	get supportsDtdRegisterVmService() { return versionIsAtLeast(this.version, "3.9.0-0"); }
+
+	get supportsMcpServer() { return versionIsAtLeast(this.version, "3.9.0-0"); }
+	// TODO(dantup): Set this accordingly and consider a config.dartMcpServerAdditionalArgs?
+	get mcpServerRequiresExperimentalFlag() { return true; }
+
 	/**
 	 * Whether this version of the SDK supports DTD. This should be checked only for
 	 * spawning DTD and not whether it's available within the extension.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,10 @@
 		"rootDir": "src",
 		"strict": true
 	},
+	"typeRoots": [
+		"./node_modules/@types",
+		"./src/extension/future_vs_code_api",
+	],
 	"exclude": [
 		".crash_dumps",
 		".dart_code_test_data_dir",


### PR DESCRIPTION
This uses the new VS Code API `registerMcpServerDefinitionProvider` to allow VS Code to ask us for MCP servers. If we're using a >= Dart 3.9.0-0 SDK and the (currently "hidden") `dart.experimentalMcpServer` setting is enabled, we will return the `dart mcp-server` command.

This allows VS Code to discover our MCP server and tools (which are then available to VS Code and other extensions).

Currently we don't provide a way to pass the DTD URI (at startup, or if we have to restart it, when the MCP server may continue to run - since VS Code controls its lifetime), but this will need adding.

@jakemac53 @kenzieschmoll
