### PR TITLE
Set environment variables detailing the environment we're running in

### DIFF
--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -206,6 +206,10 @@ export async function activate(context: vs.ExtensionContext, isRestart = false) 
 
 	// Add the PATHs to the Terminal environment so if the user runs commands
 	// there they match the versions (and can be resolved, if not already on PATH).
+	//
+	// We do not set other env vars (such as the `DASH__` vars, or anything else
+	// that ends up in toolEnv) because the terminal is just considered a
+	// terminal.
 	if (config.addSdkToTerminalPath) {
 		const baseSdk = workspaceContext.hasAnyFlutterProjects
 			? sdks.flutter

--- a/src/extension/providers/mcp_server_definition_provider.ts
+++ b/src/extension/providers/mcp_server_definition_provider.ts
@@ -5,6 +5,7 @@ import { dartVMPath } from "../../shared/constants";
 import { DartSdks, IAmDisposable } from "../../shared/interfaces";
 import { disposeAll } from "../../shared/utils";
 import { config } from "../config";
+import { getToolEnv } from "../utils/processes";
 
 export class DartMcpServerDefinitionProvider implements vs.McpServerDefinitionProvider, IAmDisposable {
 	private readonly disposables: IAmDisposable[] = [];
@@ -50,7 +51,7 @@ export class DartMcpServerDefinitionProvider implements vs.McpServerDefinitionPr
 		}
 
 		return [
-			new vs.McpStdioServerDefinition("Dart SDK MCP Server", binPath, args),
+			new vs.McpStdioServerDefinition("Dart SDK MCP Server", binPath, args, getToolEnv()),
 		];
 	}
 

--- a/src/extension/utils/processes.ts
+++ b/src/extension/utils/processes.ts
@@ -10,8 +10,13 @@ let flutterRoot: string | undefined;
 let toolEnv: Record<string, string> = {};
 let globalFlutterArgs: string[] = [];
 
