### PR TITLE
Read package:test version from .dart_tool/package_graph.json instead of running `dart test --version`

### DIFF
--- a/src/extension/commands/test.ts
+++ b/src/extension/commands/test.ts
@@ -8,7 +8,7 @@ import { FlutterCapabilities } from "../../shared/capabilities/flutter";
 import { noAction } from "../../shared/constants";
 import { Logger } from "../../shared/interfaces";
 import { RunnableTreeNode, SuiteData, SuiteNode, TestNode, TreeNode } from "../../shared/test/test_model";
-import { getPackageTestCapabilities } from "../../shared/test/version";
+import { getPackageTestCapabilitiesForDartProject } from "../../shared/test/version";
 import { disposeAll, escapeDartString, generateTestNameFromFileName, uniq } from "../../shared/utils";
 import { sortBy } from "../../shared/utils/array";
 import { fsPath, getPackageName, isWithinPath, mkDirRecursive } from "../../shared/utils/fs";
@@ -180,7 +180,7 @@ export class TestCommands implements vs.Disposable {
 		if (!isFlutter) {
 			const projectFolderPath = locateBestProjectRoot(programPath);
 			if (projectFolderPath)
-				dartTestCapabilities = await getPackageTestCapabilities(this.logger, this.wsContext, projectFolderPath);
+				dartTestCapabilities = getPackageTestCapabilitiesForDartProject(this.logger, this.wsContext, projectFolderPath);
 		}
 
 		let shouldRunTestsByLine = false;

--- a/src/extension/providers/debug_config_provider.ts
+++ b/src/extension/providers/debug_config_provider.ts
@@ -11,7 +11,7 @@ import { Device } from "../../shared/flutter/daemon_interfaces";
 import { getFutterWebRenderer } from "../../shared/flutter/utils";
 import { DartWorkspaceContext, IFlutterDaemon, Logger } from "../../shared/interfaces";
 import { TestModel } from "../../shared/test/test_model";
-import { getPackageTestCapabilities } from "../../shared/test/version";
+import { getPackageTestCapabilitiesForDartProject } from "../../shared/test/version";
 import { isWebDevice, notNullOrUndefined } from "../../shared/utils";
 import { findCommonAncestorFolder, forceWindowsDriveLetterToUppercase, fsPath, isFlutterProjectFolder, isWithinPath } from "../../shared/utils/fs";
 import { getProgramPath } from "../../shared/utils/test";
@@ -679,23 +679,23 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 
 		switch (debuggerType) {
 			case DebuggerType.Dart:
-				args = args.concat(await this.buildDartToolArgs(debugConfig, conf));
+				args = args.concat(this.buildDartToolArgs(debugConfig, conf));
 				break;
 			case DebuggerType.DartTest:
-				args = args.concat(await this.buildDartTestToolArgs(debugConfig, conf));
+				args = args.concat(this.buildDartTestToolArgs(debugConfig, conf));
 				break;
 			case DebuggerType.Flutter:
 				args = args.concat(await this.buildFlutterToolArgs(debugConfig, conf));
 				break;
 			case DebuggerType.FlutterTest:
-				args = args.concat(await this.buildFlutterTestToolArgs(debugConfig, conf));
+				args = args.concat(this.buildFlutterTestToolArgs(debugConfig, conf));
 				break;
 		}
 
 		return args;
 	}
 
