### PR TITLE
Support waiting for a VM Service in AutoLaunch

### DIFF
--- a/src/shared/vscode/autolaunch.ts
+++ b/src/shared/vscode/autolaunch.ts
@@ -82,7 +82,7 @@ export class AutoLaunch implements IAmDisposable {
 	}
 
 	private async waitForVmService(vmServiceUri: string, timeoutMs: number): Promise<boolean> {
-		this.logger.info(`Waiting for VM Service at ${vmServiceUri} to become accessible (timeout: ${timeoutMs}ms)...`);
+		this.logger.info(`[AutoLaunch] Waiting for VM Service at ${vmServiceUri} to become accessible (timeout: ${timeoutMs}ms)...`);
 
 		const startTime = Date.now();
 		const retryDelayMs = 1000; // Wait 1s between attempts.
@@ -117,7 +117,7 @@ export class AutoLaunch implements IAmDisposable {
 				});
 
 				// If we get here, the connection succeeded.
-				this.logger.info(`Successfully connected to VM Service at ${vmServiceUri}`);
+				this.logger.info(`[AutoLaunch] Successfully connected to VM Service at ${vmServiceUri}, will launch debug session!`);
 				return true;
 			} catch (error) {
 				// Stop if we've hit the timeout.
@@ -128,7 +128,7 @@ export class AutoLaunch implements IAmDisposable {
 				}
 
 				// Otherwise, retry.
-				this.logger.info(`Failed to connect to VM Service, will retry: ${error}`);
+				this.logger.info(`[AutoLaunch] Failed to connect to VM Service, will retry: ${error}`);
 				await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
 			}
 		}

