### PR TITLE
Ping over the DTD WebSocket every 15s to avoid some proxies (like Norton) dropping the connection

### DIFF
--- a/src/shared/services/tooling_daemon.ts
+++ b/src/shared/services/tooling_daemon.ts
@@ -8,6 +8,7 @@ import { EventsEmitter } from "../events";
 import { DartSdks, IAmDisposable, Logger } from "../interfaces";
 import { CategoryLogger } from "../logging";
 import { disposeAll, PromiseCompleter, PromiseOr } from "../utils";
+import { attachPing } from "../utils/ws";
 import { UnknownNotification } from "./interfaces";
 import { StdIOService } from "./stdio_service";
 import { ActiveLocation, ActiveLocationChangedEvent, DebugSessionChangedEvent, DebugSessionStartedEvent, DebugSessionStoppedEvent, DeviceAddedEvent, DeviceChangedEvent, DeviceRemovedEvent, DeviceSelectedEvent, DtdMessage, DtdNotification, DtdRequest, DtdResponse, DtdResult, EnablePlatformTypeParams, Event, EventKind, GetDebugSessionsResult, GetDevicesResult, GetIDEWorkspaceRootsParams, GetIDEWorkspaceRootsResult, GetVmServicesResult, HotReloadParams, HotRestartParams, NavigateToCodeParams, OpenDevToolsPageParams, ReadFileAsStringParams, ReadFileAsStringResult, RegisterServiceParams, RegisterServiceResult, RegisterVmServiceParams, RegisterVmServiceResult, SelectDeviceParams, Service, ServiceMethod, ServiceRegisteredEventData, ServiceUnregisteredEventData, SetIDEWorkspaceRootsParams, SetIDEWorkspaceRootsResult, Stream, SuccessResult, UnregisterVmServiceParams, UnregisterVmServiceResult } from "./tooling_daemon_services";
@@ -63,6 +64,7 @@ export class DartToolingDaemon implements IAmDisposable {
 
 		this.logger.info(`Connecting to DTD at ${dtdUri}...`);
 		const socket = new ws.WebSocket(dtdUri, { followRedirects: true });
+		attachPing(socket);
 		socket.on("open", () => this.handleOpen());
 		// eslint-disable-next-line @typescript-eslint/no-base-to-string
 		socket.on("message", (data) => this.handleData(data.toString()));

--- a/src/shared/utils/ws.ts
+++ b/src/shared/utils/ws.ts
@@ -1,0 +1,40 @@
+import * as ws from "ws";
+
+/**
+ * Start a frequent (15s) ping over the websocket until it closes.
+ *
+ * This avoids issues where proxies (such as the Norton 360 antivirus) might
+ * drop connections if there is no traffic for 60s.
+ *
+ * https://github.com/Dart-Code/Dart-Code/issues/5794
+ */
+export function attachPing(socket: ws.WebSocket, pingInterval = 15000) {
+	const startPinging = () => {
+		const timer = setInterval(() => {
+			if (socket.readyState === ws.WebSocket.OPEN) {
+				try {
+					socket.ping();
+				} catch {
+					clear();
+				}
+			} else {
+				clear();
+			}
+		}, pingInterval);
+
+		const clear = () => {
+			clearInterval(timer);
+			socket.removeListener("close", clear);
+			socket.removeListener("error", clear);
+		};
+
+		socket.on("close", clear);
+		socket.on("error", clear);
+	};
+
+	if (socket.readyState === ws.WebSocket.OPEN) {
+		startPinging();
+	} else {
+		socket.once("open", startPinging);
+	}
+}

--- a/src/test/dart/utils/ws.test.ts
+++ b/src/test/dart/utils/ws.test.ts
@@ -1,0 +1,32 @@
+import * as http from "http";
+import * as ws from "ws";
+import { attachPing } from "../../../shared/utils/ws";
+
+describe("attachPing", () => {
+	let server: http.Server;
+	let wss: ws.Server;
+
+	beforeEach(() => {
+		server = http.createServer();
+		wss = new ws.Server({ server });
+		server.listen();
+	});
+
+	afterEach(() => {
+		wss.close();
+		server.close();
+	});
+
+	it("sends pings", async () => {
+		const serverReceivedPingPromise = new Promise((resolve) => wss.once("connection", (c) => c.once("ping", resolve)));
+
+		const port = (server.address() as any).port;
+		const socket = new ws.WebSocket(`ws://localhost:${port}`);
+		attachPing(socket, 10); // 10ms interval to avoid test taking long.
+
+		// Wait for the server to get a ping.
+		await serverReceivedPingPromise;
+
+		socket.close();
+	});
+});


### PR DESCRIPTION
Users with Norton 360 installed found that if there is no traffic over the WebSocket for 60s, it gets dropped. This appears to be that the connections are proxied (even if all scanning is disabled) and "idle" connections are dropped.

This forces traffic ever 15s which will prevent them from dropping the connection.

Fixes https://github.com/Dart-Code/Dart-Code/issues/5794