-	protected async buildDartToolArgs(debugConfig: DartVsCodeLaunchArgs, conf: ResourceConfig): Promise<string[]> {
+	protected buildDartToolArgs(debugConfig: DartVsCodeLaunchArgs, conf: ResourceConfig): string[] {
 		const args: string[] = [];
 
 		this.addArgsIfNotExist(args, ...conf.cliAdditionalArgs);
@@ -706,7 +706,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		return args;
 	}
 
-	protected async buildDartTestToolArgs(debugConfig: DartVsCodeLaunchArgs, conf: ResourceConfig): Promise<string[]> {
+	protected buildDartTestToolArgs(debugConfig: DartVsCodeLaunchArgs, conf: ResourceConfig): string[] {
 		const args: string[] = [];
 
 		this.addArgsIfNotExist(args, ...conf.testAdditionalArgs);
@@ -714,7 +714,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 			// Check whether package:test supports --ignore-timeouts
 			let useIgnoreTimeouts = false;
 			if (debugConfig.cwd) {
-				const testCapabilities = await getPackageTestCapabilities(this.logger, this.wsContext, debugConfig.cwd);
+				const testCapabilities = getPackageTestCapabilitiesForDartProject(this.logger, this.wsContext, debugConfig.cwd);
 				useIgnoreTimeouts = testCapabilities.supportsIgnoreTimeouts;
 			}
 			if (useIgnoreTimeouts)
@@ -802,7 +802,7 @@ export class DebugConfigProvider implements DebugConfigurationProvider {
 		return args;
 	}
 
-	protected async buildFlutterTestToolArgs(debugConfig: DartVsCodeLaunchArgs, conf: ResourceConfig): Promise<string[]> {
+	protected buildFlutterTestToolArgs(debugConfig: DartVsCodeLaunchArgs, conf: ResourceConfig): string[] {
 		const args: string[] = [];
 
 		this.addArgsIfNotExist(args, ...getGlobalFlutterArgs());

--- a/src/extension/test/vs_test_controller.ts
+++ b/src/extension/test/vs_test_controller.ts
@@ -426,18 +426,13 @@ export class VsCodeTestController implements TestEventListener, IAmDisposable {
 		this.itemForNode.set(node, item);
 
 		if (node instanceof RunnableTreeNode && this.isRunnableTest(node)) {
-			item.tags = [runnableTestTag];
-
-			// Checking if coverage is supported is async, so we need to do this later.
 			let project: TreeNode | undefined = node;
 			while (project && !(project instanceof ProjectNode))
 				project = project.parent;
 
-			void project?.supportsCoverage.then((supportsCoverage) => {
-				if (supportsCoverage) {
-					item.tags = [...item.tags, runnableWithCoverageTestTag]; // Reassign to force update.
-				}
-			});
+			item.tags = project?.supportsCoverage
+				? [runnableTestTag, runnableWithCoverageTestTag]
+				: [runnableTestTag];
 		}
 
 		item.children.replace(

--- a/src/shared/test/coordinator.ts
+++ b/src/shared/test/coordinator.ts
@@ -10,28 +10,34 @@ import { TestOutlineVisitor } from "../utils/outline";
 import { isSetupOrTeardownTestName } from "../utils/test";
 import { SuiteData, TestModel, TestSource } from "./test_model";
 
-/// Handles results from a test debug session and provides them to the test model.
+/** Handles results from a test debug session and provides them to the test model. */
 export class TestSessionCoordinator implements IAmDisposable {
 	private disposables: IAmDisposable[] = [];
 
-	/// A link between a suite path and the debug session ID that owns it, so we can ensure
-	/// it is correctly ended when the debug session ends, even if we don't get the correct
-	/// end events.
+	/**
+	 * A link between a suite path and the debug session ID that owns it, so we can ensure
+	 * it is correctly ended when the debug session ends, even if we don't get the correct
+	 * end events.
+	 */
 	private owningDebugSessions: Record<string, string | undefined> = {};
 
-	/// For a given debug session, lookups by IDs to get back to the suite.
+	/** For a given debug session, lookups by IDs to get back to the suite. */
 	private debugSessionLookups: Record<string, {
 		cwd: string | undefined,
 		suiteForID: Record<string, SuiteData | undefined>,
 		suiteForTestID: Record<string, SuiteData | undefined>,
 	} | undefined> = {};
 
-	/// A link between a suite path and a visitor for visiting its latest outline data.
-	/// This data is refreshed when a test suite starts running.
+	/**
+	 * A link between a suite path and a visitor for visiting its latest outline data.
+	 * This data is refreshed when a test suite starts running.
+	 */
 	private suiteOutlineVisitors: Record<string, TestOutlineVisitor | undefined> = {};
 
-	/// For each debug session ID, stores a mapping of phantom (empty) groups and their parent IDs so we can
-	/// jump over them.
+	/**
+	 * For each debug session ID, stores a mapping of phantom (empty) groups and their parent IDs so we can
+	 * jump over them.
+	 */
 	private phantomGroupParents: Record<string, Record<number, number | null | undefined>> = {};
 
 	constructor(private readonly logger: Logger, private readonly data: TestModel, private readonly fileTracker: { getOutlineFor(uri: URI): Outline | undefined }) { }
@@ -158,10 +164,12 @@ export class TestSessionCoordinator implements IAmDisposable {
 		}
 		this.debugSessionLookups[dartCodeDebugSessionID]!.suiteForTestID[evt.test.id] = suite;
 
-		/// We prefer the root location (the location inside the executed test suite) for normal tests, but for
-		// setup/tearDown we want to consider them in their actual locations so that failures will be attributed
-		// to them correctly.
-		// https://github.com/Dart-Code/Dart-Code/issues/4681#issuecomment-1671191742
+		/**
+		 * We prefer the root location (the location inside the executed test suite) for normal tests, but for
+		 * setup/tearDown we want to consider them in their actual locations so that failures will be attributed
+		 * to them correctly.
+		 * https://github.com/Dart-Code/Dart-Code/issues/4681#issuecomment-1671191742
+		 */
 		const useRootLocation = !isSetupOrTeardownTestName(evt.test.name) && !!evt.test.root_url && !!evt.test.root_line && !!evt.test.root_column;
 
 		const path = maybeUriToFilePath(useRootLocation ? evt.test.root_url ?? undefined : evt.test.url ?? undefined);

--- a/src/shared/test/test_model.ts
+++ b/src/shared/test/test_model.ts
@@ -12,7 +12,7 @@ import { makeRegexForTests } from "../utils/test";
 import { locateBestProjectRoot } from "../vscode/project";
 import { DocumentRangeTracker } from "../vscode/trackers";
 import { WorkspaceContext } from "../workspace";
-import { getPackageTestCapabilities } from "./version";
+import { getPackageTestCapabilitiesForDartProject } from "./version";
 
 export abstract class TreeNode {
 	public abstract parent: TreeNode | undefined;
@@ -107,7 +107,7 @@ export class ProjectNode extends TreeNode {
 		public readonly parent: WorkspaceFolderNode | undefined,
 		public readonly name: string,
 		public readonly path: string,
-		public readonly supportsCoverage: Promise<boolean>) {
+		public readonly supportsCoverage: boolean) {
 		super();
 	}
 
@@ -322,11 +322,9 @@ export class TestModel {
 			? path.relative(workspaceFolder.path, projectPath)
 			: path.basename(projectPath);
 
-		// Pass a promise that resolves to whether this project supports coverage so we don't need to look
-		// it up for each suite.
-		const checkProjectSupportsCoverage = async () => isFlutterProjectFolder(projectPath) || (await getPackageTestCapabilities(this.logger, this.workspaceContext, projectPath)).supportsLcovCoverage;
+		const supportsCoverage = isFlutterProjectFolder(projectPath) || getPackageTestCapabilitiesForDartProject(this.logger, this.workspaceContext, projectPath).supportsLcovCoverage;
 
-		const node = new ProjectNode(parent, name, projectPath, checkProjectSupportsCoverage());
+		const node = new ProjectNode(parent, name, projectPath, supportsCoverage);
 		this.projectNodes.set(projectPath, node);
 
 		if (parent) {
@@ -393,7 +391,7 @@ export class TestModel {
 		this.updateTestCountLabels(suite.node, forceUpdate, "DOWN");
 	}
 
-	/// Recomputes the test counts and labels for a node and it's parent/children (based on `direction`).
+	/** Recomputes the test counts and labels for a node and its parent/children (based on `direction`). */
 	private updateTestCountLabels(node: RunnableTreeNode, forceUpdate: boolean, direction: "UP" | "DOWN"): void {
 		if (direction === "DOWN") {
 			for (const child of node.children) {
@@ -462,8 +460,10 @@ export class TestModel {
 		const oldParent = existingGroup?.parent;
 		let parent = parentID ? suite.getMyGroup(dartCodeDebugSessionID, parentID)! : suite.node;
 
-		/// If we're a dynamic test/group, we should be re-parented under the dynamic node that came from
-		/// the analyzer.
+		/**
+		 * If we're a dynamic test/group, we should be re-parented under the dynamic node that came from
+		 * the analyzer.
+		 */
 		if (groupName && source === TestSource.Result)
 			parent = this.findMatchingDynamicNode(parent, groupName) ?? parent;
 
@@ -508,8 +508,10 @@ export class TestModel {
 		const oldParent = existingTest?.parent;
 		let parent = groupID ? suite.getMyGroup(dartCodeDebugSessionID, groupID)! : suite.node;
 
-		/// If we're a dynamic test/group, we should be re-parented under the dynamic node that came from
-		/// the analyzer.
+		/**
+		 * If we're a dynamic test/group, we should be re-parented under the dynamic node that came from
+		 * the analyzer.
+		 */
 		if (testName && source === TestSource.Result)
 			parent = this.findMatchingDynamicNode(parent, testName) ?? parent;
 
@@ -569,8 +571,10 @@ export class TestModel {
 		return testNode;
 	}
 
-	/// Find a matching node in 'parent' that might be a node for a dynamic test/group that name is
-	/// an instance of.
+	/**
+	 * Find a matching node in 'parent' that might be a node for a dynamic test/group that name is
+	 * an instance of.
+	 */
 	private findMatchingDynamicNode<T extends GroupNode | SuiteNode>(parent: T, name: string): T | undefined {
 		// If the parent has any children exactly named us, they should be used regardless.
 		if (parent.children.find((c) => c.name === name))

--- a/src/shared/test/version.ts
+++ b/src/shared/test/version.ts
@@ -1,63 +1,52 @@
+import * as fs from "fs";
 import * as path from "path";
 import * as semver from "semver";
-import { DartTestCapabilities, DartTestCapabilitiesFromHelpText } from "../../shared/capabilities/dart_test";
-import { dartVMPath, packageTestCapabilitiesCacheTimeInMs } from "../../shared/constants";
-import { DartSdks, Logger } from "../../shared/interfaces";
-import { runProcess, safeSpawn } from "../processes";
+import { DartTestCapabilities } from "../../shared/capabilities/dart_test";
+import { packageTestCapabilitiesCacheTimeInMs } from "../../shared/constants";
+import { Logger } from "../../shared/interfaces";
 import { PackageMap } from "../pub/package_map";
-import { PromiseCompleter } from "../utils";
 import { SimpleTimeBasedCache } from "../utils/cache";
 import { WorkspaceContext } from "../workspace";
 
-/// A cache of both project folder + package config paths, to the capabilities.
-export const cachedTestCapabilities = new SimpleTimeBasedCache<Promise<DartTestCapabilities>>();
+/** A cache of both project folder + package config paths, to the capabilities. */
+export const cachedTestCapabilities = new SimpleTimeBasedCache<DartTestCapabilities>();
 
-/// Get the capabilities by using "dart test --version".
-///
-/// Returns `undefined` in the case where `--version` doesn't work, and we should fall back to `--help`.
-async function getCapabilitiesFromVersion(logger: Logger, binPath: string, folder: string): Promise<DartTestCapabilities | undefined> {
-	const proc = await runProcess(logger, binPath, ["run", "test:test", "--version"], folder, {}, safeSpawn);
-	if (proc.exitCode === 0) {
-		// Take the last line of the output, because we can get "Resolving dependencies..." in front of it.
-		const output = proc.stdout.trim().split("\n").pop()?.trim();
-		if (output && semver.valid(output))
-			return new DartTestCapabilities(output);
-		else
-			console.warn(`Failed to parse pkg:test version number: ${output}`);
-	} else {
-		// Log failure.
-		const output = (proc.stdout.trim() + "\n" + proc.stderr.trim()).trim();
-		console.warn(`Failed to get pkg:test version number: ${output}`);
+/**
+ * Get the capabilities by reading the version from package_graph.json.
+ *
+ * Returns `undefined` if the graph/version cannot be read.
+ */
+function getCapabilitiesFromVersionInPackageGraph(logger: Logger, packageFile: string): DartTestCapabilities | undefined {
+	const packageGraphFile = path.join(path.dirname(packageFile), "package_graph.json");
 
-		// In Pub workspaces, the version is not (currently) available because
-		// of https://github.com/dart-lang/test/issues/2535, so if we see this message,
-		// fall back to using the `--help` text to determine the capabilities.
-		if (output.includes("Couldn't find version number")) {
-			return undefined; // Signal that we should fall back to --help.
-		}
+	try {
+		const packageGraphJson = fs.readFileSync(packageGraphFile, "utf8");
+		const packageGraph = JSON.parse(packageGraphJson) as PackageGraphJson;
+		const testVersion = packageGraph.packages?.find((pkg) => pkg.name === "test")?.version;
+
+		if (!testVersion)
+			return undefined;
+
+		if (semver.valid(testVersion))
+			return new DartTestCapabilities(testVersion);
+
+		logger.warn(`Failed to parse pkg:test version number from ${packageGraphFile}: ${testVersion}`);
+	} catch (e: any) {
+		if (e?.code !== "ENOENT")
+			logger.warn(`Failed to read pkg:test version number from ${packageGraphFile}: ${e}`);
 	}
 
-	return DartTestCapabilities.empty;
+	return undefined;
 }
 
-/// Get the capabilities by using "dart test --help" and reading the flags.
-///
-/// This is a fallback for when --version does not work - see
-/// https://github.com/dart-lang/test/issues/2535
-async function getCapabilitiesFromHelp(logger: Logger, binPath: string, folder: string): Promise<DartTestCapabilities> {
-	const proc = await runProcess(logger, binPath, ["test", "--help"], folder, {}, safeSpawn);
-	if (proc.exitCode === 0) {
-		const helpText = proc.stdout.trim();
-		return new DartTestCapabilitiesFromHelpText(helpText);
-	} else {
-		const output = (proc.stdout.trim() + "\n" + proc.stderr.trim()).trim();
-		console.warn(`Failed to get pkg:test capabilities from --help: ${output}`);
-		return DartTestCapabilities.empty;
-	}
-}
-
-export async function getPackageTestCapabilities(logger: Logger, workspaceContext: WorkspaceContext, folderPath: string): Promise<DartTestCapabilities> {
-	// Don't ever run the command below in places like g3.
+/**
+ * Gets the pkg:test capabilities for a Dart project.
+ *
+ * This function should not be used for Flutter projects, as Flutter uses flutter_test and capabilities for that are
+ * versioned with the Flutter SDK and don't need a package version check.
+ */
+export function getPackageTestCapabilitiesForDartProject(logger: Logger, workspaceContext: WorkspaceContext, folderPath: string): DartTestCapabilities {
+	// Don't look for a version in places where we don't support `dart run test`.
 	if (workspaceContext.config.supportsDartRunTest === false)
 		return DartTestCapabilities.empty;
 
@@ -78,26 +67,24 @@ export async function getPackageTestCapabilities(logger: Logger, workspaceContex
 	if (cached !== undefined)
 		return cached;
 
-	const sdks = workspaceContext.sdks as DartSdks;
-	const completer = new PromiseCompleter<DartTestCapabilities>();
-	cachedTestCapabilities.add(folderPath, completer.promise, packageTestCapabilitiesCacheTimeInMs);
-	cachedTestCapabilities.add(packageFile, completer.promise, packageTestCapabilitiesCacheTimeInMs);
-	const binPath = path.join(sdks.dart, dartVMPath);
-
 	try {
-		const capabilities =
-			// First try to get the version from "dart run test:test --version".
-			await getCapabilitiesFromVersion(logger, binPath, folderPath)
-			// If that returns undefined, we should fall back to using "dart test --help".
-			?? await getCapabilitiesFromHelp(logger, binPath, folderPath);
-
-		completer.resolve(capabilities);
+		const capabilities = getCapabilitiesFromVersionInPackageGraph(logger, packageFile) ?? DartTestCapabilities.empty;
+		cachedTestCapabilities.add(folderPath, capabilities, packageTestCapabilitiesCacheTimeInMs);
+		cachedTestCapabilities.add(packageFile, capabilities, packageTestCapabilitiesCacheTimeInMs);
 
 		return capabilities;
 	} catch (e) {
 		logger.error(`Failed to get package:test capabilities: ${e}`);
 
-		completer.resolve(DartTestCapabilities.empty);
 		return DartTestCapabilities.empty;
 	}
+}
+
+interface PackageGraphJson {
+	packages?: PackageGraphPackage[];
+}
+
+interface PackageGraphPackage {
+	name: string;
+	version?: string;
 }

--- a/src/test/dart/debug_configuration.test.ts
+++ b/src/test/dart/debug_configuration.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from "assert";
-import { getPackageTestCapabilities } from "../../shared/test/version";
+import { getPackageTestCapabilitiesForDartProject } from "../../shared/test/version";
 import { fsPath } from "../../shared/utils/fs";
 import { activate, ensureArrayContainsArray, getResolvedDebugConfiguration, helloWorldFolder, helloWorldMainFile, helloWorldTestMainFile, openFile, privateApi, setConfigForTest } from "../helpers";
 
@@ -81,7 +81,7 @@ describe("dart test debugger", () => {
 				program: fsPath(helloWorldTestMainFile),
 			});
 
-			const testCapabilities = await getPackageTestCapabilities(privateApi.logger, privateApi.workspaceContext, resolvedConfig.cwd!);
+			const testCapabilities = getPackageTestCapabilitiesForDartProject(privateApi.logger, privateApi.workspaceContext, resolvedConfig.cwd!);
 			if (testCapabilities.supportsIgnoreTimeouts)
 				ensureArrayContainsArray(resolvedConfig.toolArgs!, ["--ignore-timeouts"]);
 			else

--- a/src/test/dart_debug/dart_cli.test.ts
+++ b/src/test/dart_debug/dart_cli.test.ts
@@ -245,6 +245,7 @@ void printSomething() {
 			dc.assertOutputContains("stdout", "ORIGINAL CONTENT"),
 			dc.launch(config),
 		);
+		await delay(50); // Without this, this test can flake when run in a batch.
 
 		// Replace the content and trigger hot reload.
 		const editor = currentEditor();

--- a/src/test/dart_debug/dart_test.test.ts
+++ b/src/test/dart_debug/dart_test.test.ts
@@ -5,7 +5,7 @@ import { SinonStub } from "sinon";
 import * as vs from "vscode";
 import { URI } from "vscode-uri";
 import { DebuggerType } from "../../shared/enums";
-import { getPackageTestCapabilities } from "../../shared/test/version";
+import { getPackageTestCapabilitiesForDartProject } from "../../shared/test/version";
 import { SuiteNotification, TestStartNotification } from "../../shared/test_protocol";
 import { fsPath } from "../../shared/utils/fs";
 import { TestOutlineVisitor } from "../../shared/utils/outline";
@@ -692,7 +692,7 @@ test/empty_test.dart
 		});
 
 		it("and includes dependencies", async function () {
-			const testCapabilities = await getPackageTestCapabilities(privateApi.logger, privateApi.workspaceContext, fsPath(helloWorldExampleSubFolder));
+			const testCapabilities = getPackageTestCapabilitiesForDartProject(privateApi.logger, privateApi.workspaceContext, fsPath(helloWorldExampleSubFolder));
 			if (!testCapabilities.supportsCoveragePackage)
 				this.skip();
 
@@ -712,7 +712,7 @@ test/empty_test.dart
 		});
 
 		it("and excludes configured paths", async function () {
-			const testCapabilities = await getPackageTestCapabilities(privateApi.logger, privateApi.workspaceContext, fsPath(helloWorldExampleSubFolder));
+			const testCapabilities = getPackageTestCapabilitiesForDartProject(privateApi.logger, privateApi.workspaceContext, fsPath(helloWorldExampleSubFolder));
 			if (!testCapabilities.supportsCoveragePackage)
 				this.skip();
 
@@ -734,7 +734,7 @@ test/empty_test.dart
 		});
 
 		it("uses correct regex for --coverage-package", async function () {
-			const testCapabilities = await getPackageTestCapabilities(privateApi.logger, privateApi.workspaceContext, fsPath(helloWorldExampleSubFolder));
+			const testCapabilities = getPackageTestCapabilitiesForDartProject(privateApi.logger, privateApi.workspaceContext, fsPath(helloWorldExampleSubFolder));
 			if (!testCapabilities.supportsCoveragePackage)
 				this.skip();
 


### PR DESCRIPTION
We currently spawn `dart run test:test --version` for each package in the workspace to get the test capabilities during test discovery (to know if we can add profiles like Coverage to a given suite). This can be expensive (in terms of CPU and RAM) if the project is large.

For example opening the Dart SDK root on my machine and then clicking the Test Explorer icon results in all RAM being consumed. We already filter out packages in the same Pub Workspace, but there are lots of non-Workspace packages in there.

With this change, we just read the version from the `.dart_tool/package_graph.json` file instead which is significantly faster and uses little resources.

This also resulted in quite a bit of async code becoming sync.

Fixes https://github.com/Dart-Code/Dart-Code/issues/5936