### PR TITLE
Fix coverage false positives for structural lines like } finally {

### DIFF
--- a/src/shared/test/coverage.ts
+++ b/src/shared/test/coverage.ts
@@ -27,6 +27,8 @@ export class CoverageParser {
 		let sourceFilePath: string | undefined;
 		const coverableLines = new Set<number>();
 		const coveredLines = new Set<number>();
+		const linesWithDirectCoverage = new Set<number>(); // Track lines that have DA entries
+		const branchEntries: Array<{ lineNumber: number, taken: number }> = []; // Store BRDA entries for second pass
 
 		function recordLine(lineNumber: number, taken: number) {
 			coverableLines.add(lineNumber);
@@ -35,6 +37,7 @@ export class CoverageParser {
 			}
 		}
 
+		// First pass: collect all lines and identify which have direct coverage (DA) entries
 		for (const line of record.split("\n").map((l) => l.trim()).filter((l) => l !== "" && !l.startsWith("#"))) {
 			const fields = line.split(":");
 			if (fields.length !== 2) {
@@ -59,6 +62,7 @@ export class CoverageParser {
 						const valueParts = value.split(",").map((p) => p.trim());
 						const lineNumber = parseInt(valueParts[0], 10);
 						const taken = parseInt(valueParts[1], 10);
+						linesWithDirectCoverage.add(lineNumber);
 						recordLine(lineNumber, taken);
 					}
 					break;
@@ -67,7 +71,7 @@ export class CoverageParser {
 						const valueParts = value.split(",").map((p) => p.trim());
 						const lineNumber = parseInt(valueParts[0], 10);
 						const taken = parseInt(valueParts[3], 10);
-						recordLine(lineNumber, taken);
+						branchEntries.push({ lineNumber, taken });
 					}
 					break;
 				case "LF": // LF:<number of instrumented lines>
@@ -80,6 +84,17 @@ export class CoverageParser {
 					// are reported. Instead, we will count the values from lineHits at the end.
 					// numberOfLinesHit = parseInt(value, 10);
 					break;
+			}
+		}
+
+		// Second pass: process BRDA entries, filtering out spurious ones
+		// Only include BRDA entries if:
+		// 1. The branch was taken (taken > 0), OR
+		// 2. There's a corresponding DA entry for that line
+		// This filters out false positives from the Dart VM for structural lines like "} finally {"
+		for (const branch of branchEntries) {
+			if (branch.taken > 0 || linesWithDirectCoverage.has(branch.lineNumber)) {
+				recordLine(branch.lineNumber, branch.taken);
 			}
 		}
 

--- a/src/test/dart/test/coverage.test.ts
+++ b/src/test/dart/test/coverage.test.ts
@@ -39,11 +39,39 @@ end_of_record
 		const result2 = results[1];
 
 		assert.equal(result1.sourceFilePath, "lib\\main.dart");
-		assert.deepStrictEqual(result1.coverableLines, new Set<number>([1, 2, 3, 4, 5, 6, 7, 8]));
+		// Line 6 is excluded because it has BRDA with taken=0 but no DA entry
+		// This filters out false positives for structural lines like "} finally {"
+		assert.deepStrictEqual(result1.coverableLines, new Set<number>([1, 2, 3, 4, 5, 7, 8]));
 		assert.deepStrictEqual(result1.coveredLines, new Set<number>([1, 2, 3, 5, 7, 8]));
 
 		assert.equal(result2.sourceFilePath, "lib\\main2.dart");
 		assert.deepStrictEqual(result2.coverableLines, new Set<number>([4]));
 		assert.deepStrictEqual(result2.coveredLines, new Set<number>([]));
+	});
+
+	it("filters out spurious BRDA entries for structural lines", async () => {
+		// This test verifies the fix for false positive coverage on structural lines
+		// like "} finally {" which the Dart VM incorrectly generates BRDA entries for
+		const content = `
+SF:lib\\example.dart
+DA:227,1
+DA:230,1
+DA:234,1
+BRDA:229,0,0,0
+end_of_record
+		`.trim();
+
+		const parser = new CoverageParser(privateApi.logger);
+		const results = parser.parseLcovContent(content);
+
+		assert.equal(results.length, 1);
+		const result = results[0];
+
+		// Line 229 should NOT be in coverableLines because:
+		// - It has BRDA:229,0,0,0 (taken=0)
+		// - It has no DA entry
+		// This is a structural line like "} finally {" that shouldn't be coverable
+		assert.deepStrictEqual(result.coverableLines, new Set<number>([227, 230, 234]));
+		assert.deepStrictEqual(result.coveredLines, new Set<number>([227, 230, 234]));
 	});
 });


### PR DESCRIPTION
## Description

This PR fixes false positive coverage reporting for structural lines like `} finally {` that are incorrectly shown as uncovered in VS Code's coverage visualization.

## Problem

The Dart VM incorrectly generates branch coverage entries (BRDA) for structural lines like `} finally {` without corresponding line coverage entries (DA). This causes the extension to mark these lines as coverable but uncovered, resulting in:
- Red gutter markers on structural lines
- Coverage showing < 100% even when all executable code is covered

### Example

```dart
try {
  // code
} finally {  // ← Line incorrectly shown as uncovered
  cleanup();
}
```

**lcov.info data:**
```
DA:227,1    (line before finally - covered)
BRDA:229,0,0,0  (} finally { - spurious entry!)
DA:230,1    (first line in finally - covered)
```

## Solution

Implements a two-pass parsing approach that filters out spurious BRDA entries:
1. **First pass**: Collect all lines with DA (direct coverage) entries
2. **Second pass**: Process BRDA entries, only including them if:
   - The branch was taken (`taken > 0`), OR
   - There's a corresponding DA entry for that line

This prevents structural lines without DA entries from being marked as coverable.

## Validation

This approach is validated by **the official LCOV tool itself**, which rejects BRDA entries without corresponding DA entries as "inconsistent data":

```perl
# From lcovutil.pm:7575-7585
foreach my $line ($brData->keylist()) {
    # we expect to find a line everywhere there is a branch
    my $lineHit = $lineData->value($line);
    unless (defined($lineHit)) {
        lcovutil::ignorable_error($lcovutil::ERROR_INCONSISTENT_DATA,
              "location has branchcov but no linecov data");
    }
```

Our implementation aligns with this standard by filtering such entries rather than reporting them as coverage gaps.

## Testing

- ✅ Existing test updated to reflect new behavior
- ✅ New test added specifically for the `} finally {` false positive case
- ✅ All tests passing

## Impact

- **Fixes false negatives**: Structural lines no longer show as uncovered
- **Maintains accuracy**: Legitimate uncovered code (with DA entries) still shows correctly  
- **No breaking changes**: Only filters obviously spurious entries

## Related Issues

Similar to dart-lang/sdk#31222 which fixed async function closing brace coverage issues.