### PR TITLE
unref() long timeouts to ensure we don't delay shutdown

### DIFF
--- a/src/extension/commands/add_dependency.ts
+++ b/src/extension/commands/add_dependency.ts
@@ -80,7 +80,7 @@ export class AddDependencyCommand extends BaseSdkCommands {
 	private queueNextPackageNameFetch(ms: number) {
 		if (this.nextPackageNameFetchTimeout)
 			clearTimeout(this.nextPackageNameFetchTimeout);
-		this.nextPackageNameFetchTimeout = setTimeout(() => this.fetchPackageNames(), ms);
+		this.nextPackageNameFetchTimeout = setTimeout(() => this.fetchPackageNames(), ms).unref();
 	}
 
 	private async fetchPackageNames(): Promise<void> {

--- a/src/extension/commands/packages.ts
+++ b/src/extension/commands/packages.ts
@@ -305,7 +305,7 @@ export class PackageCommands extends BaseSdkCommands {
 		isFetchingPackages = true;
 		// VS Code will hide any prompt after 10seconds, so if the user didn't respond within 10s we assume this prompt is not
 		// going to be responded to and should clear the flag to avoid run-pub-get-on-save not working.
-		setTimeout(() => isFetchingPackages = false, tenSecondsInMs);
+		setTimeout(() => isFetchingPackages = false, tenSecondsInMs).unref();
 
 		// TODO: Extract this into a Pub class with the things in pub.ts.
 

--- a/src/extension/commands/sdk.ts
+++ b/src/extension/commands/sdk.ts
@@ -132,7 +132,7 @@ export class BaseSdkCommands implements IAmDisposable {
 				// If we complete with a non-zero code, or don't complete within 30s, we should show
 				// the output pane.
 				const completedWithErrorPromise = new Promise((resolve) => proc.on("close", resolve));
-				const timedOutPromise = new Promise((resolve) => setTimeout(() => resolve(true), thirtySecondsInMs));
+				const timedOutPromise = new Promise((resolve) => setTimeout(() => resolve(true), thirtySecondsInMs).unref());
 				void Promise.race([completedWithErrorPromise, timedOutPromise]).then((showOutput) => {
 					if (showOutput)
 						channel.show(true);
@@ -220,7 +220,7 @@ export class SdkCommands extends BaseSdkCommands {
 			// Ensure we don't fire too often as some OSes may generate multiple events.
 			commandState.promptToReloadOnVersionChanges = false;
 			// Allow it again in 60 seconds.
-			setTimeout(() => commandState.promptToReloadOnVersionChanges = true, 60000);
+			setTimeout(() => commandState.promptToReloadOnVersionChanges = true, 60000).unref();
 
 			// Wait a short period before prompting.
 			setTimeout(() => util.promptToReloadExtension(this.logger, {

--- a/src/extension/sdk/dev_tools/manager.ts
+++ b/src/extension/sdk/dev_tools/manager.ts
@@ -585,7 +585,7 @@ export class DevToolsManager implements vs.Disposable {
 						console.error(message);
 						this.logger.error(message);
 					}
-				}, twentySecondsInMs);
+				}, twentySecondsInMs).unref();
 
 				portToBind = n.port;
 				resolve(`http://${n.host}:${n.port}/`);

--- a/src/extension/user_prompts.ts
+++ b/src/extension/user_prompts.ts
@@ -40,7 +40,7 @@ export async function showUserPrompts(logger: Logger, context: Context, webClien
 		// It's possible that we got here when the user installed the Flutter extension, because it causes Dart to install
 		// first and activate. So, before showing this prompt we'll wait 30 seconds and then check if we still don't
 		// have the Flutter extension, and then show the prompt.
-		await new Promise((resolve) => setTimeout(resolve, 20000));
+		await new Promise((resolve) => setTimeout(resolve, 20000).unref());
 		if (!checkHasFlutterExtension())
 			return showPrompt(installFlutterExtensionPromptKey, () => extensionRecommendations.promptToInstallFlutterExtension());
 	}

--- a/src/shared/utils/promises.ts
+++ b/src/shared/utils/promises.ts
@@ -10,7 +10,7 @@ export async function waitFor<T>(action: () => T | Promise<T>, checkEveryMillise
 		} catch {
 			// Just try again if it throws.
 		}
-		await new Promise((resolve) => setTimeout(resolve, checkEveryMilliseconds));
+		await new Promise((resolve) => setTimeout(resolve, checkEveryMilliseconds).unref());
 		timeRemaining -= checkEveryMilliseconds;
 	}
 }

--- a/src/shared/vscode/autolaunch.ts
+++ b/src/shared/vscode/autolaunch.ts
@@ -159,7 +159,7 @@ export class AutoLaunch implements IAmDisposable {
 
 				// Otherwise, retry.
 				this.logger.info(`[AutoLaunch] Failed to connect to VM Service, will retry: ${error}`);
-				await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+				await new Promise((resolve) => setTimeout(resolve, retryDelayMs).unref());
 			}
 		}
 

--- a/src/shared/vscode/device_manager.ts
+++ b/src/shared/vscode/device_manager.ts
@@ -62,7 +62,7 @@ export class FlutterDeviceManager implements vs.Disposable {
 				if (this.devices.length === 0) {
 					runIfNoDevices();
 				}
-			}, 10000);
+			}, 10000).unref();
 		}
 	}
 
@@ -343,7 +343,7 @@ export class FlutterDeviceManager implements vs.Disposable {
 				device = this.findBestDevice(id);
 				if (device)
 					return device;
-				await new Promise((resolve) => setTimeout(resolve, 100));
+				await new Promise((resolve) => setTimeout(resolve, 100).unref());
 			}
 		});
 	}
@@ -511,7 +511,7 @@ export class FlutterDeviceManager implements vs.Disposable {
 			this.logger.info(`Supported platforms for the workspace are ${supportedTypes.map((t) => `"${t}"`).join(", ")}.`);
 
 			resolve(supportedTypes);
-			setTimeout(() => this.shortCacheForSupportedPlatforms = undefined, 10000);
+			setTimeout(() => this.shortCacheForSupportedPlatforms = undefined, 10000).unref();
 		});
 
 		return this.shortCacheForSupportedPlatforms;


### PR DESCRIPTION
In many places where we use setTimeout() to start long timers, we should not allow these timers to stall shutting down if the extension host is trying to exit.