### PR TITLE
Prevent Flutter daemon getEmulators/getSupportedPlatforms before device.enable has completed

### DIFF
--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -140,7 +140,6 @@ export interface CancellationToken {
 }
 
 export interface IFlutterDaemon extends IAmDisposable {
-	daemonStarted: Promise<void>;
 	capabilities: DaemonCapabilities;
 
 	enablePlatformGlobally(platformType: string): Promise<void>;

--- a/src/shared/vscode/device_manager.ts
+++ b/src/shared/vscode/device_manager.ts
@@ -405,7 +405,7 @@ export class FlutterDeviceManager implements vs.Disposable {
 	/// having exited) or there is no response within 5 seconds.
 	public async tryGetSupportedPlatformTypes(projectRoot: string): Promise<string[] | undefined> {
 		return withTimeout(
-			this.daemon.daemonStarted.then(() => this.daemon.getSupportedPlatforms(projectRoot)),
+			this.daemon.getSupportedPlatforms(projectRoot),
 			"The daemon did not respond to getSupportedPlatforms",
 			this.unresponsiveTimeoutPeriodSeconds,
 		).then(
@@ -580,7 +580,6 @@ export class FlutterDeviceManager implements vs.Disposable {
 
 	private async getEmulators(): Promise<Emulator[]> {
 		try {
-			await this.daemon.daemonStarted;
 			const emus = await this.daemon.getEmulators();
 
 			const allEmulatorsByID: Record<string, Emulator> = {};

--- a/src/test/flutter/device_manager.test.ts
+++ b/src/test/flutter/device_manager.test.ts
@@ -355,7 +355,7 @@ class FakeFlutterDaemon extends FakeProcessStdIOService<unknown> implements IFlu
 	public capabilities = DaemonCapabilities.empty;
 	public supportedPlatforms: f.PlatformType[] | undefined;
 	public supportedPlatformsDelaySeconds: number | undefined;
-	public daemonStarted = Promise.resolve();
+	public daemonInitialized = Promise.resolve();
 
 	public async enablePlatformGlobally(_platformType: string): Promise<void> { }
 


### PR DESCRIPTION
I noticed in the logs that we can call functions before `device.enable` completes. It's a long shot, but I wonder if it might be what leads to the timeouts in https://github.com/Dart-Code/Dart-Code/issues/5793. We've had issues in the past where sending requests too early would cause issues, which lead to the `daemonStarted` promise, however it only awaited for _any_ output message and not for `device.enable` to complete.

This adds a new completer for `device.enable` completing, and then an additional 2s delay. If the timeouts reduce with this change, it might help narrow down the ultimate cause in the `flutter` tool.