### PR TITLE
Add dashTool and dashIdeName query params for DevTools, and change Source=VSCode to Source={dashIdeName} for surveys

### DIFF
--- a/src/extension/sdk/dev_tools/manager.ts
+++ b/src/extension/sdk/dev_tools/manager.ts
@@ -402,7 +402,7 @@ export class DevToolsManager implements vs.Disposable {
 	private getDefaultQueryParams(): Record<string, string | undefined> {
 		return {
 			cacheBust: this.getCacheBust(),
-			ide: "VSCode",
+			ide: vs.env.appName,
 		};
 	}
 

--- a/src/extension/sdk/dev_tools/manager.ts
+++ b/src/extension/sdk/dev_tools/manager.ts
@@ -16,7 +16,7 @@ import { DartToolingDaemon } from "../../../shared/services/tooling_daemon";
 import { disposeAll, notUndefined, usingCustomScript, versionIsAtLeast } from "../../../shared/utils";
 import { getRandomInt } from "../../../shared/utils/fs";
 import { waitFor } from "../../../shared/utils/promises";
-import { ANALYSIS_FILTERS } from "../../../shared/vscode/constants";
+import { ANALYSIS_FILTERS, dashIdeName, dashTool } from "../../../shared/vscode/constants";
 import { DartDebugSessionInformation } from "../../../shared/vscode/interfaces";
 import { getLanguageStatusItem } from "../../../shared/vscode/status_bar";
 import { envUtils, getAllProjectFolders, isRunningLocally } from "../../../shared/vscode/utils";
@@ -402,7 +402,12 @@ export class DevToolsManager implements vs.Disposable {
 	private getDefaultQueryParams(): Record<string, string | undefined> {
 		return {
 			cacheBust: this.getCacheBust(),
-			ide: vs.env.appName,
+			// The legacy IDE param should be kept for at least two years after the
+			// related DevTools change ships.
+			// https://github.com/flutter/devtools/issues/9811
+			ide: "VSCode",
+			dashTool,
+			dashIdeName,
 		};
 	}
 

--- a/src/extension/sdk/dev_tools/manager.ts
+++ b/src/extension/sdk/dev_tools/manager.ts
@@ -406,8 +406,8 @@ export class DevToolsManager implements vs.Disposable {
 			// related DevTools change ships.
 			// https://github.com/flutter/devtools/issues/9811
 			ide: "VSCode",
-			dashTool,
-			dashIdeName,
+			dashTool: dashTool(),
+			dashIdeName: dashIdeName(),
 		};
 	}
 

--- a/src/extension/utils/processes.ts
+++ b/src/extension/utils/processes.ts
@@ -37,9 +37,7 @@ export function setupToolEnv({ suppressAnalytics, envOverrides }: { suppressAnal
 		toolEnv = Object.assign(toolEnv, envOverrides);
 
 	toolEnv.FLUTTER_HOST = "VSCode";
-	toolEnv.PUB_ENVIRONMENT = (toolEnv.PUB_ENVIRONMENT ? `${toolEnv.PUB_ENVIRONMENT}:` : "") + "vscode.dart-code";
 	if (isDartCodeTestRun) {
-		toolEnv.PUB_ENVIRONMENT += ".test.bot";
 		globalFlutterArgs.push("--suppress-analytics");
 	}
 

--- a/src/extension/utils/processes.ts
+++ b/src/extension/utils/processes.ts
@@ -48,13 +48,13 @@ export function setupToolEnv({ suppressAnalytics, envOverrides }: { suppressAnal
 		toolEnv.FLUTTER_ROOT = flutterRoot;
 
 	// Add the names/versions of each part of the tool.
-	toolEnv.DASH__IDE_NAME = dashIdeName;
-	toolEnv.DASH__IDE_VERSION = dashIdeVersion;
-	toolEnv.DASH__PLUGIN_NAME = dashPluginName;
-	toolEnv.DASH__PLUGIN_VERSION = dashPluginVersion;
-	toolEnv.DASH__IDE_ENVIRONMENT = dashIdeEnvironment;
+	toolEnv.DASH__IDE_NAME = dashIdeName();
+	toolEnv.DASH__IDE_VERSION = dashIdeVersion();
+	toolEnv.DASH__PLUGIN_NAME = dashPluginName();
+	toolEnv.DASH__PLUGIN_VERSION = dashPluginVersion();
+	toolEnv.DASH__IDE_ENVIRONMENT = dashIdeEnvironment();
 	// And those for unified analytics.
-	toolEnv.DASH__TOOL = dashTool; // This matches the "label" of the enum constant DashTool defined in unified analytics.
+	toolEnv.DASH__TOOL = dashTool(); // This matches the "label" of the enum constant DashTool defined in unified analytics.
 	toolEnv.DASH__SUPPRESS_ANALYTICS = `${suppressAnalytics}`; // This should be a string bool parsed with bool.parse() in Dart.
 }
 

--- a/src/extension/utils/processes.ts
+++ b/src/extension/utils/processes.ts
@@ -2,8 +2,7 @@ import * as vs from "vscode";
 import { isDartCodeTestRun } from "../../shared/constants";
 import { Logger, SpawnedProcess } from "../../shared/interfaces";
 import { RunProcessResult, runProcess, safeSpawn } from "../../shared/processes";
-import { extensionVersion } from "../../shared/vscode/extension_utils";
-import { hostKind } from "../../shared/vscode/utils";
+import { dashIdeEnvironment, dashIdeName, dashIdeVersion, dashPluginName, dashPluginVersion, dashTool } from "../../shared/vscode/constants";
 
 // Environment used when spawning Dart and Flutter processes.
 let flutterRoot: string | undefined;
@@ -49,13 +48,13 @@ export function setupToolEnv({ suppressAnalytics, envOverrides }: { suppressAnal
 		toolEnv.FLUTTER_ROOT = flutterRoot;
 
 	// Add the names/versions of each part of the tool.
-	toolEnv.DASH__IDE_NAME = vs.env.appName;
-	toolEnv.DASH__IDE_VERSION = vs.version;
-	toolEnv.DASH__PLUGIN_NAME = "Dart-Code";
-	toolEnv.DASH__PLUGIN_VERSION = extensionVersion;
-	toolEnv.DASH__IDE_ENVIRONMENT = hostKind ?? "desktop";
+	toolEnv.DASH__IDE_NAME = dashIdeName;
+	toolEnv.DASH__IDE_VERSION = dashIdeVersion;
+	toolEnv.DASH__PLUGIN_NAME = dashPluginName;
+	toolEnv.DASH__PLUGIN_VERSION = dashPluginVersion;
+	toolEnv.DASH__IDE_ENVIRONMENT = dashIdeEnvironment;
 	// And those for unified analytics.
-	toolEnv.DASH__TOOL = "vscode-plugins"; // This matches the "label" of the enum constant DashTool defined in unified analytics.
+	toolEnv.DASH__TOOL = dashTool; // This matches the "label" of the enum constant DashTool defined in unified analytics.
 	toolEnv.DASH__SUPPRESS_ANALYTICS = `${suppressAnalytics}`; // This should be a string bool parsed with bool.parse() in Dart.
 }
 

--- a/src/shared/vscode/constants.ts
+++ b/src/shared/vscode/constants.ts
@@ -14,9 +14,26 @@ export const ANALYSIS_FILTERS: DocumentSelector = [
 	ANALYSIS_OPTIONS_FILTER,
 ];
 
-export const dashIdeName = env.appName;
-export const dashIdeVersion = vsVersion;
-export const dashIdeEnvironment = hostKind ?? "desktop";
-export const dashPluginName = "Dart-Code";
-export const dashPluginVersion = extensionVersion;
-export const dashTool = "vscode-plugins";
+export function dashIdeName() {
+	return env.appName;
+}
+
+export function dashIdeVersion() {
+	return vsVersion;
+}
+
+export function dashIdeEnvironment() {
+	return hostKind ?? "desktop";
+}
+
+export function dashPluginName() {
+	return "Dart-Code";
+}
+
+export function dashPluginVersion() {
+	return extensionVersion;
+}
+
+export function dashTool() {
+	return "vscode-plugins";
+}

--- a/src/shared/vscode/constants.ts
+++ b/src/shared/vscode/constants.ts
@@ -1,5 +1,6 @@
-import { DocumentFilter, DocumentSelector } from "vscode";
-
+import { DocumentFilter, DocumentSelector, env, version as vsVersion } from "vscode";
+import { extensionVersion } from "./extension_utils";
+import { hostKind } from "./utils";
 
 export const DART_LANGUAGE = "dart";
 export const DART_MODE: DocumentFilter[] = [
@@ -12,3 +13,10 @@ export const ANALYSIS_FILTERS: DocumentSelector = [
 	PUBSPEC_FILTER,
 	ANALYSIS_OPTIONS_FILTER,
 ];
+
+export const dashIdeName = env.appName;
+export const dashIdeVersion = vsVersion;
+export const dashIdeEnvironment = hostKind ?? "desktop";
+export const dashPluginName = "Dart-Code";
+export const dashPluginVersion = extensionVersion;
+export const dashTool = "vscode-plugins";

--- a/src/shared/vscode/user_prompts.ts
+++ b/src/shared/vscode/user_prompts.ts
@@ -5,6 +5,7 @@ import { CommandSource, alwaysOpenAction, doNotAskAgainAction, flutterSurveyData
 import { WebClient } from "../fetch";
 import { Analytics, FlutterRawSurveyData, FlutterSurveyData, Logger } from "../interfaces";
 import { WorkspaceContext } from "../workspace";
+import { dashIdeName } from "./constants";
 import { envUtils, isRunningLocally } from "./utils";
 import { Context } from "./workspace";
 
@@ -43,7 +44,7 @@ export async function showFlutterSurveyNotificationIfAppropriate(context: Contex
 	if (lastShown && now - lastShown < longRepeatPromptThreshold)
 		return false;
 
-	const queryData = [{ key: "Source", value: vs.env.appName }];
+	const queryData = [{ key: "Source", value: dashIdeName }];
 	if (workspaceContext.sdks.dartVersion)
 		queryData.push({ key: "DartVersion", value: workspaceContext.sdks.dartVersion });
 	if (workspaceContext.sdks.flutterVersion)

--- a/src/shared/vscode/user_prompts.ts
+++ b/src/shared/vscode/user_prompts.ts
@@ -43,14 +43,16 @@ export async function showFlutterSurveyNotificationIfAppropriate(context: Contex
 	if (lastShown && now - lastShown < longRepeatPromptThreshold)
 		return false;
 
-	const queryData = ["Source=VSCode"];
+	const queryData = [{ key: "Source", value: vs.env.appName }];
 	if (workspaceContext.sdks.dartVersion)
-		queryData.push(`DartVersion=${workspaceContext.sdks.dartVersion}`);
+		queryData.push({ key: "DartVersion", value: workspaceContext.sdks.dartVersion });
 	if (workspaceContext.sdks.flutterVersion)
-		queryData.push(`FlutterVersion=${workspaceContext.sdks.flutterVersion}`);
+		queryData.push({ key: "FlutterVersion", value: workspaceContext.sdks.flutterVersion });
 
 	const firstQsSep = surveyData.url.includes("?") ? "&" : "?";
-	const surveyUrl = `${surveyData.url}${firstQsSep}${queryData.join("&")}`;
+	const surveyUrl = `${surveyData.url}${firstQsSep}${queryData
+		.map(({ key, value }) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+		.join("&")}`;
 
 	// Mark the last time we've shown it (now) so we can avoid showing again for
 	// 40 hours.

--- a/src/shared/vscode/user_prompts.ts
+++ b/src/shared/vscode/user_prompts.ts
@@ -44,7 +44,7 @@ export async function showFlutterSurveyNotificationIfAppropriate(context: Contex
 	if (lastShown && now - lastShown < longRepeatPromptThreshold)
 		return false;
 
-	const queryData = [{ key: "Source", value: dashIdeName }];
+	const queryData = [{ key: "Source", value: dashIdeName() }];
 	if (workspaceContext.sdks.dartVersion)
 		queryData.push({ key: "DartVersion", value: workspaceContext.sdks.dartVersion });
 	if (workspaceContext.sdks.flutterVersion)

--- a/src/test/dart/user_prompts.test.ts
+++ b/src/test/dart/user_prompts.test.ts
@@ -181,6 +181,23 @@ describe("Survey notification", async () => {
 		assert.equal(lastShown && lastShown > Date.now() - 10000 && lastShown <= Date.now(), true);
 	});
 
+	it("URL-encodes query parameters", async () => {
+		const showInformationMessage = sb.stub(vs.window, "showInformationMessage");
+		showInformationMessage.withArgs(matchPrompt, sinon.match.any).resolves(takeSurveyAction);
+
+		sb.stub(vs.env, "appName").value("Danny's Super Editor?/Beta");
+		sb.stub(privateApi.workspaceContext.sdks, "dartVersion").get(() => "3.4.0 dev+1");
+		sb.stub(privateApi.workspaceContext.sdks, "flutterVersion").get(() => "3.22.0 (custom)");
+
+		const openBrowserCommand = sb.stub(privateApi.envUtils, "openInBrowser").resolves();
+
+		const res = await showFlutterSurveyNotificationIfAppropriate(privateApi.context, privateApi.webClient, mockAnalytics, privateApi.workspaceContext, (url) => privateApi.envUtils.openInBrowser(url), surveyIsOpenDate, logger);
+
+		assert.equal(res, true);
+		await waitFor(() => openBrowserCommand.calledOnce);
+		assert.equal(openBrowserCommand.firstCall.args[0], "https://example.org/?Source=Danny's%20Super%20Editor%3F%2FBeta&DartVersion=3.4.0%20dev%2B1&FlutterVersion=3.22.0%20(custom)");
+	});
+
 	it("shows and updates context values when already seen", async () => {
 		const context = privateApi.context;
 		context.setFlutterSurveyNotificationLastShown(flutterTestSurveyID, surveyIsOpenDate - (longRepeatPromptThreshold + twoHoursInMs));


### PR DESCRIPTION
**Blocked**: pending resolutions to the things in DevTools that switch on the IDE name (see https://github.com/Dart-Code/Dart-Code/issues/5970#issuecomment-4342693874, https://github.com/flutter/devtools/issues/9811)

Fixes https://github.com/Dart-Code/Dart-Code/issues/5970