-export function getToolEnv() {
-	return toolEnv;
+/**
+ * Returns a copy of the tool env object.
+ *
+ * Mutations to toolEnv should be done via setupToolEnv/etc.
+ */
+export function getToolEnv(): Record<string, string> {
+	return Object.assign({}, toolEnv);
 }
 
 export function getGlobalFlutterArgs() {

--- a/src/extension/utils/processes.ts
+++ b/src/extension/utils/processes.ts
@@ -1,7 +1,9 @@
-import { CancellationToken } from "vscode";
+import * as vs from "vscode";
 import { isDartCodeTestRun } from "../../shared/constants";
 import { Logger, SpawnedProcess } from "../../shared/interfaces";
 import { RunProcessResult, runProcess, safeSpawn } from "../../shared/processes";
+import { extensionVersion } from "../../shared/vscode/extension_utils";
+import { hostKind } from "../../shared/vscode/utils";
 
 // Environment used when spawning Dart and Flutter processes.
 let flutterRoot: string | undefined;
@@ -38,6 +40,13 @@ export function setupToolEnv(envOverrides?: any) {
 
 	if (!toolEnv.FLUTTER_ROOT && !process.env.FLUTTER_ROOT && flutterRoot)
 		toolEnv.FLUTTER_ROOT = flutterRoot;
+
+	// Add the names/versions of each part of the tool.
+	toolEnv.DASH__IDE_NAME = vs.env.appName;
+	toolEnv.DASH__IDE_VERSION = vs.version;
+	toolEnv.DASH__PLUGIN_NAME = "Dart-Code";
+	toolEnv.DASH__PLUGIN_VERSION = extensionVersion;
+	toolEnv.DASH__IDE_ENVIRONMENT = hostKind ?? "desktop";
 }
 
 export function safeToolSpawn(workingDirectory: string | undefined, binPath: string, args: string[], envOverrides?: Record<string, string | undefined>): SpawnedProcess {
@@ -46,6 +55,6 @@ export function safeToolSpawn(workingDirectory: string | undefined, binPath: str
 }
 
 /// Runs a process and returns the exit code, stdout, stderr. Always resolves even for non-zero exit codes.
-export function runToolProcess(logger: Logger, workingDirectory: string | undefined, binPath: string, args: string[], envOverrides?: Record<string, string | undefined>, cancellationToken?: CancellationToken): Promise<RunProcessResult> {
+export function runToolProcess(logger: Logger, workingDirectory: string | undefined, binPath: string, args: string[], envOverrides?: Record<string, string | undefined>, cancellationToken?: vs.CancellationToken): Promise<RunProcessResult> {
 	return runProcess(logger, binPath, args, workingDirectory, envOverrides, safeToolSpawn, cancellationToken);
 }

--- a/src/shared/vscode/interfaces.ts
+++ b/src/shared/vscode/interfaces.ts
@@ -116,7 +116,7 @@ export interface InternalExtensionApi {
 	flutterOutlineTreeProvider: TreeDataProvider<TreeNode> | undefined;
 	getLogHeader: () => string;
 	getOutputChannel: (name: string) => OutputChannel;
-	getToolEnv: () => any;
+	getToolEnv: () => Record<string, string>;
 	initialAnalysis: Promise<void>;
 	logger: EmittingLogger;
 	analyzer: Analyzer;

--- a/src/test/dart/extension.test.ts
+++ b/src/test/dart/extension.test.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as vs from "vscode";
 import { Sdks } from "../../shared/interfaces";
 import { fsPath } from "../../shared/utils/fs";
+import { extensionVersion } from "../../shared/vscode/extension_utils";
 import { activateWithoutAnalysis, ext, extApi, logger, privateApi } from "../helpers";
 
 describe("test environment", () => {
@@ -49,5 +50,20 @@ describe("extension", () => {
 	it("did read custom env", async () => {
 		await activateWithoutAnalysis();
 		assert.equal(privateApi.getToolEnv().CUSTOM_DART_ENV, "x");
+	});
+	it("did set the expected DASH__ env variables", async () => {
+		await activateWithoutAnalysis();
+		const toolEnv = privateApi.getToolEnv();
+		assert.equal(toolEnv.DASH__IDE_NAME, vs.env.appName);
+		assert.equal(toolEnv.DASH__IDE_VERSION, vs.version);
+		assert.equal(toolEnv.DASH__PLUGIN_NAME, "Dart-Code");
+		assert.equal(toolEnv.DASH__PLUGIN_VERSION, extensionVersion);
+		assert.equal(toolEnv.DASH__IDE_ENVIRONMENT, "desktop");
+
+		// Sanity check some values that are variable.
+		assert.match(String(toolEnv.DASH__IDE_NAME), /Visual Studio Code|Antigravity/);
+		// Don't anchor to the end, allow suffixes for pre-releases.
+		assert.match(String(toolEnv.DASH__IDE_VERSION), /^\d+.\d+.\d/);
+		assert.match(String(toolEnv.DASH__PLUGIN_VERSION), /^3.\d+.\d/);
 	});
 });

--- a/src/test/dart/extension.test.ts
+++ b/src/test/dart/extension.test.ts
@@ -3,8 +3,7 @@ import * as path from "path";
 import * as vs from "vscode";
 import { Sdks } from "../../shared/interfaces";
 import { fsPath } from "../../shared/utils/fs";
-import { extensionVersion } from "../../shared/vscode/extension_utils";
-import { activateWithoutAnalysis, ext, extApi, logger, privateApi } from "../helpers";
+import { activateWithoutAnalysis, ext, extApi, logger, privateApi, validateExpectedEnv } from "../helpers";
 
 describe("test environment", () => {
 	it("has opened the correct folder", () => {
@@ -54,16 +53,6 @@ describe("extension", () => {
 	it("did set the expected DASH__ env variables", async () => {
 		await activateWithoutAnalysis();
 		const toolEnv = privateApi.getToolEnv();
-		assert.equal(toolEnv.DASH__IDE_NAME, vs.env.appName);
-		assert.equal(toolEnv.DASH__IDE_VERSION, vs.version);
-		assert.equal(toolEnv.DASH__PLUGIN_NAME, "Dart-Code");
-		assert.equal(toolEnv.DASH__PLUGIN_VERSION, extensionVersion);
-		assert.equal(toolEnv.DASH__IDE_ENVIRONMENT, "desktop");
-
-		// Sanity check some values that are variable.
-		assert.match(String(toolEnv.DASH__IDE_NAME), /Visual Studio Code|Antigravity/);
-		// Don't anchor to the end, allow suffixes for pre-releases.
-		assert.match(String(toolEnv.DASH__IDE_VERSION), /^\d+.\d+.\d/);
-		assert.match(String(toolEnv.DASH__PLUGIN_VERSION), /^3.\d+.\d/);
+		validateExpectedEnv(toolEnv);
 	});
 });

--- a/src/test/dart/mcp_server.test.ts
+++ b/src/test/dart/mcp_server.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from "assert";
 import * as vs from "vscode";
 import { fsPath } from "../../shared/utils/fs";
-import { activate, activateWithoutAnalysis, closeAllOpenFiles, currentDoc, emptyFile, privateApi, sb, setConfigForTest } from "../helpers";
+import { activate, activateWithoutAnalysis, closeAllOpenFiles, currentDoc, emptyFile, validateExpectedEnv as ensureExpectedEnvVariables, privateApi, sb, setConfigForTest } from "../helpers";
 
 describe("MCP server", () => {
 	let originalCapabilitiesVersion: string;
@@ -25,6 +25,17 @@ describe("MCP server", () => {
 		}
 		return excludedTools;
 	}
+
+	it("sets expected dash env vars", async () => {
+		privateApi.dartCapabilities.version = "3.10.0";
+
+		const provider = privateApi.mcpServerProvider!;
+		const servers = await provider.provideMcpServerDefinitions(new vs.CancellationTokenSource().token);
+		const server = servers![0] as vs.McpStdioServerDefinition;
+
+		// Just check some basics, there's another test for more specific values.
+		ensureExpectedEnvVariables(server.env);
+	});
 
 	it("passes --exclude-tool for run_tests by default", async () => {
 		privateApi.dartCapabilities.version = "3.10.0";

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -1461,6 +1461,6 @@ export function validateExpectedEnv(e: Record<string, string | number | null>) {
 	// Sanity check some values that are variable.
 	assert.match(String(e.DASH__IDE_NAME), /Visual Studio Code|Antigravity/);
 	// Don't anchor to the end, allow suffixes for pre-releases.
-	assert.match(String(e.DASH__IDE_VERSION), /^\d+.\d+.\d/);
-	assert.match(String(e.DASH__PLUGIN_VERSION), /^3.\d+.\d/);
+	assert.match(String(e.DASH__IDE_VERSION), /^\d+\.\d+\.\d/);
+	assert.match(String(e.DASH__PLUGIN_VERSION), /^3\.\d+\.\d/);
 }

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -23,6 +23,7 @@ import { SourceSortMembersCodeActionKind, treeLabel } from "../shared/vscode/uti
 import { Context } from "../shared/vscode/workspace";
 // eslint-disable-next-line no-restricted-imports
 import { PublicDartExtensionApi } from "../extension/api/interfaces";
+import { extensionVersion } from "../shared/vscode/extension_utils";
 import { locateBestProjectRoot } from "../shared/vscode/project";
 
 export const ext = vs.extensions.getExtension(dartCodeExtensionIdentifier)!;
@@ -1448,4 +1449,18 @@ export function createTempTestFile(absolutePath: string) {
 	createFolderForFile(absolutePath);
 	fs.writeFileSync(absolutePath, "");
 	defer("delete temp file", () => tryDeleteFile(absolutePath));
+}
+
+export function validateExpectedEnv(e: Record<string, string | number | null>) {
+	assert.equal(e.DASH__IDE_NAME, vs.env.appName);
+	assert.equal(e.DASH__IDE_VERSION, vs.version);
+	assert.equal(e.DASH__PLUGIN_NAME, "Dart-Code");
+	assert.equal(e.DASH__PLUGIN_VERSION, extensionVersion);
+	assert.equal(e.DASH__IDE_ENVIRONMENT, "desktop");
+
+	// Sanity check some values that are variable.
+	assert.match(String(e.DASH__IDE_NAME), /Visual Studio Code|Antigravity/);
+	// Don't anchor to the end, allow suffixes for pre-releases.
+	assert.match(String(e.DASH__IDE_VERSION), /^\d+.\d+.\d/);
+	assert.match(String(e.DASH__PLUGIN_VERSION), /^3.\d+.\d/);
 }


### PR DESCRIPTION
Currently the extension only advertises itself as "Dart-Code" or "VSCode" to all tools, which can be misleading when the extension is run inside another editor (like Antigravity or Cursor).

This change adds some additional values in new env vars that a tool might want to know about that will be available to all spawned processes without relying on protocol-specific values (such as the client info in LSP).

All of these are informational and may contain arbitrary values. They are not intended to replace existing values (like `--client-id` for analysis server) that might control the opt-in/opt-out of analytics, though an additional env variable might be added for this in future (see `DASH__TOOL` in https://github.com/Dart-Code/Dart-Code/issues/5561).

Fixes https://github.com/Dart-Code/Dart-Code/issues/5561

(this table is copied from https://github.com/Dart-Code/Dart-Code/issues/5561 to here for convenience)

| Environment Variable | Example Values | Description | Replaces |
| - | - | - | - |
| `DASH__IDE_NAME` | `VS Code`, `Cursor`, `Antigravity`, `IntelliJ`, `Android Studio` | The name of the IDE that the user launched (regardless of any plugin) | N/A |
| `DASH__IDE_VERSION` | `1.2.3`, `1.2.3-alpha.4` | The version of the software named in `DASH__IDE_NAME` | N/A |
| `DASH__PLUGIN_NAME` | `Dart-Code`, `dart-intellij`(?) | The name of the plugin that provides the integration with Dart/Flutter tools | |
| `DASH__PLUGIN_VERSION` | `1.2.3`, `1.2.3-alpha.4` | The version of the software named in `DASH__PLUGIN_NAME` | `--client-version` |
| `DASH__TOOL` (**not implemented by this PR**) | `vscode-plugins`, `intellijPlugins` | The ID of the tool used for analytics reporting (maps to fixed enum in unified analytics). This also controls whether the user is prompted about analytics collection (the first use of a given value triggers a new prompt). | `--client-id`, `FLUTTER_HOST`(?) |
| `DASH__IDE_ENVIRONMENT` | `desktop`, `wsl`, `ssh-remote`, `codespaces`, `dev-container` | Additional string to describe if the environment is special in some way (like a VS Code "remote" session) | The `-Remote` suffix in the tool name? |