### PR TITLE
Resolve a pubspec/package to its workspace before running "pub get"

### DIFF
--- a/src/extension/commands/batch_progress.ts
+++ b/src/extension/commands/batch_progress.ts
@@ -1,8 +1,9 @@
 import * as vs from "vscode";
 import { maxConcurrentProcesses, runWithConcurrencyLimit } from "../../shared/pub/utils";
 import { fsPath } from "../../shared/utils/fs";
+import { OperationProgress } from "../../shared/vscode/interfaces";
 import { config } from "../config";
-import { getPackageOrFolderDisplayName, OperationProgress } from "./sdk";
+import { getPackageOrFolderDisplayName } from "./sdk";
 
 export async function runBatchFolderOperation(
 	uris: vs.Uri[],

--- a/src/extension/commands/flutter.ts
+++ b/src/extension/commands/flutter.ts
@@ -14,7 +14,7 @@ import { fsPath, isFlutterProjectFolder, mkDirRecursive, nextAvailableFilename }
 import { writeFlutterSdkSettingIntoProject, writeFlutterTriggerFile } from "../../shared/utils/projects";
 import { FlutterDeviceManager } from "../../shared/vscode/device_manager";
 import { createFlutterSampleInTempFolder } from "../../shared/vscode/flutter_samples";
-import { FlutterSampleSnippet } from "../../shared/vscode/interfaces";
+import { FlutterSampleSnippet, OperationProgress } from "../../shared/vscode/interfaces";
 import { getAllProjectFolders } from "../../shared/vscode/utils";
 import { Context } from "../../shared/vscode/workspace";
 import { Analytics } from "../analytics";
@@ -25,7 +25,7 @@ import * as util from "../utils";
 import { PickableSetting, showInputBoxWithSettings, showSimpleSettingsEditor } from "../utils/vscode/input";
 import { getFolderToRunCommandIn } from "../utils/vscode/projects";
 import { runBatchFolderOperation } from "./batch_progress";
-import { BaseSdkCommands, commandState, OperationProgress, packageNameRegex } from "./sdk";
+import { BaseSdkCommands, commandState, packageNameRegex } from "./sdk";
 
 export class FlutterCommands extends BaseSdkCommands {
 	private flutterScreenshotPath?: string;

--- a/src/extension/commands/packages.ts
+++ b/src/extension/commands/packages.ts
@@ -6,7 +6,8 @@ import { DartWorkspaceContext, Logger } from "../../shared/interfaces";
 import { RunProcessResult } from "../../shared/processes";
 import { uniq } from "../../shared/utils";
 import { fsPath, touchFile } from "../../shared/utils/fs";
-import { getPubWorkspaceOrPackageFolders, getPubWorkspaceStatus, isValidPubGetTarget, promptToRunPubGet, promptToRunPubUpgrade, runPubGet } from "../../shared/vscode/pub";
+import { OperationProgress } from "../../shared/vscode/interfaces";
+import { getPubWorkspaceFolderOrPackageFolderPath, getPubWorkspaceFolderOrPackageFolderUri, getPubWorkspaceOrPackageFolderUris, getPubWorkspaceStatus, isValidPubGetTarget, promptToRunPubGet, promptToRunPubUpgrade, runPubGet } from "../../shared/vscode/pub";
 import { getAllProjectFolders } from "../../shared/vscode/utils";
 import { Context } from "../../shared/vscode/workspace";
 import { config } from "../config";
@@ -14,7 +15,7 @@ import * as util from "../utils";
 import { getExcludedFolders } from "../utils";
 import { getFolderToRunCommandIn } from "../utils/vscode/projects";
 import { runBatchFolderOperation } from "./batch_progress";
-import { BaseSdkCommands, commandState, OperationProgress } from "./sdk";
+import { BaseSdkCommands, commandState } from "./sdk";
 
 let isFetchingPackages = false;
 let runPubGetDelayTimer: NodeJS.Timeout | undefined;
@@ -53,13 +54,15 @@ export class PackageCommands extends BaseSdkCommands {
 
 	/// Touches pubspec.lock and .dart_tool/package_config.json to update their modification times.
 	/// This is a workaround for https://github.com/Dart-Code/Dart-Code/issues/5549.
-	private touchPubFiles(uri: vs.Uri): void {
-		const folder = fsPath(uri);
+	private touchPubFiles(pubRootUri: vs.Uri): void {
+		const folder = fsPath(pubRootUri);
 		touchFile(path.join(folder, "pubspec.lock"));
 		touchFile(path.join(folder, ".dart_tool", "package_config.json"));
 	}
 
 	private async getPackages(
+		// URI could be a file path or a URI.
+		// It could be a pubspec.yaml directly, or a project folder.
 		uri: string | vs.Uri | vs.Uri[] | undefined,
 		operationProgress?: OperationProgress,
 	): Promise<RunProcessResult | undefined> {
@@ -73,6 +76,17 @@ export class PackageCommands extends BaseSdkCommands {
 				location: vs.ProgressLocation.Notification,
 				title: "pub get",
 			}, (progress, token) => this.getPackages(uri, { progressReporter: progress, cancellationToken: token }));
+		}
+
+		// Map any packages on to their workspaces.
+		if (Array.isArray(uri)) {
+			uri = getPubWorkspaceOrPackageFolderUris(uri);
+			if (uri.length === 1)
+				uri = uri[0];
+		} else if (typeof uri === "string") {
+			uri = getPubWorkspaceFolderOrPackageFolderPath(uri);
+		} else if (uri) {
+			uri = getPubWorkspaceFolderOrPackageFolderUri(uri);
 		}
 
 		// If we are a batch, run for each item.
@@ -89,7 +103,7 @@ export class PackageCommands extends BaseSdkCommands {
 		return this.getPackagesForUri(resolvedUri, operationProgress);
 	}
 
-	private async getPackagesForUri(uri: vs.Uri, operationProgress?: OperationProgress) {
+	public async getPackagesForUri(uri: vs.Uri, operationProgress?: OperationProgress): Promise<RunProcessResult | undefined> {
 		// Exclude folders we should never run pub get for.
 		if (!isValidPubGetTarget(uri).valid)
 			return;
@@ -118,8 +132,7 @@ export class PackageCommands extends BaseSdkCommands {
 			return;
 
 		const allFolders = await getAllProjectFolders(this.logger, getExcludedFolders, { requirePubspec: true, sort: true, searchDepth: config.projectSearchDepth });
-		const allRoots = getPubWorkspaceOrPackageFolders(allFolders);
-		const uriFolders = allRoots.map((f) => vs.Uri.file(f));
+		const uriFolders = allFolders.map((f) => vs.Uri.file(f));
 		await vs.commands.executeCommand("dart.getPackages", uriFolders);
 	}
 
@@ -314,6 +327,7 @@ export class PackageCommands extends BaseSdkCommands {
 			//   1 - then just do that one
 			//   more than 1 - prompt to do all
 			const projectFolders = await getAllProjectFolders(this.logger, util.getExcludedFolders, { requirePubspec: true, searchDepth: config.projectSearchDepth });
+			// TODO(dantup): See if we can migrate this to use the getPubWorkspaceFolderOrPackageFolderPath/Uri and getPubWorkspaceOrPackageFolderUris helpers which might simplify this?
 			const pubStatuses = getPubWorkspaceStatus(
 				this.sdks,
 				this.logger,

--- a/src/extension/commands/sdk.ts
+++ b/src/extension/commands/sdk.ts
@@ -9,6 +9,7 @@ import { logProcess } from "../../shared/logging";
 import { getPubExecutionInfo, RunProcessResult } from "../../shared/processes";
 import { disposeAll, nullToUndefined, PromiseCompleter, usingCustomScript } from "../../shared/utils";
 import { fsPath, tryGetPackageName } from "../../shared/utils/fs";
+import { OperationProgress } from "../../shared/vscode/interfaces";
 import { Context } from "../../shared/vscode/workspace";
 import { config } from "../config";
 import { DartSdkManager, FlutterSdkManager } from "../sdk/sdk_manager";
@@ -24,11 +25,6 @@ export const commandState = {
 	numProjectCreationsInProgress: 0,
 	promptToReloadOnVersionChanges: true,
 };
-
-export interface OperationProgress {
-	progressReporter: vs.Progress<{ message?: string; increment?: number }>;
-	cancellationToken: vs.CancellationToken;
-}
 
 export class BaseSdkCommands implements IAmDisposable {
 	protected readonly sdks: DartSdks;

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -23,7 +23,7 @@ import { extensionVersion, isDevExtension } from "../shared/vscode/extension_uti
 import { InternalExtensionApi } from "../shared/vscode/interfaces";
 import { McpTools } from "../shared/vscode/mcp";
 import { locateBestProjectRoot } from "../shared/vscode/project";
-import { getPubWorkspaceFolderOrPackageFolder } from "../shared/vscode/pub";
+import { getPubWorkspaceFolderOrPackageFolderPath } from "../shared/vscode/pub";
 import { DartFileUriLinkProvider } from "../shared/vscode/terminal/file_uri_link_provider";
 import { DartPackageUriLinkProvider } from "../shared/vscode/terminal/package_uri_link_provider";
 import { DartUriHandler } from "../shared/vscode/uri_handlers/uri_handler";
@@ -446,7 +446,7 @@ export async function activate(context: vs.ExtensionContext, isRestart = false) 
 		// https://github.com/flutter/flutter/issues/173550
 		const firstFlutterProject = workspaceContext.firstFlutterProject;
 		if (firstFlutterProject) {
-			const flutterProjectOrWorkspace = getPubWorkspaceFolderOrPackageFolder(firstFlutterProject);
+			const flutterProjectOrWorkspace = getPubWorkspaceFolderOrPackageFolderPath(firstFlutterProject);
 			context.subscriptions.push(new FlutterWidgetPreviewManager(logger, flutterSdk, dartToolingDaemon?.dtdUri, devTools?.devtoolsUrl, flutterProjectOrWorkspace, config.flutterWidgetPreviewLocation, flutterWidgetPreviewBehavior));
 		}
 	}

--- a/src/shared/vscode/interfaces.ts
+++ b/src/shared/vscode/interfaces.ts
@@ -8,6 +8,7 @@ import { DebuggerType, VersionStatus, VmService, VmServiceExtension } from "../e
 import { WebClient } from "../fetch";
 import { CustomScript, DartWorkspaceContext, GetSDKCommandConfig, GetSDKCommandResult, SpawnedProcess } from "../interfaces";
 import { EmittingLogger } from "../logging";
+import { RunProcessResult } from "../processes";
 import { PubDeps } from "../pub/deps";
 import { PackageMapLoader } from "../pub/package_map";
 import { DartToolingDaemon } from "../services/tooling_daemon";
@@ -124,6 +125,7 @@ export interface InternalExtensionApi {
 	nextAnalysis: () => Promise<void>;
 	packageCommands: {
 		fetchPackagesOrPrompt(uri: Uri | undefined, options?: { alwaysPrompt?: boolean, upgradeOnSdkChange?: boolean }): Promise<void>;
+		getPackagesForUri(uri: Uri, operationProgress?: OperationProgress): Promise<RunProcessResult | undefined>;
 	},
 	packagesTreeProvider: TreeDataProvider<TreeItem> & { deps?: PubDeps, packageMapLoader?: PackageMapLoader, projectFinder?: ProjectFinder };
 	pubGlobal: {
@@ -162,4 +164,9 @@ export interface FlutterSampleSnippet {
 	readonly id: string;
 	readonly file: string;
 	readonly description: string;
+}
+
+export interface OperationProgress {
+	progressReporter: Progress<{ message?: string; increment?: number }>;
+	cancellationToken: CancellationToken;
 }

--- a/src/shared/vscode/pub.ts
+++ b/src/shared/vscode/pub.ts
@@ -226,41 +226,72 @@ function runPubUpgrade(folders: Uri[]) {
 }
 
 /**
- * Returns the set of "pub roots" for a set of package folders, where "pub root" is
+ * Returns the paths of "pub roots" for a set of package folders/pubspecs, where "pub root" is
  * the Pub Workspace root (if the package is part of a workspace) or the package folder.
  *
  * If multiple packages belong to the same Pub Workspace, it will only be returned once.
  */
-export function getPubWorkspaceOrPackageFolders(packageFolders: string[]): string[] {
-	return uniq(packageFolders.map(getPubWorkspaceFolderOrPackageFolder)).sort();
+export function getPubWorkspaceOrPackageFolderPaths(packageFolderOrPubspecPaths: string[]): string[] {
+	return uniq(packageFolderOrPubspecPaths.map(getPubWorkspaceFolderOrPackageFolderPath)).sort();
 }
 
 /**
- * If `packageFolder` is part of a Pub Workspace, returns the workspace root folder.
+ * Returns the uris of "pub roots" for a set of package folders/pubspecs, where "pub root" is
+ * the Pub Workspace root (if the package is part of a workspace) or the package folder.
  *
- * Otherwise (or if there is no workspace root), returns `packageFolder`.
+ * If multiple packages belong to the same Pub Workspace, it will only be returned once.
+ *
+ * If any URIs are non-file URIs, they will be dropped.
  */
-export function getPubWorkspaceFolderOrPackageFolder(packageFolder: string): string {
-	const pubspecPath = path.join(packageFolder, "pubspec.yaml");
+export function getPubWorkspaceOrPackageFolderUris(packageFolderOrPubspecUris: Uri[]): Uri[] {
+	const packageFolderPaths = packageFolderOrPubspecUris
+		.filter((uri) => uri.scheme === "file")
+		.map((uri) => fsPath(uri));
+	const mappedPaths = getPubWorkspaceOrPackageFolderPaths(packageFolderPaths);
+	return mappedPaths.map((mappedPath) => Uri.file(mappedPath));
+}
+
+/**
+ * If `packageFolderOrPubspecUri` is part of a Pub Workspace, returns the workspace root folder URI.
+ *
+ * Otherwise (or if there is no workspace root, or URI is not file-scheme), returns `packageFolderOrPubspecUri`.
+ */
+export function getPubWorkspaceFolderOrPackageFolderUri(packageFolderOrPubspecUri: Uri): Uri {
+	return packageFolderOrPubspecUri.scheme === "file"
+		? Uri.file(getPubWorkspaceFolderOrPackageFolderPath(fsPath(packageFolderOrPubspecUri)))
+		: packageFolderOrPubspecUri;
+}
+
+/**
+ * If `packageFolderOrPubspecPath` is part of a Pub Workspace, returns the workspace root folder.
+ *
+ * Otherwise (or if there is no workspace root), returns `packageFolderOrPubspecPath` (or if it's a pubspec path, the
+ * containing folder).
+ */
+export function getPubWorkspaceFolderOrPackageFolderPath(packageFolderOrPubspecPath: string): string {
+	const pubspecPath = path.basename(packageFolderOrPubspecPath) === "pubspec.yaml"
+		? packageFolderOrPubspecPath
+		: path.join(packageFolderOrPubspecPath, "pubspec.yaml");
+	const packageFolderPath = path.dirname(pubspecPath);
 
 	// We shouldn't really have gotten here without a pubspec because that means this isn't
-	// a package, but in that case just return the original string.
+	// a package, but in that case just return the containing folder.
 	if (!fs.existsSync(pubspecPath))
-		return packageFolder;
+		return packageFolderPath;
 
 	let pubspecContent: string;
 	try {
 		pubspecContent = fs.readFileSync(pubspecPath, "utf8").toString();
 	} catch {
-		return packageFolder;
+		return packageFolderPath;
 	}
 
 	// If this is not a Pub Workspace project, just return the package itself.
 	if (!pubspecIsWorkspaceProjectRegex.test(pubspecContent))
-		return packageFolder;
+		return packageFolderPath;
 
 	// Walk up the tree to find the workspace root.
-	let currentFolder = path.dirname(packageFolder);
+	let currentFolder = path.dirname(packageFolderPath);
 	while (true) {
 		// Check if the current folder is the workspace root
 		try {
@@ -279,7 +310,7 @@ export function getPubWorkspaceFolderOrPackageFolder(packageFolder: string): str
 
 		// If we get to the root of the filesystem without finding, use the original package.
 		if (parent === currentFolder)
-			return packageFolder;
+			return packageFolderPath;
 
 		// Otherwise, loop.
 		currentFolder = parent;

--- a/src/test/dart/pub/packages.test.ts
+++ b/src/test/dart/pub/packages.test.ts
@@ -407,16 +407,23 @@ describe("pub package status", () => {
 describe("pub package commands", () => {
 	before("activate", () => activate());
 
-	it(`"Get Packages for All Projects" runs pub get once per workspace root and once per standalone package`, async () => {
-		const currentWorkspaceRoot = fsPath(vs.workspace.workspaceFolders![0].uri);
-		const tempRoot = path.join(currentWorkspaceRoot, "temp", `pub_get_all_test_${Date.now()}`);
+	const currentWorkspaceRoot = fsPath(vs.workspace.workspaceFolders![0].uri);
+	let tempRoot: string;
+	let workspaceRoot: string;
+	let workspaceProject1: string;
+	let workspaceProject2: string;
+	let standalone1: string;
+	let standalone2: string;
+
+	beforeEach("Set up workspace project", () => {
+		tempRoot = path.join(currentWorkspaceRoot, "temp", `pub_get_all_test_${Date.now()}`);
 		defer("clean up temp test projects", () => tryDelete(tempRoot));
 
-		const workspaceRoot = path.join(tempRoot, "workspace_root");
-		const workspaceProject1 = path.join(workspaceRoot, "proj1");
-		const workspaceProject2 = path.join(workspaceRoot, "proj2");
-		const standalone1 = path.join(tempRoot, "standalone1");
-		const standalone2 = path.join(tempRoot, "standalone2");
+		workspaceRoot = path.join(tempRoot, "workspace_root");
+		workspaceProject1 = path.join(workspaceRoot, "proj1");
+		workspaceProject2 = path.join(workspaceRoot, "proj2");
+		standalone1 = path.join(tempRoot, "standalone1");
+		standalone2 = path.join(tempRoot, "standalone2");
 
 		const write = (filePath: string, content: string) => {
 			fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -431,14 +438,78 @@ describe("pub package commands", () => {
 
 		// Clear caches in case another test recently cached the package results.
 		privateApi.clearCaches();
+	});
 
-		const executeCommand = sb.stub(vs.commands, "executeCommand").callThrough();
-		const getPackagesCommand = executeCommand.withArgs("dart.getPackages", sinon.match.any).resolves();
+	it(`"Get Packages" works with a single project folder path`, async () => {
+		const getPackagesForUri = sb.stub(privateApi.packageCommands, "getPackagesForUri").callThrough();
+		const getPackagesForUriCall = getPackagesForUri.withArgs(sinon.match.any).resolves();
+
+		await vs.commands.executeCommand("dart.getPackages", standalone1);
+
+		assert.ok(getPackagesForUriCall.calledOnce);
+		const calledPath = fsPath(getPackagesForUriCall.args[0][0] as vs.Uri);
+		assert.equal(calledPath, standalone1);
+	});
+
+	it(`"Get Packages" works with a single project pubspec file path`, async () => {
+		const getPackagesForUri = sb.stub(privateApi.packageCommands, "getPackagesForUri").callThrough();
+		const getPackagesForUriCall = getPackagesForUri.withArgs(sinon.match.any).resolves();
+
+		await vs.commands.executeCommand("dart.getPackages", path.join(standalone1, "pubspec.yaml"));
+
+		assert.ok(getPackagesForUriCall.calledOnce);
+		const calledPath = fsPath(getPackagesForUriCall.args[0][0] as vs.Uri);
+		assert.equal(calledPath, standalone1);
+	});
+
+	it(`"Get Packages" works with a single project folder uri`, async () => {
+		const getPackagesForUri = sb.stub(privateApi.packageCommands, "getPackagesForUri").callThrough();
+		const getPackagesForUriCall = getPackagesForUri.withArgs(sinon.match.any).resolves();
+
+		await vs.commands.executeCommand("dart.getPackages", vs.Uri.file(standalone1));
+
+		assert.ok(getPackagesForUriCall.calledOnce);
+		const calledPath = fsPath(getPackagesForUriCall.args[0][0] as vs.Uri);
+		assert.equal(calledPath, standalone1);
+	});
+
+	it(`"Get Packages" works with a single project pubspec file uri`, async () => {
+		const getPackagesForUri = sb.stub(privateApi.packageCommands, "getPackagesForUri").callThrough();
+		const getPackagesForUriCall = getPackagesForUri.withArgs(sinon.match.any).resolves();
+
+		await vs.commands.executeCommand("dart.getPackages", vs.Uri.file(path.join(standalone1, "pubspec.yaml")));
+
+		assert.ok(getPackagesForUriCall.calledOnce);
+		const calledPath = fsPath(getPackagesForUriCall.args[0][0] as vs.Uri);
+		assert.equal(calledPath, standalone1);
+	});
+
+	it(`"Get Packages" works with an array`, async () => {
+		const getPackagesForUri = sb.stub(privateApi.packageCommands, "getPackagesForUri").callThrough();
+		const getPackagesForUriCall = getPackagesForUri.withArgs(sinon.match.any).resolves();
+
+		const uris = [
+			vs.Uri.file(path.join(standalone1, "pubspec.yaml")),
+			vs.Uri.file(path.join(standalone2)),
+			vs.Uri.file(path.join(workspaceProject1)),
+		];
+		await vs.commands.executeCommand("dart.getPackages", uris);
+
+		assert.ok(getPackagesForUriCall.called);
+		const paths = (getPackagesForUriCall.getCalls().map((call) => call.args[0] as vs.Uri))
+			.map((uri) => fsPath(uri))
+			.sort();
+		assert.deepStrictEqual(paths.sort(), [standalone1, standalone2, workspaceRoot].sort());
+	});
+
+	it(`"Get Packages for All Projects" runs pub get once per workspace root and once per standalone package`, async () => {
+		const getPackagesForUri = sb.stub(privateApi.packageCommands, "getPackagesForUri").callThrough();
+		const getPackagesForUriCall = getPackagesForUri.withArgs(sinon.match.any).resolves();
 
 		await vs.commands.executeCommand("dart.getPackages.all");
 
-		assert.ok(getPackagesCommand.calledOnce);
-		const paths = (getPackagesCommand.args[0][1] as vs.Uri[])
+		assert.ok(getPackagesForUriCall.called);
+		const paths = (getPackagesForUriCall.getCalls().map((call) => call.args[0] as vs.Uri))
 			.map((uri) => fsPath(uri))
 			.sort();
 		const tempWorkspacePaths = paths.filter((p) => p.startsWith(tempRoot)).sort();


### PR DESCRIPTION
We previously did this for "Pub Get for All Packages", but clicking buttons in pubspec.yamls or changing and saving should also do the same. This also fixes that we would try to touch() the files in the wrong place and therefore do nothing.

Fixes https://github.com/Dart-Code/Dart-Code/issues/5917