### PR TITLE
Fold packages into their Pub Workspace root in the "Select package to…

### DIFF
--- a/src/extension/commands/flutter.ts
+++ b/src/extension/commands/flutter.ts
@@ -69,7 +69,7 @@ export class FlutterCommands extends BaseSdkCommands {
 		}
 
 		if (!uri) {
-			const path = await getFolderToRunCommandIn(this.logger, `Select the folder to run "flutter clean" in`, uri, true);
+			const path = await getFolderToRunCommandIn(this.logger, `Select the folder to run "flutter clean" in`, { selection: uri, flutterOnly: true });
 			if (!path)
 				return;
 			uri = vs.Uri.file(path);
@@ -175,7 +175,7 @@ export class FlutterCommands extends BaseSdkCommands {
 
 	private async flutterCreate({ packageName, packagePath, triggerData, platform }: FlutterCreateCommandArgs) {
 		if (!packagePath) {
-			packagePath = await getFolderToRunCommandIn(this.logger, `Select the folder to run "flutter create" in`, undefined, true);
+			packagePath = await getFolderToRunCommandIn(this.logger, `Select the folder to run "flutter create" in`, { flutterOnly: true });
 			if (!packagePath)
 				return;
 		}

--- a/src/extension/commands/packages.ts
+++ b/src/extension/commands/packages.ts
@@ -70,7 +70,7 @@ export class PackageCommands extends BaseSdkCommands {
 			placeHolder: "Select which folder to get packages for",
 			progressTitle: "pub get",
 			runForUri: this.getPackagesForUri.bind(this),
-		});
+		}, { onlyShowWorkspaceRoots: true });
 	}
 
 	public async getPackagesForUri(uri: vs.Uri, operationProgress?: OperationProgress): Promise<RunProcessResult | undefined> {
@@ -103,7 +103,7 @@ export class PackageCommands extends BaseSdkCommands {
 			return;
 
 		if (!uri || !(uri instanceof vs.Uri)) {
-			uri = await getFolderToRunCommandIn(this.logger, "Select which folder to check for outdated packages");
+			uri = await getFolderToRunCommandIn(this.logger, "Select which folder to check for outdated packages", { onlyShowWorkspaceRoots: true });
 			// If the user cancelled, bail out (otherwise we'll prompt them again below).
 			if (!uri)
 				return;
@@ -125,7 +125,7 @@ export class PackageCommands extends BaseSdkCommands {
 			placeHolder: "Select which folder to upgrade packages in",
 			progressTitle: "pub upgrade",
 			runForUri: this.upgradePackagesForUri.bind(this),
-		});
+		}, { onlyShowWorkspaceRoots: true });
 	}
 
 	public async upgradePackagesForUri(uri: vs.Uri, operationProgress?: OperationProgress): Promise<RunProcessResult | undefined> {
@@ -140,6 +140,7 @@ export class PackageCommands extends BaseSdkCommands {
 			progressTitle: string,
 			runForUri: (uri: vs.Uri, operationProgress?: OperationProgress) => Promise<RunProcessResult | undefined>,
 		},
+		{ onlyShowWorkspaceRoots = false }: { onlyShowWorkspaceRoots?: boolean; } = {}
 	): Promise<RunProcessResult | undefined> {
 		if (!config.enablePub)
 			return;
@@ -149,7 +150,7 @@ export class PackageCommands extends BaseSdkCommands {
 				cancellable: true,
 				location: vs.ProgressLocation.Notification,
 				title: options.progressTitle,
-			}, (progress, token) => this.runPackageCommand(uri, { progressReporter: progress, cancellationToken: token }, options));
+			}, (progress, token) => this.runPackageCommand(uri, { progressReporter: progress, cancellationToken: token }, options, { onlyShowWorkspaceRoots }));
 		}
 
 		if (Array.isArray(uri)) {
@@ -168,7 +169,7 @@ export class PackageCommands extends BaseSdkCommands {
 			return;
 		}
 
-		const resolvedUri = await this.resolvePackageTargetUri(uri, options.placeHolder);
+		const resolvedUri = await this.resolvePackageTargetUri(uri, options.placeHolder, { onlyShowWorkspaceRoots });
 		if (!resolvedUri)
 			return;
 
@@ -186,13 +187,13 @@ export class PackageCommands extends BaseSdkCommands {
 			return this.runPub(args, uri, false, operationProgress);
 	}
 
-	private async resolvePackageTargetUri(uri: string | vs.Uri | undefined, placeHolder: string): Promise<vs.Uri | undefined> {
+	private async resolvePackageTargetUri(uri: string | vs.Uri | undefined, placeHolder: string, { onlyShowWorkspaceRoots = false }: { onlyShowWorkspaceRoots?: boolean; } = {}): Promise<vs.Uri | undefined> {
 		if (uri)
 			return typeof uri === "string"
 				? vs.Uri.file(uri)
 				: uri;
 
-		const folder = await getFolderToRunCommandIn(this.logger, placeHolder);
+		const folder = await getFolderToRunCommandIn(this.logger, placeHolder, { onlyShowWorkspaceRoots });
 		return folder ? vs.Uri.file(folder) : undefined;
 
 	}
@@ -210,7 +211,7 @@ export class PackageCommands extends BaseSdkCommands {
 		}
 
 		if (!uri || !(uri instanceof vs.Uri)) {
-			uri = await getFolderToRunCommandIn(this.logger, "Select which folder to upgrade packages --major-versions in");
+			uri = await getFolderToRunCommandIn(this.logger, "Select which folder to upgrade packages --major-versions in", { onlyShowWorkspaceRoots: true });
 			// If the user cancelled, bail out (otherwise we'll prompt them again below).
 			if (!uri)
 				return;
@@ -218,9 +219,9 @@ export class PackageCommands extends BaseSdkCommands {
 		if (typeof uri === "string")
 			uri = vs.Uri.file(uri);
 		if (util.isInsideFlutterProject(uri))
-			return this.runFlutter(["pub", "upgrade", "--major-versions"], uri);
+			return this.runFlutter(["pub", "upgrade", "--major-versions"], uri, undefined, undefined, { onlyShowWorkspaceRoots: true });
 		else
-			return this.runPub(["upgrade", "--major-versions"], uri);
+			return this.runPub(["upgrade", "--major-versions"], uri, undefined, undefined, { onlyShowWorkspaceRoots: true });
 	}
 
 	private setupPubspecWatcher() {

--- a/src/extension/commands/sdk.ts
+++ b/src/extension/commands/sdk.ts
@@ -44,8 +44,9 @@ export class BaseSdkCommands implements IAmDisposable {
 		selection: vs.Uri | undefined,
 		alwaysShowOutput = false,
 		operationProgress?: OperationProgress,
+		{ onlyShowWorkspaceRoots = false }: { onlyShowWorkspaceRoots?: boolean; } = {}
 	): Promise<RunProcessResult | undefined> {
-		const folderToRunCommandIn = await getFolderToRunCommandIn(this.logger, placeHolder, selection);
+		const folderToRunCommandIn = await getFolderToRunCommandIn(this.logger, placeHolder, { selection, onlyShowWorkspaceRoots });
 		if (!folderToRunCommandIn)
 			return;
 
@@ -54,8 +55,8 @@ export class BaseSdkCommands implements IAmDisposable {
 		return handler(folderToRunCommandIn, args, packageOrFolderDisplayName, alwaysShowOutput, operationProgress);
 	}
 
-	protected runFlutter(args: string[], selection: vs.Uri | undefined, alwaysShowOutput = false, operationProgress?: OperationProgress): Promise<RunProcessResult | undefined> {
-		return this.runCommandForWorkspace(this.runFlutterInFolder.bind(this), `Select the folder to run "flutter ${args.join(" ")}" in`, args, selection, alwaysShowOutput, operationProgress);
+	protected runFlutter(args: string[], selection: vs.Uri | undefined, alwaysShowOutput = false, operationProgress?: OperationProgress, { onlyShowWorkspaceRoots = false }: { onlyShowWorkspaceRoots?: boolean; } = {}): Promise<RunProcessResult | undefined> {
+		return this.runCommandForWorkspace(this.runFlutterInFolder.bind(this), `Select the folder to run "flutter ${args.join(" ")}" in`, args, selection, alwaysShowOutput, operationProgress, { onlyShowWorkspaceRoots });
 	}
 
 	public runFlutterInFolder(folder: string, args: string[], packageOrFolderDisplayName: string | undefined, alwaysShowOutput = false, operationProgress?: OperationProgress, customScript?: CustomScript): Promise<RunProcessResult | undefined> {
@@ -75,8 +76,8 @@ export class BaseSdkCommands implements IAmDisposable {
 		return this.runCommandInFolder(packageOrFolderDisplayName, folder, execution.executable, allArgs, alwaysShowOutput, operationProgress);
 	}
 
-	protected runPub(args: string[], selection: vs.Uri | undefined, alwaysShowOutput = false, operationProgress?: OperationProgress): Promise<RunProcessResult | undefined> {
-		return this.runCommandForWorkspace(this.runPubInFolder.bind(this), `Select the folder to run "pub ${args.join(" ")}" in`, args, selection, alwaysShowOutput, operationProgress);
+	protected runPub(args: string[], selection: vs.Uri | undefined, alwaysShowOutput = false, operationProgress?: OperationProgress, { onlyShowWorkspaceRoots = false }: { onlyShowWorkspaceRoots?: boolean; } = {}): Promise<RunProcessResult | undefined> {
+		return this.runCommandForWorkspace(this.runPubInFolder.bind(this), `Select the folder to run "pub ${args.join(" ")}" in`, args, selection, alwaysShowOutput, operationProgress, { onlyShowWorkspaceRoots });
 	}
 
 	protected runPubInFolder(folder: string, args: string[], packageOrFolderDisplayName: string, alwaysShowOutput = false, operationProgress?: OperationProgress): Promise<RunProcessResult | undefined> {

--- a/src/extension/utils/vscode/projects.ts
+++ b/src/extension/utils/vscode/projects.ts
@@ -6,11 +6,25 @@ import { notUndefined } from "../../../shared/utils";
 import { fsPath, homeRelativePath, isFlutterProjectFolder } from "../../../shared/utils/fs";
 import { getActiveRealFileEditor } from "../../../shared/vscode/editors";
 import { locateBestProjectRoot } from "../../../shared/vscode/project";
+import type { PubWorkspaceOrPackageFolderInfo } from "../../../shared/vscode/pub";
+import { getPubWorkspaceOrPackageFolderInfo } from "../../../shared/vscode/pub";
 import { getAllProjectFolders } from "../../../shared/vscode/utils";
 import { config } from "../../config";
 import { getExcludedFolders } from "../../utils";
 
-export async function getFolderToRunCommandIn(logger: Logger, placeHolder: string, selection?: vs.Uri, flutterOnly = false): Promise<string | undefined> {
+export async function getFolderToRunCommandIn(
+	logger: Logger,
+	placeHolder: string,
+	{
+		selection,
+		flutterOnly = false,
+		// TODO(dantup): Consider making this required.
+		onlyShowWorkspaceRoots = false
+	}: {
+		selection?: vs.Uri;
+		flutterOnly?: boolean;
+		onlyShowWorkspaceRoots?: boolean;
+	} = {}): Promise<string | undefined> {
 	// Attempt to find a project based on the supplied folder of active file.
 	let file = selection && fsPath(selection);
 	if (!file) {
@@ -33,7 +47,11 @@ export async function getFolderToRunCommandIn(logger: Logger, placeHolder: strin
 		return undefined;
 	}
 
-	return showFolderPicker(selectableFolders, placeHolder); // TODO: What if the user didn't pick anything?
+	const selectableFolderInfo: PubWorkspaceOrPackageFolderInfo[] = onlyShowWorkspaceRoots
+		? getPubWorkspaceOrPackageFolderInfo(selectableFolders)
+		: selectableFolders.map((folder) => ({ path: folder }));
+
+	return showPackagePicker(selectableFolderInfo, placeHolder); // TODO: What if the user didn't pick anything?
 }
 
 export async function getProjectSelection(logger: Logger, placeHolder: string): Promise<string[] | undefined> {
@@ -58,22 +76,26 @@ export async function getProjectSelection(logger: Logger, placeHolder: string): 
 	return showFolderMultiPicker(selectableProjectFolders, prePickedFolders, placeHolder);
 }
 
-async function showFolderPicker(folders: string[], placeHolder: string): Promise<string | undefined> {
+async function showPackagePicker(folders: PubWorkspaceOrPackageFolderInfo[], placeHolder: string): Promise<string | undefined> {
 	// No point asking the user if there's only one.
 	if (folders.length === 1) {
-		return folders[0];
+		return folders[0]?.path;
 	}
 
-	const items = folders.map((f) => {
-		const workspaceFolder = vs.workspace.getWorkspaceFolder(Uri.file(f));
-		if (!workspaceFolder)
-			return undefined;
-
-		const workspacePathParent = path.dirname(fsPath(workspaceFolder.uri));
+	const items = folders.map((folderInfo) => {
+		const folderPath = folderInfo.path;
+		const workspaceFolder = vs.workspace.getWorkspaceFolder(Uri.file(folderPath));
+		const workspacePathParent = workspaceFolder
+			? path.dirname(fsPath(workspaceFolder.uri))
+			: path.dirname(folderPath);
+		const detail = folderInfo.workspacePackageCount
+			? `Pub Workspace, ${folderInfo.workspacePackageCount} package${folderInfo.workspacePackageCount === 1 ? "" : "s"}`
+			: undefined;
 		return {
 			description: homeRelativePath(workspacePathParent),
-			label: path.relative(workspacePathParent, f),
-			path: f,
+			label: path.relative(workspacePathParent, folderPath),
+			detail,
+			path: folderPath,
 		} as vs.QuickPickItem & { path: string };
 	}).filter(notUndefined);
 

--- a/src/shared/vscode/pub.ts
+++ b/src/shared/vscode/pub.ts
@@ -10,6 +10,15 @@ import { uniq } from "../utils";
 
 interface PubPackageStatus { folderUri: Uri, pubRequired: false | "GET" | "UPGRADE", reason?: string, workspace: "NONE" | "ROOT" | "PROJECT" }
 
+/**
+ * Information about a package folder, that is either a single package
+ * folder, or a Pub Workspace that has a count of packages within.
+ */
+export interface PubWorkspaceOrPackageFolderInfo {
+	path: string;
+	workspacePackageCount?: number;
+}
+
 const pubspecHasDependenciesRegex = new RegExp("^(dev_)?dependencies\\s*:", "im");
 const pubspecIsWorkspaceProjectRegex = new RegExp("^resolution\\s*:\\s*workspace", "im");
 const pubspecIsWorkspaceRootRegex = new RegExp("^workspace\\s*:", "im");
@@ -232,7 +241,38 @@ function runPubUpgrade(folders: Uri[]) {
  * If multiple packages belong to the same Pub Workspace, it will only be returned once.
  */
 function getPubWorkspaceOrPackageFolderPaths(packageFolderOrPubspecPaths: string[]): string[] {
-	return uniq(packageFolderOrPubspecPaths.map(getPubWorkspaceFolderOrPackageFolderPath)).sort();
+	return uniq(packageFolderOrPubspecPaths.map((p) => getPubWorkspaceFolderOrPackageFolderPath(p))).sort();
+}
+
+/**
+ * Gets the set of packages in `packageFolderOrPubspecPaths`, folding any workspace packages into
+ * the workspace root. This is used for commands like `pub get` which are always run in the context
+ * of a Pub Workspace root and not the child packages.
+ */
+export function getPubWorkspaceOrPackageFolderInfo(
+	packageFolderOrPubspecPaths: string[],
+	existsSync: (itemPath: string) => boolean = fs.existsSync,
+	readFileSync: (itemPath: string) => string = (p) => fs.readFileSync(p, "utf8").toString(),
+): PubWorkspaceOrPackageFolderInfo[] {
+	const pubWorkspacePackageCounts = new Map<string, number>();
+
+	for (const packageFolderOrPubspecPath of packageFolderOrPubspecPaths) {
+		const packageFolderPath = path.basename(packageFolderOrPubspecPath) === "pubspec.yaml"
+			? path.dirname(packageFolderOrPubspecPath)
+			: packageFolderOrPubspecPath;
+		const workspaceRootPath = getPubWorkspaceFolderOrPackageFolderPath(packageFolderOrPubspecPath, existsSync, readFileSync);
+
+		let count = pubWorkspacePackageCounts.get(workspaceRootPath) ?? 0;
+		const isRoot = workspaceRootPath === packageFolderPath;
+		if (!isRoot)
+			count++;
+
+		pubWorkspacePackageCounts.set(workspaceRootPath, count);
+	}
+
+	return [...pubWorkspacePackageCounts.entries()]
+		.map((p) => p[1] ? { path: p[0], workspacePackageCount: p[1] } : { path: p[0] })
+		.sort((a, b) => a.path.localeCompare(b.path));
 }
 
 /**
@@ -268,7 +308,11 @@ export function getPubWorkspaceFolderOrPackageFolderUri(packageFolderOrPubspecUr
  * Otherwise (or if there is no workspace root), returns `packageFolderOrPubspecPath` (or if it's a pubspec path, the
  * containing folder).
  */
-export function getPubWorkspaceFolderOrPackageFolderPath(packageFolderOrPubspecPath: string): string {
+export function getPubWorkspaceFolderOrPackageFolderPath(
+	packageFolderOrPubspecPath: string,
+	existsSync: (itemPath: string) => boolean = fs.existsSync,
+	readFileSync: (itemPath: string) => string = (p) => fs.readFileSync(p, "utf8").toString(),
+): string {
 	const pubspecPath = path.basename(packageFolderOrPubspecPath) === "pubspec.yaml"
 		? packageFolderOrPubspecPath
 		: path.join(packageFolderOrPubspecPath, "pubspec.yaml");
@@ -276,12 +320,12 @@ export function getPubWorkspaceFolderOrPackageFolderPath(packageFolderOrPubspecP
 
 	// We shouldn't really have gotten here without a pubspec because that means this isn't
 	// a package, but in that case just return the containing folder.
-	if (!fs.existsSync(pubspecPath))
+	if (!existsSync(pubspecPath))
 		return packageFolderPath;
 
 	let pubspecContent: string;
 	try {
-		pubspecContent = fs.readFileSync(pubspecPath, "utf8").toString();
+		pubspecContent = readFileSync(pubspecPath);
 	} catch {
 		return packageFolderPath;
 	}
@@ -296,7 +340,7 @@ export function getPubWorkspaceFolderOrPackageFolderPath(packageFolderOrPubspecP
 		// Check if the current folder is the workspace root
 		try {
 			const currentPubspecPath = path.join(currentFolder, "pubspec.yaml");
-			const currentPubspecContent = fs.readFileSync(currentPubspecPath, "utf8").toString();
+			const currentPubspecContent = readFileSync(currentPubspecPath);
 
 			// We've found the root.
 			if (pubspecIsWorkspaceRootRegex.test(currentPubspecContent))

--- a/src/test/dart/pub/packages.test.ts
+++ b/src/test/dart/pub/packages.test.ts
@@ -3,10 +3,12 @@ import * as fs from "fs";
 import * as path from "path";
 import * as sinon from "sinon";
 import * as vs from "vscode";
+import { getFolderToRunCommandIn } from "../../../extension/utils/vscode/projects";
 import { isWin } from "../../../shared/constants";
 import { fsPath, isWithinPathOrEqual } from "../../../shared/utils/fs";
-import { getPubWorkspaceStatus } from "../../../shared/vscode/pub";
-import { activate, defer, privateApi, sb, tryDelete } from "../../helpers";
+import { getPubWorkspaceOrPackageFolderInfo, getPubWorkspaceStatus } from "../../../shared/vscode/pub";
+import * as sharedVscodeUtils from "../../../shared/vscode/utils";
+import { activate, activateWithoutAnalysis, defer, privateApi, sb, tryDelete } from "../../helpers";
 
 describe("pub package status", () => {
 	before("activate", () => activate());
@@ -358,8 +360,6 @@ describe("pub package status", () => {
 	}
 
 	function expectStatus(workspace: WorkspaceInfo, expectedStatuses: Array<{ folder: string, pubRequired: false | "GET" | "UPGRADE", reason?: string }>) {
-		// Rewrite paths for Windows because we convert to/from URIs and VS Code's URI class always assumes the current platform.
-		const fixPath = isWin ? (p: string) => `Z:${p.replaceAll("/", "\\")}` : (p: string) => p;
 		workspace.openFolders = workspace.openFolders.map(fixPath);
 		const fixedFiles: typeof workspace.files = {};
 		for (const p of Object.keys(workspace.files))
@@ -527,6 +527,88 @@ describe("pub package commands", () => {
 			}
 		});
 	}
+
+	describe("package picker", () => {
+		beforeEach("activate without an open file", () => activateWithoutAnalysis(null));
+
+		it("collapses pub workspace projects into a single picker entry with a package count", async () => {
+			const openFolders = ["/projects/root/proj1", "/projects/root/proj2", "/projects/standalone"].map(fixPath);
+			const files: FilesInfo = {};
+
+			files[fixPath("/projects/root/pubspec.yaml")] = { mtime: 1, content: "workspace:\n- proj1\n- proj2" };
+			files[fixPath("/projects/root/proj1/pubspec.yaml")] = { mtime: 1, content: "resolution: workspace\ndependencies:" };
+			files[fixPath("/projects/root/proj2/pubspec.yaml")] = { mtime: 1, content: "resolution: workspace\ndependencies:" };
+			files[fixPath("/projects/standalone/pubspec.yaml")] = { mtime: 1, content: "dependencies:" };
+
+			const results = getPubWorkspaceOrPackageFolderInfo(
+				openFolders,
+				(filePath) => !!files[filePath],
+				(filePath) => {
+					const file = files[filePath];
+					if (!file)
+						throw new Error("No file/content");
+					return file.content;
+				},
+			);
+
+			assert.deepStrictEqual(results, [
+				{ path: fixPath("/projects/root"), workspacePackageCount: 2 },
+				{ path: fixPath("/projects/standalone") },
+			]);
+		});
+
+		it("shows each pub workspace only once with a package count suffix", async () => {
+			sb.stub(sharedVscodeUtils, "getAllProjectFolders").resolves([workspaceProject1, workspaceProject2, standalone1]);
+			const showQuickPick = sb.stub(vs.window, "showQuickPick").resolves({ path: workspaceRoot } as vs.QuickPickItem & { path: string });
+
+			const folder = await getFolderToRunCommandIn(privateApi.logger, "Select which folder to get packages for", { onlyShowWorkspaceRoots: true });
+
+			assert.ok(showQuickPick.calledOnce);
+			const workspaceFolder = vs.workspace.getWorkspaceFolder(vs.Uri.file(workspaceRoot));
+			assert.ok(workspaceFolder);
+			const workspacePathParent = path.dirname(fsPath(workspaceFolder.uri));
+			const items = showQuickPick.firstCall.args[0] as Array<vs.QuickPickItem & { path: string }>;
+			assert.deepStrictEqual(items.map((item) => ({ label: item.label, detail: item.detail, path: item.path })), [
+				{ label: path.relative(workspacePathParent, standalone1), detail: undefined, path: standalone1 },
+				{ label: path.relative(workspacePathParent, workspaceRoot), detail: "Pub Workspace, 2 packages", path: workspaceRoot },
+			]);
+			assert.equal(folder, workspaceRoot);
+		});
+
+		it("includes a pub workspace root that is outside opened workspace folders", async () => {
+			sb.stub(sharedVscodeUtils, "getAllProjectFolders").resolves([workspaceProject1, workspaceProject2, standalone1]);
+			const getWorkspaceFolder = sb.stub(vs.workspace, "getWorkspaceFolder").callsFake((uri: vs.Uri) => {
+				const folderPath = fsPath(uri);
+				if (folderPath === workspaceRoot)
+					return undefined;
+				if (folderPath === standalone1)
+					return { index: 0, name: path.basename(standalone1), uri: vs.Uri.file(standalone1) };
+				return undefined;
+			});
+			const showQuickPick = sb.stub(vs.window, "showQuickPick").resolves({ path: workspaceRoot } as vs.QuickPickItem & { path: string });
+
+			const folder = await getFolderToRunCommandIn(privateApi.logger, "Select which folder to get packages for", { onlyShowWorkspaceRoots: true });
+
+			assert.ok(getWorkspaceFolder.called);
+			assert.ok(showQuickPick.calledOnce);
+			const items = showQuickPick.firstCall.args[0] as Array<vs.QuickPickItem & { path: string }>;
+			assert.deepStrictEqual(items.map((item) => ({ label: item.label, detail: item.detail, path: item.path })), [
+				{ label: path.basename(standalone1), detail: undefined, path: standalone1 },
+				{ label: path.basename(workspaceRoot), detail: "Pub Workspace, 2 packages", path: workspaceRoot },
+			]);
+			assert.equal(folder, workspaceRoot);
+		});
+
+		it("does not prompt if all discovered projects collapse to a single pub workspace", async () => {
+			sb.stub(sharedVscodeUtils, "getAllProjectFolders").resolves([workspaceProject1, workspaceProject2]);
+			const showQuickPick = sb.stub(vs.window, "showQuickPick");
+
+			const folder = await getFolderToRunCommandIn(privateApi.logger, "Select which folder to get packages for", { onlyShowWorkspaceRoots: true });
+
+			assert.equal(showQuickPick.called, false);
+			assert.equal(folder, workspaceRoot);
+		});
+	});
 });
 
 interface WorkspaceInfo {
@@ -540,4 +622,11 @@ type FilesInfo = Record<string, FileInfo>;
 interface FileInfo {
 	mtime: number,
 	content: string,
+}
+
+/**
+ * Rewrite paths for Windows because we convert to/from URIs and VS Code's URI class always assumes the current platform.
+ */
+function fixPath(p: string) {
+	return isWin ? `Z:${p.replaceAll("/", "\\")}` : p;
 }


### PR DESCRIPTION
… run x in" picker

For commands like "pub get" that operate on a Pub Workspace, we shouldn't ask the user to pick a single package within that workspace. Instead, show "Pub Workspace, x packages" under a single entry for the root.

Fixes https://github.com/Dart-Code/Dart-Code/issues/6034