### PR TITLE
Don't show full package list in "Add Dependency" completion immediately after separator

### DIFF
--- a/src/extension/commands/add_dependency.ts
+++ b/src/extension/commands/add_dependency.ts
@@ -346,6 +346,7 @@ export class AddDependencyCommand extends BaseSdkCommands {
 		let matches = new Set<string>();
 		// This list can be quite large, so avoid using .filter() if we can bail out early.
 		if (currentSearchString) {
+			// There is a search term, filter the packages.
 			currentSearchString = currentSearchString.trim();
 			for (let i = 0; i < packageNames.length && matches.size < max; i++) {
 				const packageName = packageNames[i];
@@ -357,7 +358,14 @@ export class AddDependencyCommand extends BaseSdkCommands {
 				if (packageName.startsWith(currentSearchString))
 					matches.add(packageName);
 			}
+		} else if (userInput && (userInput.endsWith(" ") || userInput.endsWith(","))) {
+			// The user is after a separator and we don't want to show the full list until they type a character.
+			// https://github.com/Dart-Code/Dart-Code/issues/5952
+			// Add a blank entry that will be prefixed with the current user input prefix below.
+			matches.add("");
 		} else {
+			// The current search may be empty or just a prefix like "dev:", so show
+			// the full list.
 			matches = new Set(packageNames.slice(0, Math.min(max, packageNames.length)));
 		}
 
@@ -370,7 +378,7 @@ export class AddDependencyCommand extends BaseSdkCommands {
 			} as PickablePackage;
 		});
 
-		if (currentSearchString) {
+		if (userInput) {
 			return pickablePackageNames;
 		} else {
 			return [

--- a/src/test/dart/pub/add.test.ts
+++ b/src/test/dart/pub/add.test.ts
@@ -198,6 +198,33 @@ describe("pub add", () => {
 			]);
 		});
 
+		it("with no user input", () => {
+			const results = privateApi.addDependencyCommand.getPackageEntries("")
+				.map((item) => item.label);
+
+			assert.deepStrictEqual(results, [
+				"Local Path Package",
+				"Git Repository URL",
+				"collection",
+				"convert",
+				"crypto",
+				"path",
+				"pedantic",
+			]);
+		});
+
+		it("for Flutter SDK packages", () => {
+			const results = privateApi.addDependencyCommand.getPackageEntries("flutter")
+				.map((item) => item.label);
+
+			assert.deepStrictEqual(results, [
+				"flutter",
+				"flutter_test",
+				"flutter_driver",
+				"flutter_localizations",
+			]);
+		});
+
 		it("for a single package prefix", () => {
 			const results = privateApi.addDependencyCommand.getPackageEntries("co")
 				.map((item) => item.label);
@@ -238,7 +265,7 @@ describe("pub add", () => {
 			]);
 		});
 
-		describe(`returns only the matching item when input ends with`, () => {
+		describe("returns only the matching item when input ends with", () => {
 			// We shouldn't provide the full package list for the next package due to
 			// https://github.com/Dart-Code/Dart-Code/issues/5952, they should only show
 			// up when a character is typed.
@@ -253,6 +280,7 @@ describe("pub add", () => {
 				const results = privateApi.addDependencyCommand.getPackageEntries("foo,")
 					.map((item) => item.label);
 
+				// Th improve formatting, we inject a space if the user doesn't type it.
 				assert.deepStrictEqual(results, ["foo, "]);
 			});
 

--- a/src/test/dart/pub/add.test.ts
+++ b/src/test/dart/pub/add.test.ts
@@ -238,44 +238,85 @@ describe("pub add", () => {
 			]);
 		});
 
-		it("with dev: prefix for a single package prefix", () => {
-			const results = privateApi.addDependencyCommand.getPackageEntries("dev:co")
-				.map((item) => item.label);
+		describe(`returns only the matching item when input ends with`, () => {
+			// We shouldn't provide the full package list for the next package due to
+			// https://github.com/Dart-Code/Dart-Code/issues/5952, they should only show
+			// up when a character is typed.
+			it("space", () => {
+				const results = privateApi.addDependencyCommand.getPackageEntries("foo ")
+					.map((item) => item.label);
 
-			assert.deepStrictEqual(results, [
-				"dev:collection",
-				"dev:convert",
-			]);
+				assert.deepStrictEqual(results, ["foo "]);
+			});
+
+			it("comma", () => {
+				const results = privateApi.addDependencyCommand.getPackageEntries("foo,")
+					.map((item) => item.label);
+
+				assert.deepStrictEqual(results, ["foo, "]);
+			});
+
+			it("comma space", () => {
+				const results = privateApi.addDependencyCommand.getPackageEntries("foo, ")
+					.map((item) => item.label);
+
+				assert.deepStrictEqual(results, ["foo, "]);
+			});
 		});
 
-		it("with dev: prefix for multiple packages separated by spaces", () => {
-			const results = privateApi.addDependencyCommand.getPackageEntries("path dev:co")
-				.map((item) => item.label);
+		describe("with dev: prefix", () => {
+			it("and no package name", () => {
+				const results = privateApi.addDependencyCommand.getPackageEntries("dev:")
+					.map((item) => item.label);
 
-			assert.deepStrictEqual(results, [
-				"path dev:collection",
-				"path dev:convert",
-			]);
-		});
+				assert.deepStrictEqual(results, [
+					"dev:collection",
+					"dev:convert",
+					"dev:crypto",
+					"dev:path",
+					"dev:pedantic",
+				]);
+			});
 
-		it("with dev: prefix for multiple packages separated by commas", () => {
-			const results = privateApi.addDependencyCommand.getPackageEntries("path,dev:co")
-				.map((item) => item.label);
+			it("for a single package prefix", () => {
+				const results = privateApi.addDependencyCommand.getPackageEntries("dev:co")
+					.map((item) => item.label);
 
-			assert.deepStrictEqual(results, [
-				"path,dev:collection",
-				"path,dev:convert",
-			]);
-		});
+				assert.deepStrictEqual(results, [
+					"dev:collection",
+					"dev:convert",
+				]);
+			});
 
-		it("with dev: prefix for multiple packages separated by commas and spaces", () => {
-			const results = privateApi.addDependencyCommand.getPackageEntries("path, dev:co")
-				.map((item) => item.label);
+			it("for multiple packages separated by spaces", () => {
+				const results = privateApi.addDependencyCommand.getPackageEntries("path dev:co")
+					.map((item) => item.label);
 
-			assert.deepStrictEqual(results, [
-				"path, dev:collection",
-				"path, dev:convert",
-			]);
+				assert.deepStrictEqual(results, [
+					"path dev:collection",
+					"path dev:convert",
+				]);
+			});
+
+			it("for multiple packages separated by commas", () => {
+				const results = privateApi.addDependencyCommand.getPackageEntries("path,dev:co")
+					.map((item) => item.label);
+
+				assert.deepStrictEqual(results, [
+					"path,dev:collection",
+					"path,dev:convert",
+				]);
+			});
+
+			it("for multiple packages separated by commas and spaces", () => {
+				const results = privateApi.addDependencyCommand.getPackageEntries("path, dev:co")
+					.map((item) => item.label);
+
+				assert.deepStrictEqual(results, [
+					"path, dev:collection",
+					"path, dev:convert",
+				]);
+			});
 		});
 	});
 


### PR DESCRIPTION
Require at least one character to be typed.

Fixes https://github.com/Dart-Code/Dart-Code/issues/5952