### PR TITLE
Work around Copilot mutating extension host process env variables that break SwiftPM

### DIFF
--- a/src/extension/utils/processes.ts
+++ b/src/extension/utils/processes.ts
@@ -60,7 +60,7 @@ export function setupToolEnv({ suppressAnalytics, envOverrides }: { suppressAnal
 }
 
 export function safeToolSpawn(workingDirectory: string | undefined, binPath: string, args: string[], envOverrides?: Record<string, string | undefined>): SpawnedProcess {
-	const env = Object.assign({}, toolEnv, envOverrides) as Record<string, string | undefined> | undefined;
+	const env = Object.assign({}, getToolEnv(), envOverrides) as Record<string, string | undefined> | undefined;
 	return safeSpawn(workingDirectory, binPath, args, env);
 }
 

--- a/src/extension/utils/processes.ts
+++ b/src/extension/utils/processes.ts
@@ -2,6 +2,7 @@ import * as vs from "vscode";
 import { isDartCodeTestRun } from "../../shared/constants";
 import { Logger, SpawnedProcess } from "../../shared/interfaces";
 import { RunProcessResult, runProcess, safeSpawn } from "../../shared/processes";
+import { getFixedToolEnvForCopilotMutation } from "../../shared/utils";
 import { dashIdeEnvironment, dashIdeName, dashIdeVersion, dashPluginName, dashPluginVersion, dashTool } from "../../shared/vscode/constants";
 
 // Environment used when spawning Dart and Flutter processes.
@@ -15,7 +16,7 @@ let globalFlutterArgs: string[] = [];
  * Mutations to toolEnv should be done via setupToolEnv/etc.
  */
 export function getToolEnv(): Record<string, string> {
-	return Object.assign({}, toolEnv);
+	return getFixedToolEnvForCopilotMutation({ processEnv: process.env, toolEnv: Object.assign({}, toolEnv) });
 }
 
 export function getGlobalFlutterArgs() {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -257,3 +257,47 @@ export async function withTimeout<T>(promise: Thenable<T>, message: string | (()
 		);
 	});
 }
+
+/**
+ * Returns a "fixed" toolEnv to work around a Copilot env var mutation issue.
+ *
+ * Always returns a new copy. This must be done in all tool invocations and not cached, because
+ * we don't know at what point in time the Copilot SDK will mutate the process env. If we only
+ * check at startup, we might be too early and assume we don't need the fix.
+ *
+ * Only overrides values if the last override value is explicitly what we expect. Do not
+ * alter any other settings that might have been set. If the user has a complex setup then
+ * they can apply the workaround manually by setting `dart.env`.
+ *
+ * https://github.com/Dart-Code/Dart-Code/issues/6074
+ * https://github.com/Dart-Code/Dart-Code/issues/6083
+ * https://github.com/microsoft/vscode/issues/320880
+ * https://github.com/github/copilot-cli/issues/3602
+ *
+ * @param env The process environment to check for Copilot-mutated values.
+ * @returns  The default toolEnv to use.
+ */
+export function getFixedToolEnvForCopilotMutation({ processEnv, toolEnv }: { processEnv: Record<string, string | undefined>; toolEnv: Record<string, string>; }): Record<string, string> {
+	// Workaround GitHub Copilot mutating the extension host processes env variables
+	// to include safe.bareRepository=explicit which breaks Swift PM.
+	//
+	// If the last config added was safe.bareRepository=explicit, then reduce the count to remove it.
+
+	const newToolEnv = Object.assign({}, toolEnv);
+	const configCountEnvVarValue = processEnv.GIT_CONFIG_COUNT;
+	// Has a value?
+	if (typeof configCountEnvVarValue === "string") {
+		const configCount = parseInt(configCountEnvVarValue, 10);
+		// Is numeric?
+		if (Number.isInteger(configCount)) {
+			const lastConfigIndex = configCount - 1;
+			// Last setting is the one we're trying to eliminate?
+			if (processEnv[`GIT_CONFIG_KEY_${lastConfigIndex}`] === "safe.bareRepository"
+				&& processEnv[`GIT_CONFIG_VALUE_${lastConfigIndex}`] === "explicit")
+				// Wind back the count to exclude it.
+				newToolEnv.GIT_CONFIG_COUNT = (configCount - 1).toString();
+		}
+	}
+
+	return newToolEnv;
+}

--- a/src/test/dart/utils/processes.test.ts
+++ b/src/test/dart/utils/processes.test.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { isWin } from "../../../shared/constants";
 import { nullLogger } from "../../../shared/logging";
 import { runProcess, safeSpawn } from "../../../shared/processes";
