### PR TITLE
Address Gemini feedback about handling falsy values

### DIFF
--- a/src/extension/analysis/form.ts
+++ b/src/extension/analysis/form.ts
@@ -913,7 +913,7 @@ export class InteractiveFormsFeature implements StaticFeature {
 			case 'string':
 				return await vscode.window.showInputBox({
 					prompt: field.description,
-					value: prevAnswer ? prevAnswer : field.default,
+					value: prevAnswer !== undefined ? prevAnswer : field.default,
 					placeHolder: field.description,
 					// Keep the input box open when focus is lost. This allows the
 					// user to  browse the workspace or inspect code (e.g., checking
@@ -960,9 +960,9 @@ export class InteractiveFormsFeature implements StaticFeature {
 
 			case 'number': {
 				let value: string | undefined;
-				if (prevAnswer) {
+				if (prevAnswer !== undefined && prevAnswer !== null) {
 					value = String(prevAnswer);
-				} else if (field.default) {
+				} else if (field.default !== undefined && field.default !== null) {
 					value = String(field.default);
 				}
 				const numResult = await vscode.window.showInputBox({
@@ -971,11 +971,20 @@ export class InteractiveFormsFeature implements StaticFeature {
 					placeHolder: '0',
 					ignoreFocusOut: true,
 					validateInput: (text) => {
+						if (text.trim() === '') {
+							return field.required ? 'Please enter a number' : null;
+						}
 						return isNaN(Number(text)) ? 'Please enter a valid number' : null;
 					}
 				});
 
-				return numResult !== undefined ? Number(numResult) : undefined;
+				if (numResult === undefined) {
+					return undefined; // undefined = canceled
+				}
+				if (numResult.trim() === '') {
+					return null; // null = empty (eg. not answering optional question)
+				}
+				return Number(numResult);
 			}
 
 			case 'list': {


### PR DESCRIPTION
@h9jiang this is the only thing in Gemini's feedback that seemed like a an issue to me - handling of 0/empty for number/string fields (we could convert an empty submission into a 0, and convert a 0/empty back into the default).

I think these changes make sense, but I wonder if we should specify more explicitly how optional questions should be handled by the client?

For example with this change, I think we will submit `null` for an "empty" submission of a Number field, but we would still submit an empty string for a String field. We could convert the empty string also to a `null`?