--- a/src/test/dart/debug/autolaunch.test.ts
+++ b/src/test/dart/debug/autolaunch.test.ts
@@ -113,7 +113,7 @@ describe("debug autolaunch", () => {
 
 		it("should start debugging immediately if waitForVmServiceMs is provided but vmServiceUri is not", async () => {
 			const { wf, filePath, startDebugSession } = createTestEnvironment();
-			const launchConfig = createLaunchConfig("No VM Service Test", undefined,);
+			const launchConfig = createLaunchConfig("No VM Service Test", undefined);
 
 			await triggerAutoLaunch(filePath, launchConfig);
 

--- a/src/test/dart/debug/autolaunch.test.ts
+++ b/src/test/dart/debug/autolaunch.test.ts
@@ -2,11 +2,12 @@ import { strict as assert } from "assert";
 import * as fs from "fs";
 import * as path from "path";
 import { debug, Uri, workspace } from "vscode";
+import * as ws from "ws";
 import { autoLaunchFilename, defaultDartCodeConfigurationPath } from "../../../shared/constants";
-import { fsPath, tryDeleteFile } from "../../../shared/utils/fs";
+import { fsPath } from "../../../shared/utils/fs";
 import { waitFor } from "../../../shared/utils/promises";
 import { AutoLaunch } from "../../../shared/vscode/autolaunch";
-import { defer, delay, getRandomTempFolder, helloWorldMainFile, logger, sb } from "../../helpers";
+import { defer, delay, getRandomTempFolder, helloWorldMainFile, logger, sb, tryDeleteDirectoryRecursive } from "../../helpers";
 
 describe("debug autolaunch", () => {
 	for (const alreadyExists of [true, false]) {
@@ -15,43 +16,160 @@ describe("debug autolaunch", () => {
 		describe(groupName, () => {
 
 			for (const overridePath of [".test_dart_code", getRandomTempFolder()]) {
-				const wf = workspace.workspaceFolders![0];
-				const baseUri = path.isAbsolute(overridePath) ? undefined : wf.uri;
-				const folderPath = baseUri
-					? fsPath(Uri.joinPath(baseUri, overridePath ?? defaultDartCodeConfigurationPath))
-					: overridePath;
-				fs.mkdirSync(folderPath, { recursive: true });
-				const filePath = path.join(folderPath, autoLaunchFilename);
-
-				const testName = `with config path set to "${overridePath}" (${filePath})`;
+				const testName = `with config path set to "${overridePath}"`;
 				it(testName, async () => {
-					defer(`delete ${filePath}`, () => tryDeleteFile(filePath));
-					const startDebugSession = sb.stub(debug, "startDebugging").callsFake(() => Promise.resolve());
-
-					const launchConfig = {
-						// Make a unique launch config (name) so we can verify the correct config was passed to launch.
-						name: `${groupName} ${testName}`,
-						program: fsPath(helloWorldMainFile),
-						request: "launch",
-						type: "dart",
-					};
-					const launchConfigs = { configurations: [launchConfig] };
+					const { wf, baseUri, filePath, startDebugSession } = createTestEnvironment(overridePath);
+					const launchConfig = createLaunchConfig(`${groupName} ${testName}`);
 
 					if (alreadyExists) {
-						await fs.promises.writeFile(filePath, JSON.stringify(launchConfigs));
-					}
-					const autoLaunch = new AutoLaunch(overridePath, logger, undefined);
-					if (!alreadyExists) {
+						await triggerAutoLaunch(filePath, launchConfig, overridePath);
+						await waitFor(() => startDebugSession.called);
+						assert.ok(startDebugSession.calledOnceWith(baseUri ? wf : undefined, launchConfig));
+					} else {
+						createAutoLaunch(overridePath ?? ".test_dart_code");
 						await delay(500);
+
+						const launchConfigs = { configurations: [launchConfig] };
 						await fs.promises.writeFile(filePath, JSON.stringify(launchConfigs));
+
+						await waitFor(() => startDebugSession.called);
+						assert.ok(startDebugSession.calledOnceWith(baseUri ? wf : undefined, launchConfig));
 					}
-
-					await waitFor(() => startDebugSession.called);
-					assert.ok(startDebugSession.calledOnceWith(baseUri ? wf : undefined, launchConfig));
-
-					await autoLaunch.dispose();
 				});
 			}
 		});
 	}
+
+	describe("VM Service probing", () => {
+		let mockServer: ws.WebSocketServer | undefined;
+		let serverPort: number;
+
+		async function startMockServer() {
+			mockServer = new ws.WebSocketServer({ port: serverPort });
+			await new Promise<void>((resolve) => {
+				mockServer!.on("listening", () => resolve());
+			});
+		}
+
+		beforeEach(async () => {
+			// Find an available port for our mock WebSocket server
+			serverPort = await new Promise<number>((resolve) => {
+				const server = new ws.WebSocketServer({ port: 0 });
+				server.on("listening", () => {
+					const address = server.address();
+					const port = typeof address === "object" && address ? address.port : 0;
+					server.close(() => resolve(port));
+				});
+			});
+		});
+
+		afterEach(async () => {
+			if (mockServer) {
+				await new Promise<void>((resolve) => {
+					mockServer!.close(() => resolve());
+				});
+				mockServer = undefined;
+			}
+		});
+
+		it("should handle already existing VM Service", async () => {
+			const { wf, filePath, startDebugSession } = createTestEnvironment();
+			const vmServiceUri = `ws://localhost:${serverPort}`;
+			const launchConfig = createLaunchConfig("VM Service Test", vmServiceUri, 5000);
+
+			await startMockServer();
+			await triggerAutoLaunch(filePath, launchConfig);
+
+			await waitFor(() => startDebugSession.called, 1000); // Don't wait long, it should connect immediately.
+			assert.ok(startDebugSession.calledOnceWith(wf, launchConfig));
+		});
+
+		it("should wait for VM Service to become available after a delay", async () => {
+			const { wf, filePath, startDebugSession } = createTestEnvironment();
+			const vmServiceUri = `ws://localhost:${serverPort}`;
+			const launchConfig = createLaunchConfig("VM Service Delayed Test", vmServiceUri, 5000);
+
+			await triggerAutoLaunch(filePath, launchConfig);
+			void delay(2000).then(startMockServer);
+
+			await waitFor(() => startDebugSession.called, 5000);
+			assert.ok(startDebugSession.calledOnceWith(wf, launchConfig));
+		});
+
+		it("should fail to start debugging if VM Service never becomes available", async () => {
+			const { filePath, startDebugSession } = createTestEnvironment();
+			const vmServiceUri = `ws://localhost:${serverPort}`;
+			const launchConfig = createLaunchConfig("VM Service Timeout Test", vmServiceUri, 2000);
+
+			await triggerAutoLaunch(filePath, launchConfig);
+			// Don't start the mock server - VM Service should timeout
+
+			await delay(4000); // Wait long enough for the timeout.
+			assert.ok(!startDebugSession.called);
+		});
+
+		it("should start debugging immediately if waitForVmServiceMs is provided but vmServiceUri is not", async () => {
+			const { wf, filePath, startDebugSession } = createTestEnvironment();
+			const launchConfig = createLaunchConfig("No VM Service Test", undefined,);
+
+			await triggerAutoLaunch(filePath, launchConfig);
+
+			await waitFor(() => startDebugSession.called);
+			assert.ok(startDebugSession.calledOnceWith(wf, launchConfig));
+		});
+
+		it("should start debugging immediately if vmServiceUri is provided but waitForVmServiceMs is not", async () => {
+			const { wf, filePath, startDebugSession } = createTestEnvironment();
+			const vmServiceUri = `ws://localhost:${serverPort}`;
+			const launchConfig = createLaunchConfig("VM Service No Timeout Test", vmServiceUri);
+
+			await triggerAutoLaunch(filePath, launchConfig);
+
+			await waitFor(() => startDebugSession.called);
+			assert.ok(startDebugSession.calledOnceWith(wf, launchConfig));
+		});
+	});
 });
+
+function createLaunchConfig(name: string, vmServiceUri?: string, waitForVmServiceMs?: number) {
+	return ({
+		name,
+		program: fsPath(helloWorldMainFile),
+		request: vmServiceUri ? "attach" : "launch",
+		type: "dart",
+		...(vmServiceUri && { vmServiceUri }),
+		...(waitForVmServiceMs && { waitForVmServiceMs }),
+	});
+}
+
+function createTestEnvironment(overridePath?: string) {
+	const wf = workspace.workspaceFolders![0];
+	const baseUri = overridePath
+		? path.isAbsolute(overridePath) ? undefined : wf.uri
+		: undefined;
+	const folderPath = overridePath
+		? baseUri
+			? fsPath(Uri.joinPath(baseUri, overridePath ?? defaultDartCodeConfigurationPath))
+			: overridePath
+		: fsPath(Uri.joinPath(wf.uri, ".test_dart_code"));
+	const filePath = path.join(folderPath, autoLaunchFilename);
+
+	fs.mkdirSync(folderPath, { recursive: true });
+	defer(`delete ${folderPath}`, () => tryDeleteDirectoryRecursive(folderPath));
+
+	const startDebugSession = sb.stub(debug, "startDebugging").callsFake(() => Promise.resolve());
+	return { wf, baseUri, filePath, startDebugSession };
+}
+
+async function triggerAutoLaunch(filePath: string, launchConfig: any, overridePath?: string) {
+	const launchConfigs = { configurations: [launchConfig] };
+	await fs.promises.writeFile(filePath, JSON.stringify(launchConfigs));
+	await delay(100); // Small delay to ensure file exists before we create AutoLaunch.
+
+	createAutoLaunch(overridePath ?? ".test_dart_code");
+}
+
+function createAutoLaunch(overridePath: string) {
+	const autoLaunch = new AutoLaunch(overridePath ?? ".test_dart_code", logger, undefined);
+	defer("dispose AutoLaunch", () => autoLaunch.dispose());
+}


### PR DESCRIPTION
If you include these fields in your `autolaunch.json`:

```js
  "vmServiceUri": "ws://xxx",
  "waitForVmServiceMs": 30000, // number of ms to wait for vmServiceUri to become accessible
```

Then we will wait up to `waitForVmServiceMs` for `vmServiceUri` to be connectable (as a WebSocket) before we start the debug session. If it never becomes available within this time, we will do nothing (we can add another flag later if we think we should have functionality to start the debug session anyway, but I suspect this won't be wanted, because stale files would result in failed debug sessions).

Fixes https://github.com/Dart-Code/Dart-Code/issues/5614