### PR TITLE
Add support for running specific test suites from the CLI with "npm run test"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ Here are some useful commands when working on the project.
 - `npm run lint`: Run the linter (`eslint`) to ensure code conforms to enabled lints.
 - `npm run lint-fix`: Fixes lints that can be fixed automatically.
 - `npm run build`: Builds the extension.
-- `npm test`: Runs all automatic tests. This should first be run with the `BOT` env variable set to `"dart"` to run only a subset of basic Dart tests. If all of those tests, the whole test suite should be run.
+- `npm run test <...test-file-globs>`: Runs tests for the given glob (or file path). This should be used while working on an individual feature because it is faster than running all tests.
+- `npm run test`: Runs _all_ automatic tests for _all_ bots. This can be run with the `BOT` env variable set to (as defined in `test_all.ts`, for example to `"dart"`) to run only a single bots tests. The test suite is large and this can be slow.
 - `npm run test-grammar`: Runs snapshot tests for the textmate grammar.
 - `npm run update-grammar-snapshots`: Updates the textmate grammar snapshots.

--- a/package.json
+++ b/package.json
@@ -3620,19 +3620,24 @@
 	"scripts": {
 		"ensure-icon-submodule": "node -e \"process.exit(require('fs').existsSync('media/doc-icons/material/ac_unit@2x.png') ? 0 : 999)\"",
 		"vscode:prepublish": "npm run ensure-icon-submodule && webpack --mode production",
-		"build": "webpack --mode development",
+		"build": "webpack --mode development --stats errors-only",
 		"watch": "webpack --mode development --watch",
 		"build-tests": "tsc -p ./tsconfig.build.json",
 		"watch-non-ext": "tsc -p ./tsconfig.build.json --watch --extendedDiagnostics",
-		"lint-fix": "eslint . --fix",
+
 		"lint": "eslint .",
-		"test": "npm run build && npm run build-tests && npm run instrument-dist && npm run instrument && npm run test-only && npm run report_lcov && npm run report_screen",
+		"lint-fix": "eslint . --fix",
+
+		"pretest": "npm run build && npm run build-tests && npm run instrument-dist && npm run instrument",
+		"test": "node ./out/src/test/test_all.js",
+		"posttest": "npm run report_lcov && npm run report_screen",
+		"test-grammar": "vscode-tmgrammar-snap --expandDiff src/test/test_projects/grammar_testing/**/*.dart",
+		"test-all": "npm run test && npm run test-grammar",
+
 		"instrument-dist": "cd out/dist && nyc instrument --compact false --in-place . . && cd ../..",
 		"instrument": "cd out/src && nyc instrument --compact false --in-place . . && cd ../..",
-		"test-only": "node ./out/src/test/test_all.js && npm run test-grammar",
 		"report_lcov": "nyc report -r lcovonly --report-dir coverage/$BOT",
 		"report_screen": "nyc report",
-		"test-grammar": "vscode-tmgrammar-snap --expandDiff src/test/test_projects/grammar_testing/**/*.dart",
 		"update-grammar-snapshots": "vscode-tmgrammar-snap --updateSnapshot \"src/test/test_projects/grammar_testing/**/*.dart\""
 	},
 	"dependencies": {

--- a/src/test/test_all.ts
+++ b/src/test/test_all.ts
@@ -1,16 +1,30 @@
 import * as vstest from "@vscode/test-electron";
 import * as fs from "fs";
 import * as path from "path";
+import { getTestSuites } from "./test_runner";
 
 let exitCode = 0;
 const cwd = process.cwd();
 const testEnv = Object.create(process.env) as NodeJS.Dict<string>;
 
-async function runTests(testFolder: string, workspaceFolder: string, logSuffix?: string, env?: NodeJS.Dict<string>): Promise<void> {
-	console.log(`Running ${testFolder} tests folder in workspace ${workspaceFolder}`);
+// Read command line arguments for test filtering
+const testFilterArgs = process.argv.slice(2);
+if (testFilterArgs.length > 0) {
+	testEnv.DART_CODE_TEST_FILTER = JSON.stringify(testFilterArgs);
+	console.log(`Running tests with filter(s): ${testFilterArgs.join(", ")}`);
+}
+
+async function runTests(testFolderName: string, workspaceFolder: string, logSuffix?: string, env?: NodeJS.Dict<string>): Promise<void> {
+	const testFolder = path.join(cwd, "out", "src", "test", testFolderName);
+	const files = await getTestSuites(testFolder, testFilterArgs);
+	if (!files.length)
+		return;
+
+	console.log("\n\n");
+	console.log(`Starting "${testFolderName}" tests folder in workspace "${workspaceFolder}"...`);
 
 	const logsName = process.env.LOGS_NAME;
-	const testRunName = `${testFolder.replace(/\//g, "_")}${logSuffix ? `_${logSuffix}` : ""}_${logsName}`;
+	const testRunName = `${testFolderName.replace(/\//g, "_")}${logSuffix ? `_${logSuffix}` : ""}_${logsName}`;
 	const logPath = path.join(cwd, ".dart_code_test_logs", `${testRunName}`);
 
 	testEnv.TEST_RUN_NAME = testRunName;
@@ -23,6 +37,11 @@ async function runTests(testFolder: string, workspaceFolder: string, logSuffix?:
 
 	const codeVersion = (!process.env.BUILD_VERSION || process.env.BUILD_VERSION === "stable") ? "stable" : "insiders";
 
+	const reporter = {
+		report: () => { },
+		error: console.error
+	};
+
 	// The VS Code download is often flaky on GH Actions, so we want to retry
 	// if required - however we don't want to re-run tests if they fail, so do
 	// the download step separately.
@@ -30,8 +49,8 @@ async function runTests(testFolder: string, workspaceFolder: string, logSuffix?:
 	const maxAttempts = 5;
 	while (currentAttempt <= maxAttempts) {
 		try {
-			console.log(`Attempting to download VS Code attempt #${currentAttempt}`);
-			await vstest.downloadAndUnzipVSCode(codeVersion);
+			// console.log(`Attempting to download VS Code attempt #${currentAttempt}`);
+			await vstest.downloadAndUnzipVSCode({ version: codeVersion, reporter, });
 			break;
 		} catch (e) {
 			if (currentAttempt >= maxAttempts)
@@ -42,19 +61,18 @@ async function runTests(testFolder: string, workspaceFolder: string, logSuffix?:
 		}
 	}
 
-	console.log("Running tests with pre-downloaded VS Code");
 	try {
 		const res = await vstest.runTests({
 			extensionDevelopmentPath: cwd,
 			extensionTestsEnv: { ...testEnv, ...env },
-			extensionTestsPath: path.join(cwd, "out", "src", "test", testFolder),
+			extensionTestsPath: testFolder,
 			launchArgs: [
 				path.isAbsolute(workspaceFolder)
 					? workspaceFolder
 					: path.join(cwd, "src", "test", "test_projects", workspaceFolder),
 				"--profile-temp",
 				"--crash-reporter-directory",
-				path.join(cwd, ".crash_dumps", testFolder),
+				path.join(cwd, ".crash_dumps", testFolderName),
 				// Disable the Git extensions as these may be causing test failures on GitHub Actions:
 				// https://github.com/Dart-Code/Dart-Code/runs/2297610200?check_suite_focus=true#step:23:121
 				"--disable-extension",
@@ -62,24 +80,33 @@ async function runTests(testFolder: string, workspaceFolder: string, logSuffix?:
 				"--disable-extension",
 				"vscode.git-ui",
 				"--disable-extension",
+				"vscode.git-base",
+				"--disable-extension",
 				"vscode.github",
 				"--disable-extension",
 				"vscode.github-authentication",
 				"--disable-workspace-trust",
+				"--log",
+				"info",
+				"--sync",
+				"off",
 			],
 			version: codeVersion,
+			reporter,
 		});
 		exitCode = exitCode || res;
 	} catch (e) {
 		console.error(e);
 		exitCode = exitCode || 999;
 	}
-
-	console.log("############################################################");
-	console.log("\n\n");
 }
 
 async function runAllTests(): Promise<void> {
+	console.log("\n\n");
+	console.log("#############################");
+	console.log("## Dart-Code Tests         ##");
+	console.log("#############################");
+
 	testEnv.DART_CODE_IS_TEST_RUN = "true";
 	testEnv.MOCHA_FORBID_ONLY = "true";
 

--- a/src/test/test_runner.ts
+++ b/src/test/test_runner.ts
@@ -1,13 +1,43 @@
-console.log("Starting test runner...");
-
 import { glob } from "glob";
+import { minimatch } from "minimatch";
 import { default as Mocha } from "mocha";
 import * as path from "path";
 import { isCI } from "../shared/constants";
 import { MultiReporter } from "./mocha_multi_reporter";
 
+function normalizeTestFilter(filter: string): string {
+	return filter
+		// Convert backslashes to forward slashes for glob.
+		.replace(/\\/g, "/")
+		// Remove leading "./" if present.
+		.replace(/^\.\//, "")
+		// Replace any .ts with .js.
+		.replace(/\.ts$/, ".js");
+}
+
+export async function getTestSuites(testsRoot: string, filters: string[] | undefined): Promise<string[]> {
+	let allFiles = await glob("**/**.test.js", { cwd: testsRoot });
+	allFiles = allFiles.map((f) => path.resolve(testsRoot, f));
+	allFiles.sort();
+
+	if (!filters)
+		return allFiles;
+
+	// If there are filters, return those that match any of them.
+	const files = new Set<string>();
+	for (let filter of filters.map(normalizeTestFilter)) {
+		filter = `**/*${filter}*`;
+		allFiles.filter((file) => minimatch(file, filter)).forEach((f) => files.add(f));
+	}
+	return [...files].sort();
+}
+
 module.exports = {
+	getTestSuites,
+
 	async run(testsRoot: string): Promise<void> {
+		console.log("\nStarting test runner...\n");
+
 		// Create the mocha test
 		const mocha = new Mocha({
 			color: true,
@@ -29,10 +59,18 @@ module.exports = {
 
 		return new Promise(async (resolve, reject) => {
 			try {
-				const files = await glob("**/**.test.js", { cwd: testsRoot });
+				const testFilter = process.env.DART_CODE_TEST_FILTER;
+				const filters: string[] | undefined = testFilter ? JSON.parse(testFilter) : undefined;
+				const files = await getTestSuites(testsRoot, filters);
 
 				// Add files to the test suite
-				files.forEach((f) => mocha.addFile(path.resolve(testsRoot, f)));
+				files.forEach((f) => mocha.addFile(f));
+
+				if (files.length === 0) {
+					console.log(`No test files found.`);
+					resolve();
+					return;
+				}
 
 				// Run the mocha test
 				mocha.run((failures) => {


### PR DESCRIPTION
and some tidying up of the test output to make it less noisy.

Fixes https://github.com/Dart-Code/Dart-Code/issues/5604