### PR TITLE
Add support for excluding MCP tools from the Dart MCP server

### DIFF
--- a/package.json
+++ b/package.json
@@ -3029,6 +3029,18 @@
 						"description": "Whether to register the Dart SDK's MCP server with VS Code. This only applies to Dart SDKs >= v3.9.0 which added the server.",
 						"scope": "window"
 					}
+					,
+					"dart.mcpServerTools": {
+						"type": "object",
+						"default": {
+							"run_tests": false
+						},
+						"markdownDescription": "A map of MCP tool names to booleans to enable/disable specific tools from the Dart MCP server. Tools set to `false` will be excluded (if supported). By default, tools that overlap with built-in VS Code functionality will be excluded.",
+						"additionalProperties": {
+							"type": "boolean"
+						},
+						"scope": "window"
+					}
 				}
 			},
 			{

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -10,6 +10,8 @@ import { setupToolEnv } from "./utils/processes";
 class Config {
 	private config: WorkspaceConfiguration;
 
+	// TODO(dantup): We might not need defaults here, they are read from package.json!
+
 	constructor() {
 		workspace.onDidChangeConfiguration((e) => this.reloadConfig());
 		this.config = workspace.getConfiguration("dart");
@@ -116,6 +118,8 @@ class Config {
 
 	get mcpServer(): boolean { return this.getConfig<boolean>("mcpServer", true); }
 	get mcpServerLogFile(): undefined | string { return createFolderForFile(insertWorkspaceName(resolvePaths(this.getConfig<null | string>("mcpServerLogFile", null)))); }
+	// eslint-disable-next-line camelcase
+	get mcpServerTools(): Record<string, boolean> { return this.getConfig<Record<string, boolean>>("mcpServerTools", {/* defaults from package.json */ }); }
 
 	get experimentalRefactors(): boolean { return this.getConfig<boolean>("experimentalRefactors", false); }
 	get extensionLogFile(): undefined | string { return createFolderForFile(insertWorkspaceName(resolvePaths(this.getConfig<null | string>("extensionLogFile", null)))); }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -19,6 +19,7 @@ import { AutoLaunch } from "../shared/vscode/autolaunch";
 import { DART_LANGUAGE, DART_MODE, HTML_MODE } from "../shared/vscode/constants";
 import { FlutterDeviceManager } from "../shared/vscode/device_manager";
 import { extensionVersion, isDevExtension } from "../shared/vscode/extension_utils";
+import { InternalExtensionApi } from "../shared/vscode/interfaces";
 import { DartUriHandler } from "../shared/vscode/uri_handlers/uri_handler";
 import { ProjectFinder, clearCaches, createWatcher, envUtils, hostKind, isRunningLocally, warnIfPathCaseMismatch } from "../shared/vscode/utils";
 import { isFirebaseStudio } from "../shared/vscode/utils_cloud";
@@ -583,9 +584,10 @@ export async function activate(context: vs.ExtensionContext, isRestart = false) 
 	else
 		context.subscriptions.push(new FlutterPostMessageSidebar(devTools, deviceManager, dartCapabilities));
 
+	let mcpServerProvider: DartMcpServerDefinitionProvider | undefined;
 	if (vs.lm.registerMcpServerDefinitionProvider) {
 		try {
-			const mcpServerProvider = new DartMcpServerDefinitionProvider(sdks, dartCapabilities);
+			mcpServerProvider = new DartMcpServerDefinitionProvider(sdks, dartCapabilities);
 			context.subscriptions.push(mcpServerProvider);
 			context.subscriptions.push(vs.lm.registerMcpServerDefinitionProvider("dart-sdk-mcp-servers", mcpServerProvider));
 		} catch (e) {
@@ -736,6 +738,7 @@ export async function activate(context: vs.ExtensionContext, isRestart = false) 
 		initialAnalysis: analyzer.onInitialAnalysis,
 		interactiveRefactors: analyzer.refactors,
 		logger,
+		mcpServerProvider: isDartCodeTestRun ? mcpServerProvider : undefined,
 		nextAnalysis: () => analyzer?.onNextAnalysisComplete,
 		packagesTreeProvider: dartPackagesProvider,
 		pubGlobal,
@@ -749,7 +752,7 @@ export async function activate(context: vs.ExtensionContext, isRestart = false) 
 		trackerFactories,
 		webClient,
 		workspaceContext,
-	};
+	} as InternalExtensionApi;
 	// Copy all fields and getters from privateApi into the existing object so that it works
 	// correctly through exports.
 	Object.defineProperties(

--- a/src/extension/views/packages_view.ts
+++ b/src/extension/views/packages_view.ts
@@ -22,7 +22,7 @@ export class DartPackagesProvider implements vs.TreeDataProvider<PackageDep>, IA
 
 	private processPackageMapChangeEvents = true;
 
-	constructor(private readonly logger: Logger, private readonly projectFinder: ProjectFinder, private readonly context: DartWorkspaceContext, private readonly dartCapabilities: DartCapabilities) {
+	constructor(private readonly logger: Logger, public readonly projectFinder: ProjectFinder, private readonly context: DartWorkspaceContext, private readonly dartCapabilities: DartCapabilities) {
 		this.disposables.push(vs.commands.registerCommand("_dart.removeDependencyFromTreeNode", this.removeDependency, this));
 		this.disposables.push(vs.commands.registerCommand("_dart.openDependencyPageFromTreeNode", this.openDependencyPage, this));
 		context.events.onPackageMapChange.listen(() => {

--- a/src/shared/capabilities/dart.ts
+++ b/src/shared/capabilities/dart.ts
@@ -36,6 +36,10 @@ export class DartCapabilities {
 	get supportsMcpServerLogFile() { return versionIsAtLeast(this.version, "3.9.0-303"); }
 	get mcpServerRequiresExperimentalFlag() { return !versionIsAtLeast(this.version, "3.9.0-293"); }
 
+	// https://github.com/dart-lang/ai/pull/253
+	// https://github.com/dart-lang/sdk/commit/d90b10c1b167663b9b51adc274ea0fdb18ba5856
+	get supportsMcpServerExcludeTool() { return versionIsAtLeast(this.version, "3.10.0-69"); }
+
 	/**
 	 * Whether this version of the SDK supports DTD. This should be checked only for
 	 * spawning DTD and not whether it's available within the extension.

--- a/src/shared/vscode/interfaces.ts
+++ b/src/shared/vscode/interfaces.ts
@@ -1,4 +1,4 @@
-import { CancellationToken, DebugAdapterDescriptor, DebugConfiguration, DebugConfigurationProvider, DebugSession, DebugSessionCustomEvent, OutputChannel, Progress, TestController, TestItem, TestRunRequest, TreeDataProvider, TreeItem, Uri } from "vscode";
+import { CancellationToken, DebugAdapterDescriptor, DebugConfiguration, DebugConfigurationProvider, DebugSession, DebugSessionCustomEvent, McpServerDefinitionProvider, OutputChannel, Progress, TestController, TestItem, TestRunRequest, TreeDataProvider, TreeItem, Uri } from "vscode";
 import { DartVsCodeLaunchArgs } from "../../shared/debug/interfaces";
 import * as lsp from "../analysis/lsp/custom_protocol";
 import { Analyzer } from "../analyzer";
@@ -146,6 +146,7 @@ export interface InternalExtensionApi {
 	webClient: WebClient;
 	workspaceContext: DartWorkspaceContext;
 	// Only available in test runs.
+	mcpServerProvider?: McpServerDefinitionProvider;
 	sdkUtils?: {
 		runCustomGetSDKCommand(command: GetSDKCommandConfig, sdkConfigName: "dart.getDartSdkCommand" | "dart.getFlutterSdkCommand", isWorkspaceSetting: boolean): Promise<GetSDKCommandResult>
 	},

--- a/src/test/dart/mcp_server.test.ts
+++ b/src/test/dart/mcp_server.test.ts
@@ -1,0 +1,59 @@
+import { strict as assert } from "assert";
+import * as vs from "vscode";
+import { activateWithoutAnalysis, privateApi, setConfigForTest } from "../helpers";
+
+describe("MCP server", () => {
+	beforeEach(async () => activateWithoutAnalysis());
+
+	function getExcludedTools(server: vs.McpServerDefinition): string[] {
+		server = server as vs.McpStdioServerDefinition;
+		const args = server.args;
+		const excludedTools: string[] = [];
+		for (let i = 0; i < args.length - 1; i++) {
+			if (args[i] === "--exclude-tool")
+				excludedTools.push(args[i + 1]);
+		}
+		return excludedTools;
+	}
+
+	it("passes --exclude-tool for run_tests by default", async () => {
+		privateApi.dartCapabilities.version = "3.10.0";
+
+		const provider = privateApi.mcpServerProvider!;
+		const servers = await provider.provideMcpServerDefinitions(new vs.CancellationTokenSource().token);
+		const excludedTools = getExcludedTools(servers![0]);
+		assert.deepStrictEqual(excludedTools, ["run_tests"]);
+	});
+
+	it("merges excluded tools with defaults", async () => {
+		privateApi.dartCapabilities.version = "3.10.0";
+
+		await setConfigForTest("dart", "mcpServerTools", { tool1: false, tool2: true });
+
+		const provider = privateApi.mcpServerProvider!;
+		const servers = await provider.provideMcpServerDefinitions(new vs.CancellationTokenSource().token);
+		const excludedTools = getExcludedTools(servers![0]);
+		assert.deepStrictEqual(excludedTools, ["run_tests", "tool1"]);
+	});
+
+	it("allows default exclusions to be included", async () => {
+		privateApi.dartCapabilities.version = "3.10.0";
+
+		// eslint-disable-next-line camelcase
+		await setConfigForTest("dart", "mcpServerTools", { tool1: false, tool2: true, run_tests: true });
+
+		const provider = privateApi.mcpServerProvider!;
+		const servers = await provider.provideMcpServerDefinitions(new vs.CancellationTokenSource().token);
+		const excludedTools = getExcludedTools(servers![0]);
+		assert.deepStrictEqual(excludedTools, ["tool1"]);
+	});
+
+	it("does not pass --exclude-tool when unsupported", async () => {
+		privateApi.dartCapabilities.version = "3.9.0";
+
+		const provider = privateApi.mcpServerProvider!;
+		const servers = await provider.provideMcpServerDefinitions(new vs.CancellationTokenSource().token);
+		const excludedTools = getExcludedTools(servers![0]);
+		assert.deepStrictEqual(excludedTools, []);
+	});
+});


### PR DESCRIPTION
Some of the built-in tools like `run_tests` overlap with built-in VS Code functionality, but the model might choose the SDK version despite having less functionality.

TODO
- [ ] Figure out exactly which tools we should exclude
- `run_tests` seems like a like candidate
- `analyzer_files` - maybe? VS Code has Problems, but it's not clear if the model can read them all, or only for a given file?
- `create_project` ?
- `dart_fix` ?
- `hot_reload` ?
- `pub` - should we expose the built-in Dart-Code commands so it can call things that show in the UI?

**Edit:** For now, only excluding `runTests` because it's the only one that specifically does overlap- the others require us to expose new tools from Dart-Code, or VS Code changes (I've opened https://github.com/Dart-Code/Dart-Code/issues/5647 to track the problems tool replacing `analyze_files`).