### PR TITLE
Support prompting for platforms during "Flutter: New Project" flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -2538,6 +2538,12 @@
 						"description": "The platforms to enable for new projects created using the 'Flutter: New Project' command. If unset, all platforms will be enabled.",
 						"scope": "window"
 					},
+					"dart.flutterCreatePromptForPlatforms": {
+						"type": "boolean",
+						"default": true,
+						"description": "Whether to prompt for platforms when running 'Flutter: New Project'.",
+						"scope": "window"
+					},
 					"dart.offline": {
 						"type": "boolean",
 						"default": false,

--- a/src/extension/commands/flutter.ts
+++ b/src/extension/commands/flutter.ts
@@ -24,7 +24,7 @@ import { config } from "../config";
 import { getFlutterSnippets } from "../sdk/flutter_docs_snippets";
 import { SdkUtils } from "../sdk/utils";
 import * as util from "../utils";
-import { showInputBoxWithSettings, showSimpleSettingsEditor } from "../utils/vscode/input";
+import { editSetting, showInputBoxWithSettings, showSimpleSettingsEditor } from "../utils/vscode/input";
 import { getFolderToRunCommandIn } from "../utils/vscode/projects";
 import { runBatchFolderOperation } from "./batch_progress";
 import { BaseSdkCommands, commandState, packageNameRegex } from "./sdk";
@@ -348,6 +348,13 @@ export class FlutterCommands extends BaseSdkCommands {
 		const name = await this.promptForNameWithSettings(defaultName, folderPath);
 		if (!name)
 			return;
+
+		// If enabled, show the platform selector, which persists the selection options to config automatically.
+		if (config.flutterCreatePromptForPlatforms) {
+			if (!await editSetting(this.getCurrentFlutterPlatformSettingEditMetadata())) {
+				return;
+			}
+		}
 
 		const projectFolderUri = vs.Uri.file(path.join(folderPath, name));
 		const projectFolderPath = fsPath(projectFolderUri);

--- a/src/extension/commands/flutter.ts
+++ b/src/extension/commands/flutter.ts
@@ -181,7 +181,7 @@ export class FlutterCommands extends BaseSdkCommands {
 		}
 
 		const template = triggerData?.template;
-		const templateAllowsPlatform = template === undefined || !!flutterCreateTemplatesSupportingPlatforms.find((t) => t === (template ?? "app"));
+		const templateAllowsPlatform = template === undefined || flutterCreateTemplatesSupportingPlatforms.includes(template);
 		const defaultPlatforms = config.flutterCreatePlatforms;
 		// Use "--empty" if either the user selected the empty option, or are we enabling a platform.
 		const useEmpty = (template && triggerData?.empty) || (templateAllowsPlatform && platform);
@@ -350,7 +350,8 @@ export class FlutterCommands extends BaseSdkCommands {
 			return;
 
 		// If enabled, show the platform selector, which persists the selection options to config automatically.
-		if (config.flutterCreatePromptForPlatforms) {
+		const templateAllowsPlatform = flutterCreateTemplatesSupportingPlatforms.includes(template.id);
+		if (config.flutterCreatePromptForPlatforms && templateAllowsPlatform) {
 			if (!await editSetting(this.getCurrentFlutterPlatformSettingEditMetadata(), true)) {
 				return;
 			}
@@ -479,14 +480,7 @@ export class FlutterCommands extends BaseSdkCommands {
 			},
 			description: config.flutterCreatePlatforms ? config.flutterCreatePlatforms.join(", ") : "all",
 			detail: "The platforms that should be enabled for new Flutter applications.",
-			enumValues: [{
-				values: flutterCreateAvailablePlatforms,
-			},
-				/* {
-					group: "Defaults",
-					values: ["Set as default..."],
-				} */
-			],
+			enumValues: flutterCreateAvailablePlatforms,
 			label: "Platforms",
 			setValue: async (newValues: any[]) => {
 				const valueToSave = newValues.length === flutterCreateAvailablePlatforms.length

--- a/src/extension/commands/flutter.ts
+++ b/src/extension/commands/flutter.ts
@@ -351,7 +351,7 @@ export class FlutterCommands extends BaseSdkCommands {
 
 		// If enabled, show the platform selector, which persists the selection options to config automatically.
 		if (config.flutterCreatePromptForPlatforms) {
-			if (!await editSetting(this.getCurrentFlutterPlatformSettingEditMetadata())) {
+			if (!await editSetting(this.getCurrentFlutterPlatformSettingEditMetadata(), true)) {
 				return;
 			}
 		}
@@ -472,6 +472,11 @@ export class FlutterCommands extends BaseSdkCommands {
 	private getCurrentFlutterPlatformSettingEditMetadata(): PickableSetting {
 		return {
 			currentValue: config.flutterCreatePlatforms ?? flutterCreateAvailablePlatforms,
+			doNotAskNextTimeOption: {
+				currentValue: config.flutterCreatePromptForPlatforms,
+				inverted: true,
+				setValue: (newValue: boolean | undefined) => config.setFlutterCreatePromptForPlatforms(newValue ? undefined : false),
+			},
 			description: config.flutterCreatePlatforms ? config.flutterCreatePlatforms.join(", ") : "all",
 			detail: "The platforms that should be enabled for new Flutter applications.",
 			enumValues: [{
@@ -480,7 +485,8 @@ export class FlutterCommands extends BaseSdkCommands {
 				/* {
 					group: "Defaults",
 					values: ["Set as default..."],
-				} */ ],
+				} */
+			],
 			label: "Platforms",
 			setValue: async (newValues: any[]) => {
 				const valueToSave = newValues.length === flutterCreateAvailablePlatforms.length

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -122,6 +122,7 @@ class Config {
 	get flutterCreateOffline(): boolean { return this.getConfig<boolean>("flutterCreateOffline", false); }
 	get flutterCreateOrganization(): undefined | string { return this.getConfig<null | string>("flutterCreateOrganization", null); }
 	get flutterCreatePlatforms(): string[] | undefined { return this.getConfig<string[] | undefined>("flutterCreatePlatforms", undefined); }
+	get flutterCreatePromptForPlatforms(): boolean { return this.getConfig<boolean>("flutterCreatePromptForPlatforms", true); }
 	get flutterCustomEmulators(): Array<{ id: string, name: string, executable: string, args?: string[] }> { return this.getConfig<Array<{ id: string, name: string, executable: string, args?: string[] }>>("flutterCustomEmulators", []); }
 	get flutterDaemonLogFile(): undefined | string { return createFolderForFile(insertWorkspaceName(resolvePaths(this.getConfig<null | string>("flutterDaemonLogFile", null)))); }
 	get flutterGenerateLocalizationsOnSave(): "never" | "manual" | "manualIfDirty" | "all" | "allIfDirty" { return this.getConfig<"never" | "manual" | "manualIfDirty" | "all" | "allIfDirty">("flutterGenerateLocalizationsOnSave", "never"); }

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -229,6 +229,7 @@ class Config {
 	public setFlutterCreateAndroidLanguage(value: "java" | "kotlin" | undefined): Promise<void> { return this.setConfig("flutterCreateAndroidLanguage", value, ConfigurationTarget.Global); }
 	public setFlutterCreateIOSLanguage(value: "objc" | "swift" | undefined): Promise<void> { return this.setConfig("flutterCreateIOSLanguage", value, ConfigurationTarget.Global); }
 	public setFlutterCreatePlatforms(value: string[] | undefined): Promise<void> { return this.setConfig("flutterCreatePlatforms", value, ConfigurationTarget.Global); }
+	public setFlutterCreatePromptForPlatforms(value: boolean | undefined): Promise<void> { return this.setConfig("flutterCreatePromptForPlatforms", value, ConfigurationTarget.Global); }
 	public setFlutterSdkPath(value: string | undefined, target: ConfigurationTarget): Promise<void> { return this.setConfig("flutterSdkPath", value, target); }
 	public setGlobalDartSdkPath(value: string): Promise<void> { return this.setConfig("sdkPath", value, ConfigurationTarget.Global); }
 	public setGlobalDebugSdkLibraries(value: boolean): Promise<void> { return this.setConfig("debugSdkLibraries", value, ConfigurationTarget.Global); }

--- a/src/extension/utils/vscode/input.ts
+++ b/src/extension/utils/vscode/input.ts
@@ -84,7 +84,7 @@ export async function showSimpleSettingsEditor(title: string, placeholder: strin
 	}
 }
 
-export async function editSetting(setting: PickableSetting): Promise<boolean> {
+export async function editSetting(setting: PickableSetting, showDoNotAskNextTime = false): Promise<boolean> {
 	const title = setting.label;
 	let placeholder = `Select an option for ${setting.label} (or 'Escape' to cancel)`;
 	const prompt = setting.detail;
@@ -118,20 +118,26 @@ export async function editSetting(setting: PickableSetting): Promise<boolean> {
 			return accepted;
 		}
 		case "MULTI_ENUM": {
-			placeholder = `Select options for ${setting.label} (or 'Escape' to cancel)`;
-			const quickPick = vs.window.createQuickPick();
+			placeholder = `Select ${setting.label} (or 'Escape' to cancel)`;
+			const quickPick = vs.window.createQuickPick<vs.QuickPickItem & { isDoNotAskNextTime?: boolean }>();
+			const doNotAskOption = showDoNotAskNextTime ? setting.doNotAskNextTimeOption : undefined;
+			const doNotAskOptionChecked = doNotAskOption && (doNotAskOption.inverted ? !doNotAskOption.currentValue : doNotAskOption.currentValue);
 			quickPick.canSelectMany = true;
 			quickPick.placeholder = placeholder;
 			quickPick.title = title;
-			const items: vs.QuickPickItem[] = [];
+			const items: Array<vs.QuickPickItem & { isDoNotAskNextTime?: boolean }> = [];
 			for (const group of setting.enumValues) {
 				items.push({ label: group.group, kind: vs.QuickPickItemKind.Separator } as vs.QuickPickItem);
 				for (const value of group.values) {
 					items.push({ label: value } as vs.QuickPickItem);
 				}
 			}
+			if (doNotAskOption) {
+				items.push({ kind: vs.QuickPickItemKind.Separator } as vs.QuickPickItem);
+				items.push({ label: "Don't ask next time", isDoNotAskNextTime: true } as vs.QuickPickItem);
+			}
 			quickPick.items = items;
-			quickPick.selectedItems = quickPick.items.filter((item) => setting.currentValue.find((current) => current === item.label));
+			quickPick.selectedItems = items.filter((item) => setting.currentValue.find((current) => current === item.label) || (doNotAskOptionChecked && item.isDoNotAskNextTime));
 
 			const accepted = await new Promise<boolean>((resolve) => {
 				quickPick.onDidAccept(() => resolve(true));
@@ -140,8 +146,14 @@ export async function editSetting(setting: PickableSetting): Promise<boolean> {
 			});
 			quickPick.dispose();
 
-			if (accepted)
-				await setting.setValue(quickPick.selectedItems.map((item) => item.label));
+			if (accepted) {
+				if (doNotAskOption) {
+					const doNotAskOptionSelected = !!quickPick.selectedItems.find((item) => item.isDoNotAskNextTime);
+					const doNotAskConfigValue = doNotAskOption.inverted ? !doNotAskOptionSelected : doNotAskOptionSelected;
+					await doNotAskOption.setValue(doNotAskConfigValue);
+				}
+				await setting.setValue(quickPick.selectedItems.filter((item) => !item.isDoNotAskNextTime).map((item) => item.label));
+			}
 			return accepted;
 		}
 		case "BOOL": {

--- a/src/extension/utils/vscode/input.ts
+++ b/src/extension/utils/vscode/input.ts
@@ -84,7 +84,7 @@ export async function showSimpleSettingsEditor(title: string, placeholder: strin
 	}
 }
 
-async function editSetting(setting: PickableSetting) {
+export async function editSetting(setting: PickableSetting): Promise<boolean> {
 	const title = setting.label;
 	let placeholder = `Select an option for ${setting.label} (or 'Escape' to cancel)`;
 	const prompt = setting.detail;
@@ -93,9 +93,10 @@ async function editSetting(setting: PickableSetting) {
 	switch (setting.settingKind) {
 		case "STRING": {
 			const stringResult = await vs.window.showInputBox({ prompt, title, value: value as string | undefined });
-			if (stringResult !== undefined)
+			const accepted = stringResult !== undefined;
+			if (accepted)
 				await setting.setValue(stringResult);
-			break;
+			return accepted;
 		}
 		case "ENUM": {
 			const quickPick = vs.window.createQuickPick();
@@ -114,7 +115,7 @@ async function editSetting(setting: PickableSetting) {
 
 			if (enumResult !== undefined)
 				await setting.setValue(enumResult);
-			break;
+			return accepted;
 		}
 		case "MULTI_ENUM": {
 			placeholder = `Select options for ${setting.label} (or 'Escape' to cancel)`;
@@ -141,7 +142,7 @@ async function editSetting(setting: PickableSetting) {
 
 			if (accepted)
 				await setting.setValue(quickPick.selectedItems.map((item) => item.label));
-			break;
+			return accepted;
 		}
 		case "BOOL": {
 			const boolResult = await vs.window.showQuickPick(
@@ -151,9 +152,10 @@ async function editSetting(setting: PickableSetting) {
 				],
 				{ placeHolder: placeholder, title },
 			);
-			if (boolResult !== undefined)
+			const accepted = boolResult !== undefined;
+			if (accepted)
 				await setting.setValue(boolResult.label === "enable");
-			break;
+			return accepted;
 		}
 	}
 }

--- a/src/extension/utils/vscode/input.ts
+++ b/src/extension/utils/vscode/input.ts
@@ -111,10 +111,11 @@ export async function editSetting(setting: PickableSetting, showDoNotAskNextTime
 				quickPick.show();
 			});
 			const enumResult = accepted && quickPick.activeItems.length ? quickPick.activeItems[0].label : undefined;
-			quickPick.dispose();
 
 			if (enumResult !== undefined)
 				await setting.setValue(enumResult);
+
+			quickPick.dispose();
 			return accepted;
 		}
 		case "MULTI_ENUM": {
@@ -126,34 +127,32 @@ export async function editSetting(setting: PickableSetting, showDoNotAskNextTime
 			quickPick.placeholder = placeholder;
 			quickPick.title = title;
 			const items: Array<vs.QuickPickItem & { isDoNotAskNextTime?: boolean }> = [];
-			for (const group of setting.enumValues) {
-				items.push({ label: group.group, kind: vs.QuickPickItemKind.Separator } as vs.QuickPickItem);
-				for (const value of group.values) {
-					items.push({ label: value } as vs.QuickPickItem);
-				}
+			for (const value of setting.enumValues) {
+				items.push({ label: value } as vs.QuickPickItem);
 			}
 			if (doNotAskOption) {
 				items.push({ kind: vs.QuickPickItemKind.Separator } as vs.QuickPickItem);
 				items.push({ label: "Don't ask next time", isDoNotAskNextTime: true } as vs.QuickPickItem);
 			}
 			quickPick.items = items;
-			quickPick.selectedItems = items.filter((item) => setting.currentValue.find((current) => current === item.label) || (doNotAskOptionChecked && item.isDoNotAskNextTime));
+			quickPick.selectedItems = items.filter((item) => setting.currentValue.includes(item.label) || (doNotAskOptionChecked && item.isDoNotAskNextTime));
 
 			const accepted = await new Promise<boolean>((resolve) => {
 				quickPick.onDidAccept(() => resolve(true));
 				quickPick.onDidHide(() => resolve(false));
 				quickPick.show();
 			});
-			quickPick.dispose();
 
 			if (accepted) {
 				if (doNotAskOption) {
-					const doNotAskOptionSelected = !!quickPick.selectedItems.find((item) => item.isDoNotAskNextTime);
+					const doNotAskOptionSelected = quickPick.selectedItems.some((item) => item.isDoNotAskNextTime);
 					const doNotAskConfigValue = doNotAskOption.inverted ? !doNotAskOptionSelected : doNotAskOptionSelected;
 					await doNotAskOption.setValue(doNotAskConfigValue);
 				}
 				await setting.setValue(quickPick.selectedItems.filter((item) => !item.isDoNotAskNextTime).map((item) => item.label));
 			}
+
+			quickPick.dispose();
 			return accepted;
 		}
 		case "BOOL": {

--- a/src/shared/vscode/input.ts
+++ b/src/shared/vscode/input.ts
@@ -1,7 +1,16 @@
 import * as vs from "vscode";
 
 export type UserInputOrSettings = { value: string } | "SETTINGS";
-export type PickableSetting = vs.QuickPickItem & ({
+
+interface DoNotAskOption {
+	doNotAskNextTimeOption?: {
+		currentValue: boolean,
+		inverted?: boolean,
+		setValue: (newValue: boolean | undefined) => Promise<void>,
+	},
+}
+
+export type PickableSetting = vs.QuickPickItem & DoNotAskOption & ({
 	settingKind: "STRING" | "ENUM" | "BOOL",
 	currentValue: any,
 	setValue: (newValue: any) => Promise<void>,

--- a/src/shared/vscode/input.ts
+++ b/src/shared/vscode/input.ts
@@ -19,5 +19,5 @@ export type PickableSetting = vs.QuickPickItem & DoNotAskOption & ({
 	settingKind: "MULTI_ENUM",
 	currentValue: any[],
 	setValue: (newValue: any[]) => Promise<void>,
-	enumValues: Array<{ group?: string, values: string[] }>,
+	enumValues: string[],
 });

--- a/src/test/flutter/commands/flutter.test.ts
+++ b/src/test/flutter/commands/flutter.test.ts
@@ -169,7 +169,7 @@ describe("flutter commands", () => {
 		assert.equal(organizationSetting.currentValue, "com.example");
 		assert.equal(platformsSetting.description, "all");
 		assert.deepEqual(platformsSetting.currentValue, flutterCreateAvailablePlatforms);
-		assert.deepEqual(platformsSetting.enumValues, [{ values: flutterCreateAvailablePlatforms }]);
+		assert.deepEqual(platformsSetting.enumValues, flutterCreateAvailablePlatforms);
 
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 		await organizationSetting.setValue("com.example.changed" as any);

--- a/src/test/flutter/commands/flutter.test.ts
+++ b/src/test/flutter/commands/flutter.test.ts
@@ -169,6 +169,7 @@ describe("flutter commands", () => {
 		assert.equal(organizationSetting.currentValue, "com.example");
 		assert.equal(platformsSetting.description, "all");
 		assert.deepEqual(platformsSetting.currentValue, flutterCreateAvailablePlatforms);
+		assert.deepEqual(platformsSetting.enumValues, [{ values: flutterCreateAvailablePlatforms }]);
 
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 		await organizationSetting.setValue("com.example.changed" as any);

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -379,13 +379,14 @@ type QuickPickAction =
 	// Select a single value.
 	| { kind: "enum"; label: string }
 	// Selecting multiple values.
-	| { kind: "multi"; labels: string[] };
+	| { kind: "multi"; labels: string[] }
+	// Accept the selection with whatever was already selected.
+	| { kind: "accept-selected" };
 
 /**
  * Replaces createQuickPick() with a scripted quick pick sequence.
  *
- * showSimpleSettingsEditor() reopens the top-level picker after each edit, so tests
- * provide a full sequence of actions (usually ending with a final "cancel").
+ * The next action will be chosen for each call to createQuickPick().
  */
 export function stubCreateQuickPickActions(actions: QuickPickAction[]) {
 	const createQuickPick = sb.stub(vs.window, "createQuickPick");
@@ -429,6 +430,9 @@ export function stubCreateQuickPickActions(actions: QuickPickAction[]) {
 							break;
 						case "multi":
 							quickPick.selectedItems = quickPick.items.filter((item) => action.labels.includes(item.label));
+							acceptHandler?.();
+							break;
+						case "accept-selected":
 							acceptHandler?.();
 							break;
 					}

--- a/src/test/not_activated/flutter_create/extension.test.ts
+++ b/src/test/not_activated/flutter_create/extension.test.ts
@@ -7,7 +7,7 @@ import { FLUTTER_CREATE_PROJECT_TRIGGER_FILE } from "../../../shared/constants";
 import { FlutterCreateTriggerData } from "../../../shared/interfaces";
 import { fsPath } from "../../../shared/utils/fs";
 import { FlutterSampleSnippet } from "../../../shared/vscode/interfaces";
-import { attachLoggingWhenExtensionAvailable, ext, getRandomTempFolder, privateApi, sb, stubCreateInputBox } from "../../helpers";
+import { attachLoggingWhenExtensionAvailable, ext, getRandomTempFolder, privateApi, sb, setConfigForTest, stubCreateInputBox, stubCreateQuickPickActions } from "../../helpers";
 
 describe("test environment", () => {
 	it("has opened the correct folder", () => {
@@ -59,6 +59,18 @@ describe("command", () => {
 		await projectContainsTriggerFileForExpectedTemplate("flutter.createProject", "application", "application", true);
 	});
 
+	it("Flutter: New Project allows modifying platforms during flow", async () => {
+		const selectedPlatforms = ["android", "web"];
+		// Clear the current setting.
+		await setConfigForTest("dart", "flutterCreatePlatforms", undefined);
+
+		// Run the create flow, selecting some specific platforms.
+		await projectContainsTriggerFileForExpectedTemplate("flutter.createProject", "app", "application", undefined, selectedPlatforms);
+
+		// Ensure it was persisted.
+		assert.deepEqual(vs.workspace.getConfiguration("dart").get("flutterCreatePlatforms"), selectedPlatforms);
+	});
+
 	it("Flutter: Create Sample Project can be invoked and creates trigger file", async () => {
 		const showQuickPick = sb.stub(vs.window, "showQuickPick");
 		type SnippetOption = vs.QuickPickItem & { snippet: FlutterSampleSnippet };
@@ -85,12 +97,13 @@ describe("command", () => {
 	});
 });
 
-async function projectContainsTriggerFileForExpectedTemplate(commandToExecute: string, expectedTemplate: string, expectedName: string, empty?: boolean): Promise<void> {
+async function projectContainsTriggerFileForExpectedTemplate(commandToExecute: string, expectedTemplate: string, expectedName: string, empty?: boolean, selectedPlatforms?: string[]): Promise<void> {
 	attachLoggingWhenExtensionAvailable();
 
 	// Return the expected project type from the prompt.
 	const showQuickPick = sb.stub(vs.window, "showQuickPick");
 	showQuickPick.resolves({ template: { id: expectedTemplate, empty } });
+	stubCreateQuickPickActions([selectedPlatforms ? { kind: "multi", labels: selectedPlatforms } : { kind: "accept-selected" }]);
 
 	// Choose a random temp folder for the project output.
 	const showOpenDialog = sb.stub(vs.window, "showOpenDialog");

--- a/src/test/not_activated/flutter_create/extension.test.ts
+++ b/src/test/not_activated/flutter_create/extension.test.ts
@@ -71,6 +71,42 @@ describe("command", () => {
 		assert.deepEqual(vs.workspace.getConfiguration("dart").get("flutterCreatePlatforms"), selectedPlatforms);
 	});
 
+	it("Flutter: New Project doesn't use selected platforms automatically next time by default", async () => {
+		const selectedPlatforms = ["android", "web"];
+		await setConfigForTest("dart", "flutterCreatePlatforms", undefined);
+		await setConfigForTest("dart", "flutterCreatePromptForPlatforms", true);
+
+		await projectContainsTriggerFileForExpectedTemplate(
+			"flutter.createProject",
+			"app",
+			"application",
+			undefined,
+			selectedPlatforms,
+			false, // useOptionsAutomaticallyNextTime
+		);
+
+		assert.deepEqual(vs.workspace.getConfiguration("dart").get("flutterCreatePlatforms"), selectedPlatforms);
+		assert.equal(vs.workspace.getConfiguration("dart").get("flutterCreatePromptForPlatforms"), true);
+	});
+
+	it("Flutter: New Project uses selected platforms automatically next time if checked", async () => {
+		const selectedPlatforms = ["android", "web"];
+		await setConfigForTest("dart", "flutterCreatePlatforms", undefined);
+		await setConfigForTest("dart", "flutterCreatePromptForPlatforms", true);
+
+		await projectContainsTriggerFileForExpectedTemplate(
+			"flutter.createProject",
+			"app",
+			"application",
+			undefined,
+			selectedPlatforms,
+			true, // useOptionsAutomaticallyNextTime
+		);
+
+		assert.deepEqual(vs.workspace.getConfiguration("dart").get("flutterCreatePlatforms"), selectedPlatforms);
+		assert.equal(vs.workspace.getConfiguration("dart").get("flutterCreatePromptForPlatforms"), false);
+	});
+
 	it("Flutter: Create Sample Project can be invoked and creates trigger file", async () => {
 		const showQuickPick = sb.stub(vs.window, "showQuickPick");
 		type SnippetOption = vs.QuickPickItem & { snippet: FlutterSampleSnippet };
@@ -97,13 +133,16 @@ describe("command", () => {
 	});
 });
 
-async function projectContainsTriggerFileForExpectedTemplate(commandToExecute: string, expectedTemplate: string, expectedName: string, empty?: boolean, selectedPlatforms?: string[]): Promise<void> {
+async function projectContainsTriggerFileForExpectedTemplate(commandToExecute: string, expectedTemplate: string, expectedName: string, empty?: boolean, selectedPlatforms?: string[], useOptionsAutomaticallyNextTime?: boolean): Promise<void> {
 	attachLoggingWhenExtensionAvailable();
 
 	// Return the expected project type from the prompt.
 	const showQuickPick = sb.stub(vs.window, "showQuickPick");
 	showQuickPick.resolves({ template: { id: expectedTemplate, empty } });
-	stubCreateQuickPickActions([selectedPlatforms ? { kind: "multi", labels: selectedPlatforms } : { kind: "accept-selected" }]);
+	const selectedQuickPickLabels = selectedPlatforms ? [...selectedPlatforms] : undefined;
+	if (selectedQuickPickLabels && useOptionsAutomaticallyNextTime)
+		selectedQuickPickLabels.push("Don't ask next time");
+	stubCreateQuickPickActions([selectedQuickPickLabels ? { kind: "multi", labels: selectedQuickPickLabels } : { kind: "accept-selected" }]);
 
 	// Choose a random temp folder for the project output.
 	const showOpenDialog = sb.stub(vs.window, "showOpenDialog");

--- a/src/test/not_activated/flutter_create/extension.test.ts
+++ b/src/test/not_activated/flutter_create/extension.test.ts
@@ -56,7 +56,7 @@ describe("command", () => {
 	});
 
 	it("Flutter: New Project can be invoked and creates empty application trigger file", async () => {
-		await projectContainsTriggerFileForExpectedTemplate("flutter.createProject", "application", "application", true);
+		await projectContainsTriggerFileForExpectedTemplate("flutter.createProject", "app", "application", true);
 	});
 
 	it("Flutter: New Project allows modifying platforms during flow", async () => {


### PR DESCRIPTION
With this change, we'll prompt for platforms during the "Flutter: New Project" flow by default, with a "Don't ask next time" option that toggles the new setting `dart.flutterCreatePromptForPlatforms` that controls this.

<img width="730" height="286" alt="image" src="https://github.com/user-attachments/assets/622b6431-3718-49c7-a5ad-167282f4c3c2" />

Fixes https://github.com/Dart-Code/Dart-Code/issues/4271