### PR TITLE
Only run antigravity bots for stable

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,16 +26,15 @@ jobs:
         name: Run all builds
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
         # We only exclude beta versions of "other IDEs" that don't have insiders versions.
-        run: echo 'excludes=[{"build-version":"beta","bot":"dart-antigravity"},{"build-version":"beta","bot":"dart_debug-antigravity"}]]' >> $GITHUB_OUTPUT
+        run: echo 'excludes=[{"build-version":"beta","bot":"dart-antigravity"},{"build-version":"beta","bot":"dart_debug-antigravity"}]' >> $GITHUB_OUTPUT
       - id: exclude
         name: Exclude some builds if not running on schedule
         if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && !startsWith(github.ref, 'refs/tags/')
         # Exclude:
-        # - The same as above, plus
         # - all betas
         # - windows
         # - macOS
-        run: echo 'excludes=[{"build-version":"beta","bot":"dart-antigravity"},{"build-version":"beta","bot":"dart_debug-antigravity"},{"build-version":"beta"},{"os":"windows-latest"},{"os":"macos-latest"}]' >> $GITHUB_OUTPUT
+        run: echo 'excludes=[{"build-version":"beta"},{"os":"windows-latest"},{"os":"macos-latest"}]' >> $GITHUB_OUTPUT
 
   build:
 


### PR DESCRIPTION
We don't have beta versions of Antigravity or Ubuntu, so these bots are effectively duplicates of the stable ones (the difference in Dart/Flutter should not matter here, we're testing Dart-Code).