### PR TITLE
Show a notification for Daemon timeouts on macOS for pre-release users

### DIFF
--- a/src/extension/analysis/analyzer.ts
+++ b/src/extension/analysis/analyzer.ts
@@ -642,7 +642,7 @@ export class LspAnalyzer extends Analyzer {
 					void promptToReloadExtension(logger, {
 						prompt: "Running the analysis server from source failed because of a version mismatch. Is your Dart SDK an older version than this server version requires?",
 						offerLog: true,
-						useError: true,
+						severity: "ERROR",
 						restartReason: ExtensionRestartReason.AnalysisServerFromSourceMismatch
 					});
 				}
@@ -770,7 +770,7 @@ class DartErrorHandler implements ls.ErrorHandler {
 				void promptToReloadExtension(this.logger, {
 					prompt,
 					offerLog: true,
-					useError: true,
+					severity: "ERROR",
 					restartReason: ExtensionRestartReason.AnalysisServerCrashedManyTimes
 				});
 				return {

--- a/src/extension/analytics.ts
+++ b/src/extension/analytics.ts
@@ -368,7 +368,12 @@ export class Analytics implements IAmDisposable {
 		this.event(AnalyticsEvent.AnalysisServer_Terminate, customData);
 	}
 
-	public logErrorFlutterDaemonTimeout() { this.event(AnalyticsEvent.Error_FlutterDaemonTimeout); }
+	public logErrorFlutterDaemonTimeout(requestMethod: string) {
+		const customData: Partial<AnalyticsData> = {
+			data: requestMethod,
+		};
+		this.event(AnalyticsEvent.Error_FlutterDaemonTimeout, customData);
+	}
 	public logSdkDetectionFailure() { this.event(AnalyticsEvent.SdkDetectionFailure); }
 	public logDebuggerStart(debuggerType: string, debuggerRunType: string, sdkDap: boolean) {
 		const customData: Partial<AnalyticsData> = {

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -214,8 +214,8 @@ export function getLatestSdkVersion(): Promise<string> {
 
 export async function promptToReloadExtension(
 	logger: Logger,
-	{ prompt, buttonText, offerLog, specificLog, useError, restartReason }:
-		{ prompt?: string; buttonText?: string; offerLog?: boolean; specificLog?: string; useError?: boolean; restartReason: ExtensionRestartReason, },
+	{ prompt, buttonText, offerLog, specificLog, severity, restartReason }:
+		{ prompt?: string; buttonText?: string; offerLog?: boolean; specificLog?: string; severity?: "ERROR" | "WARNING"; restartReason: ExtensionRestartReason, },
 ): Promise<void> {
 	const restartAction = buttonText || "Restart Extension";
 	const actions = offerLog ? [restartAction, showLogAction] : [restartAction];
@@ -227,7 +227,11 @@ export async function promptToReloadExtension(
 	const tempLogPath = path.join(os.tmpdir(), `log-${getRandomInt(0x1000, 0x10000).toString(16)}.txt`);
 	while (showPromptAgain) {
 		showPromptAgain = false;
-		const show = useError ? window.showErrorMessage : window.showInformationMessage;
+		const show = severity === "ERROR"
+			? window.showErrorMessage
+			: severity === "WARNING"
+				? window.showWarningMessage
+				: window.showInformationMessage;
 		const chosenAction = prompt && await show(prompt, ...actions);
 		if (chosenAction === showLogAction) {
 			showPromptAgain = true;

--- a/src/extension/utils/misc.ts
+++ b/src/extension/utils/misc.ts
@@ -17,7 +17,7 @@ export function reportAnalyzerTerminatedWithError(logger: Logger, duringStartup 
 	void promptToReloadExtension(logger, {
 		prompt,
 		offerLog: true,
-		useError: true,
+		severity: "ERROR",
 		specificLog: config.analyzerLogFile,
 		restartReason: ExtensionRestartReason.AnalyzerTerminated,
 	}).then(() => isShowingAnalyzerError = false);

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -86,6 +86,7 @@ export enum ExtensionRestartReason {
 	FlutterDaemonTerminatedExit = "flutterDaemonTerminatedExit",
 	FlutterDaemonTerminatedPing = "flutterDaemonTerminatedPing",
 	FlutterDaemonTerminatedSend = "flutterDaemonTerminatedSend",
+	FlutterDaemonTimeout = "flutterDaemonTimeout",
 	FlutterProjectAdded = "flutterProjectAdded",
 	FlutterSdkActivationFailure = "flutterSdkActivationFailure",
 	LocatedSdk = "locatedSdk",


### PR DESCRIPTION
This is to help gather more information about the issue in https://github.com/Dart-Code/Dart-Code/issues/5793, that the timeout added for trying to track down a Windows-only issue seems to be record a lot of timeouts on macOS.