### PR TITLE
Update background task patterns for build_runner 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3592,8 +3592,8 @@
 				],
 				"background": {
 					"activeOnStart": true,
-					"beginsPattern": "^\\[INFO\\] Starting Build",
-					"endsPattern": "^(\\[INFO\\] Succeeded|\\[SEVERE\\] Failed) after"
+					"beginsPattern": "^\\[INFO\\] Starting Build|^Building,",
+					"endsPattern": "^(\\[INFO\\] Succeeded|\\[SEVERE\\] Failed) after|^(Built|Failed to build) with build_runner"
 				}
 			}
 		]


### PR DESCRIPTION
`build_runner` v2.5.0 changed the output format. The relevant new messages are:

Starting new build:
https://github.com/dart-lang/build/blob/8f9939f3c804edb91d4df33045536f6894472af0/build_runner_core/lib/src/logging/build_log.dart#L388-L390

Success/failure:
https://github.com/dart-lang/build/blob/8f9939f3c804edb91d4df33045536f6894472af0/build_runner_core/lib/src/logging/build_log.dart#L58-L62C41

The old background patterns are kept, since projects may keep using older versions of `build_runner` for a long while. I don't expect them to interfere with each other.

(As far as I can tell, there are no tests for problem matchers?)

Also: I didn't change the problem matchers, only the background ones. I don't think it's possible to build a single matcher that works with both old and new outputs, and even if we were to have two separate `problemMatcher`s, I'm not sure if the output can be properly described, since error messages are often multiline.

AFAIK the only consequence of outdated problem matchers is that we don't offer build errors in the Problems pane, whereas having outdated background matchers means `preLaunchTask`s never finish and launch operations get stuck.