### PR TITLE
Update and rename dart.json.licence to dart.json.license

### DIFF
--- a/syntaxes/dart.json.license
+++ b/syntaxes/dart.json.license
@@ -1,7 +1,7 @@
 The file dart.json is taken from:
 	https://github.com/dart-lang/dart-syntax-highlight/blob/master/grammars/dart.json
 
-Licence:
+License:
 
 	Copyright 2020, the Dart project authors.
 


### PR DESCRIPTION
Noticed this typo as I was poking around.