+import { getFixedToolEnvForCopilotMutation } from "../../../shared/utils";
 import { mkDirRecursive } from "../../../shared/utils/fs";
 import { getRandomTempFolder } from "../../helpers";
 
@@ -45,3 +46,91 @@ function testExecution(filename: string) {
 		assert.equal(lastLine, filename, `Output did not have expected output (${procResultJson})`);
 	});
 }
+
+describe("toolEnv Copilot workaround", () => {
+	it("does not apply if empty", () => {
+		const res = getFixedToolEnvForCopilotMutation({
+			processEnv: {},
+			toolEnv: {},
+		});
+		assert.deepStrictEqual(res, {});
+	});
+	it("does not apply if no count", () => {
+		const res = getFixedToolEnvForCopilotMutation({
+			processEnv: {
+				GIT_CONFIG_KEY_0: "safe.bareRepository",
+				GIT_CONFIG_VALUE_0: "explicit",
+			},
+			toolEnv: {},
+		});
+		assert.deepStrictEqual(res, {});
+	});
+	it("does not apply if different value", () => {
+		const res = getFixedToolEnvForCopilotMutation({
+			processEnv: {
+				GIT_CONFIG_COUNT: "1",
+				GIT_CONFIG_KEY_0: "safe.bareRepository",
+				GIT_CONFIG_VALUE_0: "explicit2",
+			},
+			toolEnv: {},
+		});
+		assert.deepStrictEqual(res, {});
+	});
+	it("does not apply if not last value", () => {
+		const res = getFixedToolEnvForCopilotMutation({
+			processEnv: {
+				GIT_CONFIG_COUNT: "2",
+				GIT_CONFIG_KEY_0: "safe.bareRepository",
+				GIT_CONFIG_VALUE_0: "explicit",
+				GIT_CONFIG_KEY_1: "something else",
+				GIT_CONFIG_VALUE_1: "something else",
+			},
+			toolEnv: {},
+		});
+		assert.deepStrictEqual(res, {});
+	});
+	it("applies if only value", () => {
+		const res = getFixedToolEnvForCopilotMutation({
+			processEnv: {
+				GIT_CONFIG_COUNT: "1",
+				GIT_CONFIG_KEY_0: "safe.bareRepository",
+				GIT_CONFIG_VALUE_0: "explicit",
+			},
+			toolEnv: {},
+		});
+		assert.deepStrictEqual(res, {
+			GIT_CONFIG_COUNT: "0",
+		});
+	});
+	it("applies if last of multiple values", () => {
+		const res = getFixedToolEnvForCopilotMutation({
+			processEnv: {
+				GIT_CONFIG_COUNT: "2",
+				GIT_CONFIG_KEY_0: "other",
+				GIT_CONFIG_VALUE_0: "other",
+				GIT_CONFIG_KEY_1: "safe.bareRepository",
+				GIT_CONFIG_VALUE_1: "explicit",
+			},
+			toolEnv: {},
+		});
+		assert.deepStrictEqual(res, {
+			GIT_CONFIG_COUNT: "1",
+		});
+	});
+	it("does not modify other values", () => {
+		const res = getFixedToolEnvForCopilotMutation({
+			processEnv: {
+				GIT_CONFIG_COUNT: "1",
+				GIT_CONFIG_KEY_0: "safe.bareRepository",
+				GIT_CONFIG_VALUE_0: "explicit",
+			},
+			toolEnv: {
+				UNRELATED: "12345"
+			},
+		});
+		assert.deepStrictEqual(res, {
+			GIT_CONFIG_COUNT: "0",
+			UNRELATED: "12345"
+		});
+	});
+});


### PR DESCRIPTION
The copilot SDK package (`@github/copilot`) used by the Copilot extension mutates `process.env` to restrict git settings:

```
GIT_CONFIG_COUNT=<n+1>
GIT_CONFIG_KEY_<n>=safe.bareRepository
GIT_CONFIG_VALUE_<n>=explicit
```

This breaks Swift Package Manager which uses bare repositories, because our spawned `flutter` process (which uses the package manager) inherits those variables.

Until this is fixed (https://github.com/github/copilot-cli/issues/3602, https://github.com/microsoft/vscode/issues/320880) we should detect this and reduce the count to prevent the setting from applying to our spawned processes.

We only make changes if the last value is exactly what we expect, to avoid undoing any other settings (for ex. that the user may have set). This means we must do this per-invocation and not in the cached `toolEnv` because it's possible we would first cache before Copilot has mutated the env vars.

Fixes https://github.com/Dart-Code/Dart-Code/issues/6074
Fixes https://github.com/Dart-Code/Dart-Code/issues/6083
Fixes https://github.com/flutter/flutter/issues/187828

Will merge this to main first, then cherry-pick into 3.136.1.