### PR TITLE
Fix hang during shutdown in Flutter workspaces

### DIFF
--- a/src/extension/flutter/flutter_daemon.ts
+++ b/src/extension/flutter/flutter_daemon.ts
@@ -12,6 +12,7 @@ import { CategoryLogger, logProcess } from "../../shared/logging";
 import { UnknownNotification, UnknownResponse } from "../../shared/services/interfaces";
 import { StdIOService } from "../../shared/services/stdio_service";
 import { PromiseCompleter, usingCustomScript, withTimeout } from "../../shared/utils";
+import { resolvedPromise } from "../../shared/utils/promises";
 import { isRunningLocally } from "../../shared/vscode/utils";
 import { Analytics } from "../analytics";
 import { config } from "../config";
@@ -161,9 +162,8 @@ export class FlutterDaemon extends StdIOService<UnknownNotification> implements 
 	public dispose() {
 		this.isShuttingDown = true;
 
-		if (this.pingIntervalId) {
+		if (this.pingIntervalId)
 			clearInterval(this.pingIntervalId);
-		}
 
 		super.dispose();
 	}
@@ -324,9 +324,17 @@ export class FlutterDaemon extends StdIOService<UnknownNotification> implements 
 		return this.sendRequest("devtools.serve");
 	}
 
-	public shutdown(): Thenable<void> {
+	public async shutdown(): Promise<void> {
 		this.isShuttingDown = true;
-		return this.hasStarted && !this.hasShownTerminatedError ? this.sendRequest("daemon.shutdown") : new Promise<void>((resolve) => resolve());
+		if (!this.hasStarted || this.hasShownTerminatedError || this.processExited)
+			return resolvedPromise;
+		// It's possible this shutdown will never complete, because if dispose() is also called, the process will be terminated.
+		// Since this is only called during shutdown, we should not hang here, because it will slow down VS Code exiting.
+		// https://github.com/Dart-Code/Dart-Code/issues/6015
+		await Promise.race([
+			this.sendRequest("daemon.shutdown"),
+			this.processExit,
+		]);
 	}
 
 	private async withRecordedTimeout<T>(requestMethod: string, promise: Thenable<T>): Promise<T> {

--- a/src/shared/services/stdio_service.ts
+++ b/src/shared/services/stdio_service.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import { IAmDisposable, Logger, SpawnedProcess } from "../../shared/interfaces";
 import { Request, UnknownResponse } from "../../shared/services/interfaces";
 import { safeSpawn } from "../processes";
+import { PromiseCompleter } from "../utils";
 
 // Reminder: This class is used in the debug adapter as well as the main Code process!
 
@@ -15,6 +16,8 @@ export abstract class StdIOService<T> implements IAmDisposable {
 	private openLogFile: string | undefined;
 	private logStream?: fs.WriteStream;
 	protected processExited = false;
+	private processExitCompleter = new PromiseCompleter<ProcessExitCodes>();
+	public processExit = this.processExitCompleter.promise;
 	private description: string | undefined;
 
 	constructor(
@@ -85,6 +88,7 @@ export abstract class StdIOService<T> implements IAmDisposable {
 		const isError = !!code;
 		this.logTraffic(`Process ${this.description} terminated! ${code}, ${signal}`, isError);
 		this.processExited = true;
+		this.processExitCompleter.resolve({ code, signal });
 	}
 
 	protected handleError(error: unknown) {
@@ -124,6 +128,7 @@ export abstract class StdIOService<T> implements IAmDisposable {
 	}
 
 	public cancelAllRequests() {
+		// TODO(dantup): Consider/test rejecting all active requests?
 		Object.keys(this.activeRequests).forEach((key) => this.activeRequests[key] = "CANCELLED");
 	}
 
@@ -350,3 +355,5 @@ export abstract class StdIOService<T> implements IAmDisposable {
 		}
 	}
 }
+
+export interface ProcessExitCodes { code: number | null, signal: NodeJS.Signals | null }

--- a/src/shared/services/tooling_daemon.ts
+++ b/src/shared/services/tooling_daemon.ts
@@ -10,7 +10,7 @@ import { CategoryLogger } from "../logging";
 import { disposeAll, PromiseCompleter, PromiseOr } from "../utils";
 import { attachPing } from "../utils/ws";
 import { UnknownNotification } from "./interfaces";
-import { StdIOService } from "./stdio_service";
+import { ProcessExitCodes, StdIOService } from "./stdio_service";
 import { ActiveLocation, ActiveLocationChangedEvent, DebugSessionChangedEvent, DebugSessionStartedEvent, DebugSessionStoppedEvent, DeviceAddedEvent, DeviceChangedEvent, DeviceRemovedEvent, DeviceSelectedEvent, DtdMessage, DtdNotification, DtdRequest, DtdResponse, DtdResult, EnablePlatformTypeParams, Event, EventKind, GetDebugSessionsResult, GetDevicesResult, GetIDEWorkspaceRootsParams, GetIDEWorkspaceRootsResult, GetVmServicesResult, HotReloadParams, HotRestartParams, NavigateToCodeParams, OpenDevToolsPageParams, ReadFileAsStringParams, ReadFileAsStringResult, RegisterServiceParams, RegisterServiceResult, RegisterVmServiceParams, RegisterVmServiceResult, SelectDeviceParams, Service, ServiceMethod, ServiceRegisteredEventData, ServiceUnregisteredEventData, SetIDEWorkspaceRootsParams, SetIDEWorkspaceRootsResult, Stream, SuccessResult, UnregisterVmServiceParams, UnregisterVmServiceResult } from "./tooling_daemon_services";
 
 export class DartToolingDaemon implements IAmDisposable {
@@ -325,14 +325,11 @@ export class DartToolingDaemon implements IAmDisposable {
 	}
 }
 
-interface ProcessExitCodes { code: number | null, signal: NodeJS.Signals | null }
-
 class DartToolingDaemonProcess extends StdIOService<UnknownNotification> {
 	public hasReceivedConnectionInfo = false;
 
 	private dtdUriCompleter = new PromiseCompleter<string | undefined>();
 	private dtdSecretCompleter = new PromiseCompleter<string>();
-	private processExitCompleter = new PromiseCompleter<ProcessExitCodes>();
 
 	public hasTerminated = false;
 
@@ -342,10 +339,6 @@ class DartToolingDaemonProcess extends StdIOService<UnknownNotification> {
 
 	public get dtdSecret(): Promise<string> {
 		return this.dtdSecretCompleter.promise;
-	}
-
-	public get processExit(): Promise<ProcessExitCodes> {
-		return this.processExitCompleter.promise;
 	}
 
 	constructor(logger: Logger, private readonly sdks: DartSdks, additionalArgs: string[], maxLogLineLength: number | undefined, getToolEnv: () => any) {
@@ -364,7 +357,6 @@ class DartToolingDaemonProcess extends StdIOService<UnknownNotification> {
 	protected handleExit(code: number | null, signal: NodeJS.Signals | null) {
 		this.hasTerminated = true;
 		super.handleExit(code, signal);
-		this.processExitCompleter.resolve({ code, signal });
 		this.dtdUriCompleter.resolve(undefined);
 	}
 


### PR DESCRIPTION
It appears a recent change to VS Code started waiting up to around 5s for `deactivate()` to complete and showing a "Stopping extension hosts..." notification.

It also seems that our shutdown of the Flutter daemon was hanging, but until this change it was not visibile.

The issue seems to be that we explicitly called `shutdown()` in deactivate, but VS Code was also calling `dispose()` on everything. The results was that we send a call to `shutdown()` and waited for a response, but VS Code caused the process to be terminated and therefore the response never came and we waited indefinitely.

This change causes `shutdown()` to complete if _either_ it gets a response or _or_ the process exits, avoiding this race.

Fixes https://github.com/Dart-Code/Dart-Code/issues/6015