### PR TITLE
Prompt to reload when Flutter projects are added to a Dart-only workspace

### DIFF
--- a/src/extension/flutter/flutter_project_watcher.ts
+++ b/src/extension/flutter/flutter_project_watcher.ts
@@ -1,0 +1,65 @@
+import * as path from "path";
+import { Uri, workspace } from "vscode";
+import { IAmDisposable, Logger } from "../../shared/interfaces";
+import { disposeAll } from "../../shared/utils";
+import { fsPath, projectReferencesFlutter } from "../../shared/utils/fs";
+import { WorkspaceContext } from "../../shared/workspace";
+import { promptToReloadExtension } from "../utils";
+
+/**
+ * Watches for new Flutter projects being added to Dart-only workspaces.
+ *
+ * When a Flutter project is detected, prompts the user to reload the extension
+ * to enable Flutter support.
+ */
+export class FlutterProjectWatcher implements IAmDisposable {
+	private readonly disposables: IAmDisposable[] = [];
+	private hasPrompted = false; // Don't trigger multiple times if multiple pubspecs change.
+
+	constructor(
+		private readonly logger: Logger,
+		private readonly workspaceContext: WorkspaceContext,
+	) {
+		const watcher = workspace.createFileSystemWatcher("**/pubspec.yaml");
+		this.disposables.push(watcher);
+		this.disposables.push(watcher.onDidCreate(this.handlePubspecChange, this));
+		this.disposables.push(watcher.onDidChange(this.handlePubspecChange, this));
+	}
+
+	private handlePubspecChange(uri: Uri): void {
+		if (this.hasPrompted)
+			return;
+
+		// We should not have set the watcher up if we're already in Flutter mode, but just in case...
+		if (this.workspaceContext.hasAnyFlutterProjects) {
+			this.logger.info("[FlutterWatcher] Workspace already has Flutter projects so ignoring change");
+			return;
+		}
+
+		const filePath = fsPath(uri);
+
+		if (filePath.includes(`${path.sep}.`) || filePath.includes(`${path.sep}build${path.sep}`)) {
+			this.logger.info(`[FlutterWatcher] Skipping pubspec change for ignored folder ${filePath}`);
+			return;
+		}
+
+		const folderPath = path.dirname(filePath);
+		if (projectReferencesFlutter(folderPath)) {
+			this.hasPrompted = true;
+			this.logger.info(`[FlutterWatcher] Detected a new Flutter project at ${folderPath}`);
+
+			// We only prompt once per session, so we can dispose our watcher.
+			this.dispose();
+
+			void promptToReloadExtension(
+				this.logger,
+				"A Flutter project was added to the workspace. Reload to switch to the Flutter SDK?",
+				"Reload",
+			);
+		}
+	}
+
+	public dispose(): void {
+		disposeAll(this.disposables);
+	}
+}

--- a/src/shared/utils/cache.ts
+++ b/src/shared/utils/cache.ts
@@ -22,6 +22,11 @@ export class SimpleTimeBasedCache<T> {
 			},
 		);
 	}
+
+	public clear() {
+		this.data.clear();
+	}
+
 }
 
 interface CacheItem<T> {

--- a/src/shared/vscode/utils.ts
+++ b/src/shared/vscode/utils.ts
@@ -25,6 +25,10 @@ export interface ProjectFolderSearchResults { projectFolders: string[], excluded
 const projectFolderCache = new SimpleTimeBasedCache<ProjectFolderSearchResults>();
 let inProgressProjectFolderSearch: Promise<void> | undefined;
 
+export function clearCaches() {
+	projectFolderCache.clear();
+}
+
 // The extension kind is declared as Workspace, but VS Code will return UI in the
 // case that there is no remote extension host.
 export const isRunningLocally =


### PR DESCRIPTION
If you start with a Dart-only workspace and later add a Flutter project, you'll now be prompted to reload:

<img width="499" height="175" alt="Image" src="https://github.com/user-attachments/assets/1a3f12ff-a4a2-4009-9850-576fe854f569" />

Fixes https://github.com/Dart-Code/Dart-Code/issues/5612