### PR TITLE
Prevent analyzer and services being shutdown so aggressively

### DIFF
--- a/src/extension/analysis/analyzer.ts
+++ b/src/extension/analysis/analyzer.ts
@@ -609,6 +609,10 @@ export class LspAnalyzer extends Analyzer {
 	 * 3s kill occurs. Shutdown should await this.
 	 */
 	private handleDisposeCleanup(process: SpawnedProcess): Promise<void> {
+		if (process.exitCode !== null || process.signalCode !== null) {
+			return Promise.resolve(); // Already exited, so exit won't fire.
+		}
+
 		return new Promise((resolve) => {
 			// 1. Normal exit with no error.
 			process.once("exit", () => {

--- a/src/extension/analysis/analyzer.ts
+++ b/src/extension/analysis/analyzer.ts
@@ -9,7 +9,7 @@ import { Analyzer } from "../../shared/analyzer";
 import { DartCapabilities } from "../../shared/capabilities/dart";
 import { dartVMPath, ExtensionRestartReason } from "../../shared/constants";
 import { LogCategory } from "../../shared/enums";
-import { DartSdks, Logger } from "../../shared/interfaces";
+import { DartSdks, Logger, SpawnedProcess } from "../../shared/interfaces";
 import { CategoryLogger } from "../../shared/logging";
 import { DartToolingDaemon } from "../../shared/services/tooling_daemon";
 import { fsPath } from "../../shared/utils/fs";
@@ -554,9 +554,11 @@ export class LspAnalyzer extends Analyzer {
 		logger.info(`Spawning ${vmPath} with args ${JSON.stringify(args)}`);
 		const analysisServerStartTime = Date.now();
 		const process = safeToolSpawn(undefined, vmPath, args);
-		// Ensure we terminate the process when shutting down even if the graceful shutdown
-		// doesn't work. Wait a short period to give the graceful shutdown change.
-		this.disposables.push({ dispose: () => { setTimeout(() => process.kill(), 100); } });
+		// Ensure during dispose we terminate the process if it doesn't
+		// naturally exit in time.
+		this.disposables.push({
+			dispose: () => this.handleDisposeCleanup(process)
+		});
 		logger.info(`    PID: ${process.pid}`);
 
 		const reader = process.stdout.pipe(new LoggingTransform(logger, "<=="));
@@ -597,6 +599,29 @@ export class LspAnalyzer extends Analyzer {
 		});
 
 		return Promise.resolve({ reader, writer });
+	}
+
+	/**
+	 * Handle a call to dispose by waiting for the process to exit, or
+	 * if that hasn't happened within 3s, terminates the process.
+	 *
+	 * Returns a promise that resolves when either the process exits or the
+	 * 3s kill occurs. Shutdown should await this.
+	 */
+	private handleDisposeCleanup(process: SpawnedProcess): Promise<void> {
+		return new Promise((resolve) => {
+			// 1. Normal exit with no error.
+			process.once("exit", () => {
+				clearTimeout(timer);
+				resolve();
+			});
+
+			// 2. A 3s timer to kill the server if it did not shutdown in time.
+			const timer = setTimeout(() => {
+				process.kill();
+				resolve();
+			}, 3000);
+		});
 	}
 }
 

--- a/src/extension/analysis/analyzer_snippet_text_edits.ts
+++ b/src/extension/analysis/analyzer_snippet_text_edits.ts
@@ -107,7 +107,7 @@ export class SnippetTextEditFeature implements IAmDisposable {
 		return newText.replace(indentPattern, "\n");
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/analysis/file_change_warnings.ts
+++ b/src/extension/analysis/file_change_warnings.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import * as vs from "vscode";
 import { modifyingFilesOutsideWorkspaceInfoUrl, moreInfoAction } from "../../shared/constants";
+import { IAmDisposable } from "../../shared/interfaces";
 import { disposeAll } from "../../shared/utils";
 import { fsPath } from "../../shared/utils/fs";
 import { isWithinWorkspace } from "../../shared/vscode/project";
@@ -8,8 +9,8 @@ import { envUtils } from "../../shared/vscode/utils";
 import { config } from "../config";
 import * as util from "../utils";
 
-export class FileChangeWarnings implements vs.Disposable {
-	private readonly disposables: vs.Disposable[] = [];
+export class FileChangeWarnings implements IAmDisposable {
+	private readonly disposables: IAmDisposable[] = [];
 	private readonly filesWarnedAbout = new Set<string>();
 	constructor() {
 		this.disposables.push(
@@ -55,7 +56,7 @@ export class FileChangeWarnings implements vs.Disposable {
 		}
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/analysis/file_tracker.ts
+++ b/src/extension/analysis/file_tracker.ts
@@ -95,7 +95,7 @@ export class FileTracker implements IAmDisposable {
 		watcher.onDidCreate(clearCachedPubRunTestData, this);
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/analytics.ts
+++ b/src/extension/analytics.ts
@@ -444,7 +444,7 @@ export class Analytics implements IAmDisposable {
 	}
 	public log(category: AnalyticsEvent) { this.event(category); }
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/api/extension_api.ts
+++ b/src/extension/api/extension_api.ts
@@ -3,7 +3,7 @@ import * as vs from "vscode";
 import { Range } from "vscode-languageclient";
 import { Element, Outline } from "../../shared/analysis/lsp/custom_protocol";
 import { dartVMPath } from "../../shared/constants";
-import { Sdks } from "../../shared/interfaces";
+import { IAmDisposable, Sdks } from "../../shared/interfaces";
 import { ProjectFinder } from "../../shared/vscode/utils";
 import { LspAnalyzer } from "../analysis/analyzer";
 import { SdkCommands } from "../commands/sdk";
@@ -205,7 +205,7 @@ class PublicFeaturesImpl implements PublicFeatures {
 }
 
 class PublicCodeLensImpl implements PublicCodeLens {
-	public suppress(projectFolders: vs.Uri[], options: PublicCodeLensSuppressOptions): vs.Disposable {
+	public suppress(projectFolders: vs.Uri[], options: PublicCodeLensSuppressOptions): IAmDisposable {
 		return data.codeLensSuppressions.addOverride(projectFolders, options);
 	}
 }

--- a/src/extension/api/feature_overrides.ts
+++ b/src/extension/api/feature_overrides.ts
@@ -1,4 +1,5 @@
 import * as vs from "vscode";
+import { IAmDisposable } from "../../shared/interfaces";
 import { fsPath, isWithinPathOrEqual } from "../../shared/utils/fs";
 
 interface FeatureOverrideRule<TOptions> {
@@ -16,7 +17,7 @@ export class FeatureOverrideManager<TOptions> {
 	private onDidChangeEmitter = new vs.EventEmitter<void>();
 	public readonly onDidChange = this.onDidChangeEmitter.event;
 
-	public addOverride(folders: vs.Uri[], options: TOptions): vs.Disposable {
+	public addOverride(folders: vs.Uri[], options: TOptions): IAmDisposable {
 		const rule: FeatureOverrideRule<TOptions> = { folders, options };
 		this.rules.push(rule);
 		this.onDidChangeEmitter.fire();

--- a/src/extension/api/interfaces.ts
+++ b/src/extension/api/interfaces.ts
@@ -1,5 +1,5 @@
 import * as vs from "vscode";
-import { IAmDisposable, SpawnedProcess } from "../../shared/interfaces";
+import { SpawnedProcess } from "../../shared/interfaces";
 
 export interface PublicDartExtensionApi {
 	/**
@@ -235,7 +235,7 @@ export interface PublicCodeLens {
 	 * disposables.forEach((d) => d.dispose());
 	 * ```
 	 */
-	suppress(projectFolders: vs.Uri[], options: PublicCodeLensSuppressOptions): IAmDisposable;
+	suppress(projectFolders: vs.Uri[], options: PublicCodeLensSuppressOptions): vs.Disposable;
 }
 
 export interface PublicCodeLensSuppressOptions {

--- a/src/extension/api/interfaces.ts
+++ b/src/extension/api/interfaces.ts
@@ -1,5 +1,5 @@
 import * as vs from "vscode";
-import { SpawnedProcess } from "../../shared/interfaces";
+import { IAmDisposable, SpawnedProcess } from "../../shared/interfaces";
 
 export interface PublicDartExtensionApi {
 	/**
@@ -235,7 +235,7 @@ export interface PublicCodeLens {
 	 * disposables.forEach((d) => d.dispose());
 	 * ```
 	 */
-	suppress(projectFolders: vs.Uri[], options: PublicCodeLensSuppressOptions): vs.Disposable;
+	suppress(projectFolders: vs.Uri[], options: PublicCodeLensSuppressOptions): IAmDisposable;
 }
 
 export interface PublicCodeLensSuppressOptions {

--- a/src/extension/code_lens/flutter_dartpad_samples.ts
+++ b/src/extension/code_lens/flutter_dartpad_samples.ts
@@ -72,7 +72,7 @@ export class FlutterDartPadSamplesCodeLensProvider implements CodeLensProvider, 
 			));
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/code_lens/main_code_lens_provider.ts
+++ b/src/extension/code_lens/main_code_lens_provider.ts
@@ -75,7 +75,7 @@ export class MainCodeLensProvider implements CodeLensProvider, IAmDisposable {
 		);
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/code_lens/test_code_lens_provider.ts
+++ b/src/extension/code_lens/test_code_lens_provider.ts
@@ -77,7 +77,7 @@ export class TestCodeLensProvider implements CodeLensProvider, IAmDisposable {
 		);
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/commands/add_sdk_to_path.ts
+++ b/src/extension/commands/add_sdk_to_path.ts
@@ -170,7 +170,7 @@ export class AddSdkToPathCommands extends AddSdkToPath implements IAmDisposable 
 		}));
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/commands/debug.ts
+++ b/src/extension/commands/debug.ts
@@ -57,7 +57,7 @@ export class LastTestDebugSession {
 }
 
 export class DebugCommands implements IAmDisposable {
-	protected readonly disposables: vs.Disposable[] = [];
+	protected readonly disposables: IAmDisposable[] = [];
 	private debugOptions = vs.window.createStatusBarItem("dartStatusDebugOptions", vs.StatusBarAlignment.Left, 0);
 	public currentDebugOption = DebugOption.MyCode;
 	private debugMetrics = vs.window.createStatusBarItem("dartStatusDebugMetrics", vs.StatusBarAlignment.Right, 0);
@@ -1064,7 +1064,7 @@ export class DebugCommands implements IAmDisposable {
 		void vs.commands.executeCommand("setContext", CURRENT_FILE_RUNNABLE, isRunnable);
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/commands/edit.ts
+++ b/src/extension/commands/edit.ts
@@ -1,14 +1,16 @@
 import * as vs from "vscode";
 import { dartRecommendedConfig, openSettingsAction } from "../../shared/constants";
+import { IAmDisposable } from "../../shared/interfaces";
+import { disposeAll } from "../../shared/utils";
 import { getActiveRealFileEditor } from "../../shared/vscode/editors";
 import { firstEditorColumn, showCode } from "../../shared/vscode/utils";
 import { writeToPseudoTerminal } from "../utils/vscode/terminals";
 
-export class EditCommands implements vs.Disposable {
-	private commands: vs.Disposable[] = [];
+export class EditCommands implements IAmDisposable {
+	private disposables: IAmDisposable[] = [];
 
 	constructor() {
-		this.commands.push(
+		this.disposables.push(
 			vs.commands.registerCommand("_dart.jumpToLineColInUri", this.jumpToLineColInUri.bind(this)),
 			vs.commands.registerCommand("_dart.showCode", showCode),
 			vs.commands.registerCommand("dart.writeRecommendedSettings", this.writeRecommendedSettings.bind(this)),
@@ -214,8 +216,7 @@ export class EditCommands implements vs.Disposable {
 		});
 	}
 
-	public dispose(): any {
-		for (const command of this.commands)
-			command.dispose();
+	public dispose(): void {
+		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/commands/logging.ts
+++ b/src/extension/commands/logging.ts
@@ -3,15 +3,16 @@ import * as vs from "vscode";
 import { captureLogsMaxLineLength } from "../../shared/constants";
 import { DART_IS_CAPTURING_LOGS_CONTEXT } from "../../shared/constants.contexts";
 import { LogCategory } from "../../shared/enums";
+import { IAmDisposable } from "../../shared/interfaces";
 import { captureLogs, EmittingLogger } from "../../shared/logging";
-import { PromiseCompleter } from "../../shared/utils";
+import { disposeAll, PromiseCompleter } from "../../shared/utils";
 import { createFolderForFile, forceWindowsDriveLetterToUppercase, fsPath } from "../../shared/utils/fs";
 import { analysisServerLogCategories, debuggingLogCategories, extensionsLogCategories, getExtensionLogPath, getLogHeader, userSelectableLogCategories } from "../utils/log";
 
 export let isLogging = false;
 
-export class LoggingCommands implements vs.Disposable {
-	private disposables: vs.Disposable[] = [];
+export class LoggingCommands implements IAmDisposable {
+	private disposables: IAmDisposable[] = [];
 	private currentLogCompleter: PromiseCompleter<void> | undefined;
 	private onCaptureLogsEmitter = new vs.EventEmitter<boolean>();
 	public readonly onCaptureLogs = this.onCaptureLogsEmitter.event;
@@ -116,8 +117,7 @@ export class LoggingCommands implements vs.Disposable {
 		return `Dart-Code-Log-${formattedDate}.txt`;
 	}
 
-	public dispose(): any {
-		for (const command of this.disposables)
-			command.dispose();
+	public dispose(): void {
+		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/commands/open_in_other_editors.ts
+++ b/src/extension/commands/open_in_other_editors.ts
@@ -2,13 +2,14 @@ import * as fs from "fs";
 import * as path from "path";
 import * as vs from "vscode";
 import { androidStudioPaths, isMac } from "../../shared/constants";
-import { Logger, Sdks } from "../../shared/interfaces";
+import { IAmDisposable, Logger, Sdks } from "../../shared/interfaces";
+import { disposeAll } from "../../shared/utils";
 import { fsPath } from "../../shared/utils/fs";
 import { getFlutterConfigValue } from "../utils/misc";
 import { safeToolSpawn } from "../utils/processes";
 
-export class OpenInOtherEditorCommands implements vs.Disposable {
-	private disposables: vs.Disposable[] = [];
+export class OpenInOtherEditorCommands implements IAmDisposable {
+	private disposables: IAmDisposable[] = [];
 
 	constructor(private readonly logger: Logger, private readonly sdks: Sdks) {
 
@@ -66,8 +67,7 @@ export class OpenInOtherEditorCommands implements vs.Disposable {
 		return getFlutterConfigValue(this.logger, this.sdks.flutter, folder, "android-studio-dir");
 	}
 
-	public dispose(): any {
-		for (const command of this.disposables)
-			command.dispose();
+	public dispose(): void {
+		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/commands/sdk.ts
+++ b/src/extension/commands/sdk.ts
@@ -28,7 +28,7 @@ export const commandState = {
 
 export class BaseSdkCommands implements IAmDisposable {
 	protected readonly sdks: DartSdks;
-	protected readonly disposables: vs.Disposable[] = [];
+	protected readonly disposables: IAmDisposable[] = [];
 
 	// A map of any in-progress commands so we can terminate them if we want to run another.
 	private runningCommands: Record<string, ChainedProcess | undefined> = {};
@@ -156,7 +156,7 @@ export class BaseSdkCommands implements IAmDisposable {
 		}, (progress, token) => runWithProgress(progress, token));
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/commands/settings.ts
+++ b/src/extension/commands/settings.ts
@@ -1,10 +1,10 @@
 import * as vs from "vscode";
-import { Logger } from "../../shared/interfaces";
+import { IAmDisposable, Logger } from "../../shared/interfaces";
 import { disposeAll } from "../../shared/utils";
 import { WorkspaceContext } from "../../shared/workspace";
 
-export class SettingsCommands implements vs.Disposable {
-	private disposables: vs.Disposable[] = [];
+export class SettingsCommands implements IAmDisposable {
+	private disposables: IAmDisposable[] = [];
 
 	constructor(protected readonly logger: Logger, protected readonly wsContext: WorkspaceContext) {
 		this.disposables.push(vs.commands.registerCommand("_dart.settings.openDevToolsLocationSetting", () => this.openSettings("dart.devToolsLocation", true)));
@@ -24,7 +24,7 @@ export class SettingsCommands implements vs.Disposable {
 		}
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/commands/test.ts
+++ b/src/extension/commands/test.ts
@@ -6,7 +6,7 @@ import { DartCapabilities } from "../../shared/capabilities/dart";
 import { DartTestCapabilities } from "../../shared/capabilities/dart_test";
 import { FlutterCapabilities } from "../../shared/capabilities/flutter";
 import { noAction } from "../../shared/constants";
-import { Logger } from "../../shared/interfaces";
+import { IAmDisposable, Logger } from "../../shared/interfaces";
 import { RunnableTreeNode, SuiteData, SuiteNode, TestNode, TreeNode } from "../../shared/test/test_model";
 import { getPackageTestCapabilitiesForDartProject } from "../../shared/test/version";
 import { disposeAll, escapeDartString, generateTestNameFromFileName, uniq } from "../../shared/utils";
@@ -29,8 +29,8 @@ export let isInTestFileThatHasImplementation = false;
 export let isInImplementationFileThatCanHaveTest = false;
 
 
-export class TestCommands implements vs.Disposable {
-	private disposables: vs.Disposable[] = [];
+export class TestCommands implements IAmDisposable {
+	private disposables: IAmDisposable[] = [];
 
 	constructor(protected readonly logger: Logger, protected readonly wsContext: WorkspaceContext, private readonly vsCodeTestController: VsCodeTestController | undefined, protected readonly dartCapabilities: DartCapabilities, protected readonly flutterCapabilities: FlutterCapabilities) {
 		this.disposables.push(
@@ -193,7 +193,7 @@ export class TestCommands implements vs.Disposable {
 			}
 		}
 
-		const subs: vs.Disposable[] = [];
+		const subs: IAmDisposable[] = [];
 		return new Promise<boolean>(async (resolve) => {
 			const launchConfiguration = {
 				suppressPrompts,
@@ -408,7 +408,7 @@ export class TestCommands implements vs.Disposable {
 		return candidates;
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/dart/tooling_daemon.ts
+++ b/src/extension/dart/tooling_daemon.ts
@@ -366,7 +366,7 @@ class EditorServices implements IAmDisposable {
 		]);
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 

--- a/src/extension/decorations/flutter_icon_decorations.ts
+++ b/src/extension/decorations/flutter_icon_decorations.ts
@@ -1,6 +1,6 @@
 import * as vs from "vscode";
 import { FlutterOutline } from "../../shared/analysis/lsp/custom_protocol";
-import { Logger } from "../../shared/interfaces";
+import { IAmDisposable, Logger } from "../../shared/interfaces";
 import { disposeAll } from "../../shared/utils";
 import { fsPath } from "../../shared/utils/fs";
 import { docsIconPathFormat } from "../../shared/vscode/extension_utils";
@@ -8,8 +8,8 @@ import { IconRangeComputerLsp } from "../../shared/vscode/icon_range_computer";
 import { LspAnalyzer } from "../analysis/analyzer";
 import { isAnalyzable } from "../utils";
 
-export class FlutterIconDecorations implements vs.Disposable {
-	protected readonly subscriptions: vs.Disposable[] = [];
+export class FlutterIconDecorations implements IAmDisposable {
+	protected readonly subscriptions: IAmDisposable[] = [];
 	protected activeEditor?: vs.TextEditor;
 	private readonly decorationTypes: Record<string, vs.TextEditorDecorationType> = {};
 	private readonly computer: IconRangeComputerLsp;

--- a/src/extension/decorations/flutter_ui_guides_decorations.ts
+++ b/src/extension/decorations/flutter_ui_guides_decorations.ts
@@ -1,5 +1,6 @@
 import * as vs from "vscode";
 import * as lsp from "../../shared/analysis/lsp/custom_protocol";
+import { IAmDisposable } from "../../shared/interfaces";
 import { disposeAll, flatMap } from "../../shared/utils";
 import { fsPath } from "../../shared/utils/fs";
 import { SingleDocumentPositionTracker } from "../../shared/vscode/trackers";
@@ -13,8 +14,8 @@ const horizontalLine = "─";
 const bottomCorner = "╰";
 const middleCorner = "├";
 
-export class FlutterUiGuideDecorations implements vs.Disposable {
-	protected disposables: vs.Disposable[] = [];
+export class FlutterUiGuideDecorations implements IAmDisposable {
+	protected disposables: IAmDisposable[] = [];
 	protected tracker: WidgetGuideTracker | undefined;
 
 	private readonly borderDecoration = vs.window.createTextEditorDecorationType({
@@ -198,8 +199,8 @@ class WidgetGuide {
 	constructor(public readonly start: vs.Position, public readonly end: vs.Position) { }
 }
 
-class WidgetGuideTracker implements vs.Disposable {
-	private readonly disposables: vs.Disposable[] = [];
+class WidgetGuideTracker implements IAmDisposable {
+	private readonly disposables: IAmDisposable[] = [];
 	private readonly tracker: SingleDocumentPositionTracker = new SingleDocumentPositionTracker();
 	private readonly guideMap: Map<WidgetGuide, [vs.Position, vs.Position]> = new Map<WidgetGuide, [vs.Position, vs.Position]>();
 

--- a/src/extension/diagnostic_report.ts
+++ b/src/extension/diagnostic_report.ts
@@ -9,7 +9,7 @@ import { getLogHeader } from "./utils/log";
 import { runToolProcess } from "./utils/processes";
 
 export class DiagnosticReport implements IAmDisposable {
-	protected readonly disposables: vs.Disposable[] = [];
+	protected readonly disposables: IAmDisposable[] = [];
 
 	private readonly output: string[] = [];
 
@@ -113,7 +113,7 @@ ${results.stderr.trim()}
 		this.report(undefined);
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -8,7 +8,7 @@ import { ExtensionRestartReason, dartCodeConfigurationPathEnvironmentVariableNam
 import { DART_PLATFORM_NAME, DART_PROJECT_LOADED, FLUTTER_PROJECT_LOADED, FLUTTER_PROPERTY_EDITOR_SUPPORTED_CONTEXT, FLUTTER_SUPPORTS_ATTACH, GO_TO_IMPORTS_SUPPORTED_CONTEXT, IS_RUNNING_LOCALLY_CONTEXT, OBSERVATORY_SUPPORTED_CONTEXT, PROJECT_LOADED, SDK_IS_PRE_RELEASE, WEB_PROJECT_LOADED } from "../shared/constants.contexts";
 import { LogCategory } from "../shared/enums";
 import { WebClient } from "../shared/fetch";
-import { DartWorkspaceContext, FlutterSdks, FlutterWorkspaceContext, IAmDisposable, IFlutterDaemon, Logger, WritableWorkspaceConfig } from "../shared/interfaces";
+import { DartWorkspaceContext, FlutterSdks, FlutterWorkspaceContext, IAmDisposable, IAmDisposableAsync, IFlutterDaemon, Logger, WritableWorkspaceConfig } from "../shared/interfaces";
 import { EmittingLogger, RingLog, captureLogs, logToConsole } from "../shared/logging";
 import { PubApi } from "../shared/pub/api";
 import { internalApiSymbol } from "../shared/symbols";
@@ -114,7 +114,7 @@ let extensionThisSessionStart = extensionTotalSessionStart; // Reset during ever
 let previousSettingsObject: Record<string, string | number | boolean | undefined> | undefined;
 let experiments: KnownExperiments;
 
-const loggers: IAmDisposable[] = [];
+const loggers: IAmDisposableAsync[] = [];
 let ringLogger: IAmDisposable | undefined;
 const logger = new EmittingLogger();
 let extensionLog: IAmDisposable | undefined;
@@ -382,7 +382,7 @@ export async function activate(context: vs.ExtensionContext, isRestart = false) 
 
 		// Analysis ends for the first time.
 		if (!status.isAnalyzing && analysisStartTime) {
-			void analysisCompleteEvents.dispose();
+			analysisCompleteEvents.dispose();
 		}
 	});
 

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -14,7 +14,7 @@ import { PubApi } from "../shared/pub/api";
 import { internalApiSymbol } from "../shared/symbols";
 import { TestSessionCoordinator } from "../shared/test/coordinator";
 import { TestModel } from "../shared/test/test_model";
-import { disposeAll, withTimeout } from "../shared/utils";
+import { disposeAllAsync, withTimeout } from "../shared/utils";
 import { fsPath, getRandomInt } from "../shared/utils/fs";
 import { AutoLaunch } from "../shared/vscode/autolaunch";
 import { DART_LANGUAGE, DART_MODE } from "../shared/vscode/constants";
@@ -159,7 +159,7 @@ export async function activate(context: vs.ExtensionContext, isRestart = false) 
 		logger.warn(`Performing extension reload (${reason}, ${data})...`);
 		analytics.logExtensionRestart(reason, data);
 		await deactivate(true, reason);
-		disposeAll(context.subscriptions);
+		await disposeAllAsync(context.subscriptions);
 		await activate(context, true);
 		logger.info("Done reloading extension!");
 	}));

--- a/src/extension/flutter/flutter_daemon.ts
+++ b/src/extension/flutter/flutter_daemon.ts
@@ -162,13 +162,13 @@ export class FlutterDaemon extends StdIOService<UnknownNotification> implements 
 		});
 	}
 
-	public dispose() {
+	public async dispose(): Promise<void> {
 		this.isShuttingDown = true;
 
 		if (this.pingIntervalId)
 			clearInterval(this.pingIntervalId);
 
-		super.dispose();
+		await super.dispose();
 	}
 
 	protected sendMessage(json: string) {

--- a/src/extension/flutter/flutter_daemon.ts
+++ b/src/extension/flutter/flutter_daemon.ts
@@ -7,7 +7,7 @@ import { ExtensionRestartReason, flutterPath, isChromeOS, isDartCodeTestRun, isM
 import { FLUTTER_SUPPORTS_ATTACH } from "../../shared/constants.contexts";
 import { LogCategory } from "../../shared/enums";
 import * as f from "../../shared/flutter/daemon_interfaces";
-import { FlutterWorkspaceContext, IFlutterDaemon, Logger, SpawnedProcess } from "../../shared/interfaces";
+import { FlutterWorkspaceContext, IAmDisposable, IFlutterDaemon, Logger, SpawnedProcess } from "../../shared/interfaces";
 import { CategoryLogger, logProcess } from "../../shared/logging";
 import { UnknownNotification, UnknownResponse } from "../../shared/services/interfaces";
 import { StdIOService } from "../../shared/services/stdio_service";
@@ -394,27 +394,27 @@ export class FlutterDaemon extends StdIOService<UnknownNotification> implements 
 
 	// Subscription methods.
 
-	public registerForDaemonConnected(subscriber: (notification: f.DaemonConnected) => void): vs.Disposable {
+	public registerForDaemonConnected(subscriber: (notification: f.DaemonConnected) => void): IAmDisposable {
 		return this.subscribe(this.daemonConnectedSubscriptions, subscriber);
 	}
 
-	public registerForDeviceAdded(subscriber: (notification: f.Device) => void): vs.Disposable {
+	public registerForDeviceAdded(subscriber: (notification: f.Device) => void): IAmDisposable {
 		return this.subscribe(this.deviceAddedSubscriptions, subscriber);
 	}
 
-	public registerForDeviceRemoved(subscriber: (notification: f.Device) => void): vs.Disposable {
+	public registerForDeviceRemoved(subscriber: (notification: f.Device) => void): IAmDisposable {
 		return this.subscribe(this.deviceRemovedSubscriptions, subscriber);
 	}
 
-	public registerForDaemonLogMessage(subscriber: (notification: f.DaemonLogMessage) => void): vs.Disposable {
+	public registerForDaemonLogMessage(subscriber: (notification: f.DaemonLogMessage) => void): IAmDisposable {
 		return this.subscribe(this.daemonLogMessageSubscriptions, subscriber);
 	}
 
-	public registerForDaemonLog(subscriber: (notification: f.DaemonLog) => void): vs.Disposable {
+	public registerForDaemonLog(subscriber: (notification: f.DaemonLog) => void): IAmDisposable {
 		return this.subscribe(this.daemonLogSubscriptions, subscriber);
 	}
 
-	public registerForDaemonShowMessage(subscriber: (notification: f.ShowMessage) => void): vs.Disposable {
+	public registerForDaemonShowMessage(subscriber: (notification: f.ShowMessage) => void): IAmDisposable {
 		return this.subscribe(this.daemonShowMessageSubscriptions, subscriber);
 	}
 }

--- a/src/extension/flutter/flutter_outline_view.ts
+++ b/src/extension/flutter/flutter_outline_view.ts
@@ -3,7 +3,7 @@ import * as vs from "vscode";
 import * as lsp from "vscode-languageclient";
 import { FlutterOutline } from "../../shared/analysis/lsp/custom_protocol";
 import { LogCategory } from "../../shared/enums";
-import { Logger } from "../../shared/interfaces";
+import { IAmDisposable, Logger } from "../../shared/interfaces";
 import { nullLogger } from "../../shared/logging";
 import { disposeAll } from "../../shared/utils";
 import { fsPath } from "../../shared/utils/fs";
@@ -18,8 +18,8 @@ const DART_SHOW_FLUTTER_OUTLINE = "dart-code:showFlutterOutline";
 const WIDGET_SELECTED_CONTEXT = "dart-code:isSelectedWidget";
 const WIDGET_SUPPORTS_CONTEXT_PREFIX = "dart-code:widgetSupports:";
 
-export class FlutterOutlineProvider implements vs.TreeDataProvider<FlutterWidgetItem>, vs.Disposable {
-	protected subscriptions: vs.Disposable[] = [];
+export class FlutterOutlineProvider implements vs.TreeDataProvider<FlutterWidgetItem>, IAmDisposable {
+	protected subscriptions: IAmDisposable[] = [];
 	protected activeEditor: vs.TextEditor | undefined;
 	protected flutterOutline: FlutterOutline | undefined;
 	protected rootNode: FlutterWidgetItem | undefined;

--- a/src/extension/flutter/widget_preview/webviews.ts
+++ b/src/extension/flutter/widget_preview/webviews.ts
@@ -164,7 +164,7 @@ export class WidgetPreviewEmbeddedView extends WidgetPreviewView {
 }
 
 export class WidgetPreviewSidebarView extends WidgetPreviewView {
-	protected readonly disposables: vs.Disposable[] = [];
+	protected readonly disposables: IAmDisposable[] = [];
 	protected readonly webViewProvider: WidgetPreviewSidebarViewProvider;
 
 	constructor(
@@ -192,7 +192,7 @@ export class WidgetPreviewSidebarView extends WidgetPreviewView {
 }
 
 class WidgetPreviewSidebarViewProvider implements vs.WebviewViewProvider {
-	protected readonly disposables: vs.Disposable[] = [];
+	protected readonly disposables: IAmDisposable[] = [];
 	public webviewView: vs.WebviewView | undefined;
 	private onDidResolveEmitter = new vs.EventEmitter<void>();
 	public readonly onDidResolve = this.onDidResolveEmitter.event;

--- a/src/extension/flutter/widget_preview/widget_preview_manager.ts
+++ b/src/extension/flutter/widget_preview/widget_preview_manager.ts
@@ -10,7 +10,7 @@ import { WidgetPreviewEmbeddedView, WidgetPreviewSidebarView, WidgetPreviewView 
  * Manages Flutter Widget Preview functionality.
  */
 export class FlutterWidgetPreviewManager implements IAmDisposable {
-	private readonly disposables: vs.Disposable[] = [];
+	private readonly disposables: IAmDisposable[] = [];
 	private server: FlutterWidgetPreviewServer | undefined;
 	private serverCompleter = new PromiseCompleter<FlutterWidgetPreviewServer>();
 	private view?: WidgetPreviewView;

--- a/src/extension/lsp/closing_labels_decorations.ts
+++ b/src/extension/lsp/closing_labels_decorations.ts
@@ -1,6 +1,7 @@
 import * as vs from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { ClosingLabelsParams, PublishClosingLabelsNotification } from "../../shared/analysis/lsp/custom_protocol";
+import { IAmDisposable } from "../../shared/interfaces";
 import { disposeAll } from "../../shared/utils";
 import { DocumentCache } from "../../shared/utils/document_cache";
 import { findVisibleEditor } from "../../shared/vscode/editors";
@@ -8,8 +9,8 @@ import { config } from "../config";
 
 const validLastCharacters = [")", "]"];
 
-export class LspClosingLabelsDecorations implements vs.Disposable {
-	private subscriptions: vs.Disposable[] = [];
+export class LspClosingLabelsDecorations implements IAmDisposable {
+	private subscriptions: IAmDisposable[] = [];
 	private closingLabels = new DocumentCache<ClosingLabelsParams>();
 	private editors = new DocumentCache<vs.TextEditor>();
 	private updateTimeouts = new DocumentCache<NodeJS.Timeout>();

--- a/src/extension/lsp/go_to.ts
+++ b/src/extension/lsp/go_to.ts
@@ -1,13 +1,14 @@
 import * as vs from "vscode";
 import * as ls from "vscode-languageclient";
+import { IAmDisposable } from "../../shared/interfaces";
 import { disposeAll } from "../../shared/utils";
 import { uriComparisonString } from "../../shared/utils/fs";
 import * as editors from "../../shared/vscode/editors";
 import { showCode } from "../../shared/vscode/utils";
 import { LspAnalyzer } from "../analysis/analyzer";
 
-abstract class LspGoToCommand implements vs.Disposable {
-	protected disposables: vs.Disposable[] = [];
+abstract class LspGoToCommand implements IAmDisposable {
+	protected disposables: IAmDisposable[] = [];
 
 	abstract get failureMessage(): string;
 
@@ -21,7 +22,7 @@ abstract class LspGoToCommand implements vs.Disposable {
 		void vs.commands.executeCommand("editor.action.goToLocations", sourceUri, sourcePosition, codeLocations, "gotoAndPeek", this.failureMessage);
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }
@@ -53,7 +54,7 @@ abstract class LspGoToRequestCommand extends LspGoToCommand {
 
 	abstract getLocations(params: ls.TextDocumentPositionParams): Promise<ls.Location | ls.Location[] | null>;
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }
@@ -113,8 +114,8 @@ export class LspGoToAugmentationCommand extends LspGoToRequestCommand {
 /**
  * Supports the dart.goToLocation command that the LSP server may use.
  */
-export class LspGoToLocationCommand implements vs.Disposable {
-	protected disposables: vs.Disposable[] = [];
+export class LspGoToLocationCommand implements IAmDisposable {
+	protected disposables: IAmDisposable[] = [];
 
 	constructor(protected readonly analyzer: LspAnalyzer) {
 		this.disposables.push(vs.commands.registerCommand("dart.goToLocation", this.goToLocation.bind(this)));
@@ -138,7 +139,7 @@ export class LspGoToLocationCommand implements vs.Disposable {
 		showCode(editor, codeLocation.range, codeLocation.range, codeLocation.range);
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/lsp/test_discoverer.ts
+++ b/src/extension/lsp/test_discoverer.ts
@@ -172,7 +172,7 @@ export class TestDiscoverer implements IAmDisposable {
 		}
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/providers/dart_language_configuration.ts
+++ b/src/extension/providers/dart_language_configuration.ts
@@ -1,10 +1,11 @@
-import { Disposable, IndentAction, LanguageConfiguration, languages, OnEnterRule, workspace } from "vscode";
+import { IndentAction, LanguageConfiguration, languages, OnEnterRule, workspace } from "vscode";
+import { IAmDisposable } from "../../shared/interfaces";
 import { config } from "../config";
 
 export class DartLanguageConfiguration implements LanguageConfiguration {
-	public static register(language: string): Disposable {
+	public static register(language: string): IAmDisposable {
 		// Track the current active subscription for the language config.
-		let subscription: Disposable | undefined;
+		let subscription: IAmDisposable | undefined;
 
 		// Helper to register the current language config, unregistering
 		// any existing config first.

--- a/src/extension/providers/debug_adapter_hex_view_factory.ts
+++ b/src/extension/providers/debug_adapter_hex_view_factory.ts
@@ -39,7 +39,7 @@ export class DartDebugAdapterHexViewFactory implements vs.DebugAdapterTrackerFac
 		await Promise.all([...this.hexFormatters].map((formatter) => formatter.invalidate()));
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		this.hexFormatters.clear();
 		disposeAll(this.disposables);
 	}

--- a/src/extension/providers/debug_adapter_logger_factory.ts
+++ b/src/extension/providers/debug_adapter_logger_factory.ts
@@ -1,6 +1,6 @@
 import { DebugAdapterTracker, DebugAdapterTrackerFactory, DebugSession } from "vscode";
 import { DebuggerType, LogCategory } from "../../shared/enums";
-import { IAmDisposable, Logger } from "../../shared/interfaces";
+import { IAmDisposableAsync, Logger } from "../../shared/interfaces";
 import { captureLogs, CategoryLogger, EmittingLogger } from "../../shared/logging";
 import { config } from "../config";
 import { insertSessionName } from "../utils";
@@ -16,7 +16,7 @@ export class DartDebugAdapterLoggerFactory implements DebugAdapterTrackerFactory
 
 class DartDebugAdapterLogger implements DebugAdapterTracker {
 	private logger: Logger;
-	private logFileDisposable: IAmDisposable | undefined;
+	private logFileDisposable: IAmDisposableAsync | undefined;
 
 	constructor(private readonly emittingLogger: EmittingLogger, private readonly session: DebugSession) {
 		this.logger = new CategoryLogger(emittingLogger, LogCategory.DAP);

--- a/src/extension/providers/mcp_server_definition_provider.ts
+++ b/src/extension/providers/mcp_server_definition_provider.ts
@@ -55,7 +55,7 @@ export class DartMcpServerDefinitionProvider implements vs.McpServerDefinitionPr
 		];
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/sdk/dev_tools/embedded_view.ts
+++ b/src/extension/sdk/dev_tools/embedded_view.ts
@@ -139,7 +139,7 @@ export abstract class DevToolsEmbeddedViewOrSidebarView implements IAmDisposable
 
 export class DevToolsEmbeddedView extends DevToolsEmbeddedViewOrSidebarView {
 	private readonly panel: vs.WebviewPanel;
-	private messageDisposable: vs.Disposable;
+	private messageDisposable: IAmDisposable;
 
 	constructor(
 		readonly logger: Logger,

--- a/src/extension/sdk/dev_tools/manager.ts
+++ b/src/extension/sdk/dev_tools/manager.ts
@@ -8,7 +8,7 @@ import { DevToolsServerCapabilities } from "../../../shared/capabilities/devtool
 import { FlutterCapabilities } from "../../../shared/capabilities/flutter";
 import { CommandSource, cpuProfilerPage, dartVMPath, devToolsHomePage, devToolsPages, devToolsToolLegacyPath, devToolsToolPath, isDartCodeTestRun, performancePage, twentySecondsInMs, widgetInspectorPage } from "../../../shared/constants";
 import { LogCategory, VmService } from "../../../shared/enums";
-import { DartWorkspaceContext, DevToolsPage, Logger } from "../../../shared/interfaces";
+import { DartWorkspaceContext, DevToolsPage, IAmDisposable, Logger } from "../../../shared/interfaces";
 import { CategoryLogger } from "../../../shared/logging";
 import { UnknownNotification } from "../../../shared/services/interfaces";
 import { StdIOService } from "../../../shared/services/stdio_service";
@@ -43,8 +43,8 @@ let portToBind: number | undefined;
 const devToolsEmbeddedViews: Record<string, DevToolsEmbeddedViewOrSidebarView[] | undefined> = {};
 
 /// Handles launching DevTools in the browser and managing the underlying service.
-export class DevToolsManager implements vs.Disposable {
-	private readonly disposables: vs.Disposable[] = [];
+export class DevToolsManager implements IAmDisposable {
+	private readonly disposables: IAmDisposable[] = [];
 	private readonly statusBarItem = getLanguageStatusItem("dart.devTools", ANALYSIS_FILTERS);
 	private service?: DevToolsService;
 	public debugCommands: DebugCommands | undefined;
@@ -751,7 +751,7 @@ class DevToolsService extends StdIOService<UnknownNotification> {
 
 	private serverStartedSubscriptions: Array<(notification: ServerStartedNotification) => void> = [];
 
-	public registerForServerStarted(subscriber: (notification: ServerStartedNotification) => void): vs.Disposable {
+	public registerForServerStarted(subscriber: (notification: ServerStartedNotification) => void): IAmDisposable {
 		return this.subscribe(this.serverStartedSubscriptions, subscriber);
 	}
 

--- a/src/extension/sdk/dev_tools/manager.ts
+++ b/src/extension/sdk/dev_tools/manager.ts
@@ -541,7 +541,7 @@ export class DevToolsManager implements IAmDisposable {
 		return new Promise<string>(async (resolve, reject) => {
 			if (this.service) {
 				try {
-					this.service.dispose();
+					await this.service.dispose();
 					this.service = undefined;
 					this.devtoolsUrl = undefined;
 				} catch (e) {

--- a/src/extension/sdk/status_bar_version_tracker.ts
+++ b/src/extension/sdk/status_bar_version_tracker.ts
@@ -1,13 +1,13 @@
-import * as vs from "vscode";
 import { MAX_VERSION, MISSING_VERSION_FILE_VERSION } from "../../shared/constants";
+import { IAmDisposable } from "../../shared/interfaces";
 import { disposeAll } from "../../shared/utils";
 import { ANALYSIS_FILTERS } from "../../shared/vscode/constants";
 import { getLanguageStatusItem } from "../../shared/vscode/status_bar";
 import { WorkspaceContext } from "../../shared/workspace";
 import { config } from "../config";
 
-export class StatusBarVersionTracker implements vs.Disposable {
-	private disposables: vs.Disposable[] = [];
+export class StatusBarVersionTracker implements IAmDisposable {
+	private disposables: IAmDisposable[] = [];
 
 	constructor(workspaceContext: WorkspaceContext) {
 		const isFlutter = workspaceContext.hasAnyFlutterProjects;

--- a/src/extension/test/vs_test_controller.ts
+++ b/src/extension/test/vs_test_controller.ts
@@ -596,7 +596,7 @@ export class VsCodeTestController implements TestEventListener, IAmDisposable {
 		].join("\n").trim();
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/views/devtools/base_view_provider.ts
+++ b/src/extension/views/devtools/base_view_provider.ts
@@ -1,6 +1,6 @@
 import * as vs from "vscode";
 import { DartCapabilities } from "../../../shared/capabilities/dart";
-import { Logger } from "../../../shared/interfaces";
+import { IAmDisposable, Logger } from "../../../shared/interfaces";
 import { disposeAll } from "../../../shared/utils";
 import { envUtils } from "../../../shared/vscode/utils";
 import { perSessionWebviewStateKey } from "../../extension";
@@ -8,7 +8,7 @@ import { DevToolsManager } from "../../sdk/dev_tools/manager";
 import { exposeWebViewUrls, handleUrlAuthFunction, WebViewUrls } from "../shared";
 
 export abstract class MyBaseWebViewProvider implements vs.WebviewViewProvider {
-	protected readonly disposables: vs.Disposable[] = [];
+	protected readonly disposables: IAmDisposable[] = [];
 	public webviewView: vs.WebviewView | undefined;
 
 	constructor(
@@ -210,7 +210,7 @@ export abstract class MyBaseWebViewProvider implements vs.WebviewViewProvider {
 			`;
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/views/devtools/legacy_post_message_sidebar/dart_tooling_api.ts
+++ b/src/extension/views/devtools/legacy_post_message_sidebar/dart_tooling_api.ts
@@ -14,7 +14,7 @@ import { VsCodeApi, VsCodeCapabilities, VsCodeDebugSession, VsCodeDebugSessionsE
 const apiDebugMode = false;
 
 export class DartApi implements IAmDisposable {
-	protected readonly disposables: vs.Disposable[] = [];
+	protected readonly disposables: IAmDisposable[] = [];
 	private apis: Record<string, ToolApi> = {};
 
 	constructor(readonly commandSource: string, onReceiveMessage: vs.Event<any>, private readonly post: (message: any) => void, private readonly deviceManager: FlutterDeviceManager | undefined) {
@@ -57,14 +57,14 @@ export class DartApi implements IAmDisposable {
 		}
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 		disposeAll(Object.values(this.apis));
 	}
 }
 
 abstract class ToolApi {
-	protected readonly disposables: vs.Disposable[] = [];
+	protected readonly disposables: IAmDisposable[] = [];
 	abstract apiName: string;
 
 	constructor(private readonly dartApi: DartApi) { }
@@ -75,7 +75,7 @@ abstract class ToolApi {
 		this.dartApi.postMessage({ method: `${this.apiName}.${method}`, params });
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }
@@ -131,7 +131,7 @@ class VsCodeApiImpl implements VsCodeApi, IAmDisposable {
 	public readonly devicesChanged = this.devicesChangedEmitter.event;
 	protected readonly debugSessionsChangedEmitter = new vs.EventEmitter<VsCodeDebugSessionsEvent>();
 	public readonly debugSessionsChanged = this.debugSessionsChangedEmitter.event;
-	protected readonly disposables: vs.Disposable[] = [];
+	protected readonly disposables: IAmDisposable[] = [];
 
 	constructor(private readonly commandSource: string, private readonly deviceManager: FlutterDeviceManager | undefined) {
 		if (deviceManager) {
@@ -254,7 +254,7 @@ class VsCodeApiImpl implements VsCodeApi, IAmDisposable {
 		};
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/views/devtools/legacy_post_message_sidebar/sidebar.ts
+++ b/src/extension/views/devtools/legacy_post_message_sidebar/sidebar.ts
@@ -10,7 +10,7 @@ import { DevToolsManager } from "../../../sdk/dev_tools/manager";
 import { DartApi } from "./dart_tooling_api";
 
 export class FlutterPostMessageSidebar implements IAmDisposable {
-	protected readonly disposables: vs.Disposable[] = [];
+	protected readonly disposables: IAmDisposable[] = [];
 
 	constructor(
 		devTools: DevToolsManager,
@@ -23,13 +23,13 @@ export class FlutterPostMessageSidebar implements IAmDisposable {
 		this.disposables.push(vs.window.registerWebviewViewProvider("dartFlutterSidebar", webViewProvider, { webviewOptions: { retainContextWhenHidden: true } }));
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }
 
 class MyWebViewProvider implements vs.WebviewViewProvider, IAmDisposable {
-	protected readonly disposables: vs.Disposable[] = [];
+	protected readonly disposables: IAmDisposable[] = [];
 
 	public webviewView: vs.WebviewView | undefined;
 	private api: DartApi | undefined;
@@ -40,7 +40,7 @@ class MyWebViewProvider implements vs.WebviewViewProvider, IAmDisposable {
 		private readonly logger: Logger,
 	) { }
 
-	public dispose(): any {
+	public dispose(): void {
 		this.api?.dispose();
 		disposeAll(this.disposables);
 	}

--- a/src/extension/views/devtools/property_editor.ts
+++ b/src/extension/views/devtools/property_editor.ts
@@ -6,7 +6,7 @@ import { DevToolsManager } from "../../sdk/dev_tools/manager";
 import { MySimpleBaseWebViewProvider } from "./base_view_provider";
 
 export class PropertyEditor implements IAmDisposable {
-	protected readonly disposables: vs.Disposable[] = [];
+	protected readonly disposables: IAmDisposable[] = [];
 
 	constructor(
 		devTools: DevToolsManager,
@@ -18,7 +18,7 @@ export class PropertyEditor implements IAmDisposable {
 		this.disposables.push(vs.window.registerWebviewViewProvider("flutterPropertyEditor", webViewProvider, { webviewOptions: { retainContextWhenHidden: true } }));
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/views/devtools/sidebar.ts
+++ b/src/extension/views/devtools/sidebar.ts
@@ -6,7 +6,7 @@ import { DevToolsManager } from "../../sdk/dev_tools/manager";
 import { MySimpleBaseWebViewProvider } from "./base_view_provider";
 
 export class FlutterDtdSidebar implements IAmDisposable {
-	protected readonly disposables: vs.Disposable[] = [];
+	protected readonly disposables: IAmDisposable[] = [];
 
 	constructor(
 		devTools: DevToolsManager,
@@ -18,7 +18,7 @@ export class FlutterDtdSidebar implements IAmDisposable {
 		this.disposables.push(vs.window.registerWebviewViewProvider("dartFlutterSidebar", webViewProvider, { webviewOptions: { retainContextWhenHidden: true } }));
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/views/devtools/sidebar_devtools.ts
+++ b/src/extension/views/devtools/sidebar_devtools.ts
@@ -2,7 +2,7 @@ import * as vs from "vscode";
 import { DartCapabilities } from "../../../shared/capabilities/dart";
 import { CommandSource } from "../../../shared/constants";
 import { SIDEBAR_DEVTOOLS_AVAILABLE_PREFIX } from "../../../shared/constants.contexts";
-import { DevToolsPage, Logger } from "../../../shared/interfaces";
+import { DevToolsPage, IAmDisposable, Logger } from "../../../shared/interfaces";
 import { disposeAll } from "../../../shared/utils";
 import { DevToolsEmbeddedViewOrSidebarView } from "../../sdk/dev_tools/embedded_view";
 import { DevToolsManager } from "../../sdk/dev_tools/manager";
@@ -10,7 +10,7 @@ import { WebViewUrls } from "../shared";
 import { MyBaseWebViewProvider } from "./base_view_provider";
 
 export class SidebarDevTools extends DevToolsEmbeddedViewOrSidebarView {
-	protected readonly disposables: vs.Disposable[] = [];
+	protected readonly disposables: IAmDisposable[] = [];
 	protected readonly webViewProvider: MyWebViewProvider;
 
 	/// Whether the frame has ever been loaded.
@@ -90,7 +90,7 @@ export class SidebarDevTools extends DevToolsEmbeddedViewOrSidebarView {
 		await this.webViewProvider.reload();
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/extension/views/packages_view.ts
+++ b/src/extension/views/packages_view.ts
@@ -12,7 +12,7 @@ import { envUtils, ProjectFinder } from "../../shared/vscode/utils";
 import { config } from "../config";
 
 export class DartPackagesProvider implements vs.TreeDataProvider<PackageDep>, IAmDisposable {
-	protected readonly disposables: vs.Disposable[] = [];
+	protected readonly disposables: IAmDisposable[] = [];
 	private onDidChangeTreeDataEmitter: vs.EventEmitter<PackageDep | undefined> = new vs.EventEmitter<PackageDep | undefined>();
 	public readonly onDidChangeTreeData: vs.Event<PackageDep | undefined> = this.onDidChangeTreeDataEmitter.event;
 	public readonly deps: PubDeps;
@@ -155,7 +155,7 @@ export class DartPackagesProvider implements vs.TreeDataProvider<PackageDep>, IA
 		}
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/shared/analyzer.ts
+++ b/src/shared/analyzer.ts
@@ -1,10 +1,10 @@
 import { EventEmitter } from "./events";
-import { IAmDisposable, Logger } from "./interfaces";
-import { PromiseCompleter, disposeAll } from "./utils";
+import { IAmDisposableAsync, Logger } from "./interfaces";
+import { PromiseCompleter, disposeAllAsync } from "./utils";
 import { resolvedPromise } from "./utils/promises";
 
-export abstract class Analyzer implements IAmDisposable {
-	protected disposables: IAmDisposable[] = [];
+export abstract class Analyzer implements IAmDisposableAsync {
+	protected disposables: IAmDisposableAsync[] = [];
 
 	protected readonly onReadyCompleter = new PromiseCompleter<void>();
 	public readonly onReady = this.onReadyCompleter.promise;
@@ -40,8 +40,8 @@ export abstract class Analyzer implements IAmDisposable {
 		});
 	}
 
-	public dispose(): void | Promise<void> {
-		disposeAll(this.disposables);
+	public dispose(): Promise<void> {
+		return disposeAllAsync(this.disposables);
 	}
 }
 

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -130,7 +130,17 @@ export interface LogMessage {
 	toLine(maxLength: number): string;
 }
 
+/**
+ * A disposable that is synchronous (or at least, can be treated as such).
+ */
 export interface IAmDisposable {
+	dispose(): void;
+}
+
+/**
+ * A disposable that may be async.
+ */
+export interface IAmDisposableAsync {
 	dispose(): void | Promise<void>;
 }
 

--- a/src/shared/logging.ts
+++ b/src/shared/logging.ts
@@ -4,7 +4,7 @@ import * as os from "os";
 import * as path from "path";
 import { platformEol } from "./constants";
 import { LogCategory, LogSeverity } from "./enums";
-import { IAmDisposable, LogMessage, Logger, SpawnedProcess } from "./interfaces";
+import { IAmDisposable, IAmDisposableAsync, LogMessage, Logger, SpawnedProcess } from "./interfaces";
 import { errorString } from "./utils";
 import { createFolderForFile } from "./utils/fs";
 
@@ -104,7 +104,7 @@ export function logToConsole(logger: EmittingLogger): IAmDisposable {
 	});
 }
 
-export function captureLogs(logger: EmittingLogger, file: string, header: string, maxLogLineLength: number, logCategories: LogCategory[], excludeLogCategories = false): ({ dispose: () => Promise<void> | void }) {
+export function captureLogs(logger: EmittingLogger, file: string, header: string, maxLogLineLength: number, logCategories: LogCategory[], excludeLogCategories = false): IAmDisposableAsync {
 	if (!file || !path.isAbsolute(file))
 		throw new Error("Path passed to logTo must be an absolute path");
 	const time = (detailed = false) => detailed ? `[${(new Date()).toTimeString()}] ` : `[${(new Date()).toLocaleTimeString()}] `;
@@ -117,7 +117,7 @@ export function captureLogs(logger: EmittingLogger, file: string, header: string
 	logStream.write(`${excludeLogCategories ? "Not " : ""}Logging Categories:${platformEol}    ${categoryNames.join(", ")}${platformEol}${platformEol}`);
 
 	logStream.write(`${(new Date()).toDateString()} ${time(true)}Log file started${platformEol}`);
-	let fileLogger: IAmDisposable | undefined = logger.onLog((e) => {
+	let fileLogger: IAmDisposableAsync | undefined = logger.onLog((e) => {
 		if (!logStream)
 			return;
 

--- a/src/shared/services/stdio_service.ts
+++ b/src/shared/services/stdio_service.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import { IAmDisposable, IAmDisposableAsync, Logger, SpawnedProcess } from "../interfaces";
 import { safeSpawn } from "../processes";
 import { Request, UnknownResponse } from "../services/interfaces";
-import { PromiseCompleter } from "../utils";
+import { disposeAllAsync, PromiseCompleter } from "../utils";
 
 // Reminder: This class is used in the debug adapter as well as the main Code process!
 
@@ -300,7 +300,7 @@ export abstract class StdIOService<T> implements IAmDisposable {
 			this.logStream.write(message.trim() + "\r\n");
 	}
 
-	public dispose() {
+	public async dispose(): Promise<void> {
 		this.logTraffic(`Process ${this.description} is being disposed`);
 		for (const pid of this.additionalPidsToTerminate) {
 			try {
@@ -334,15 +334,7 @@ export abstract class StdIOService<T> implements IAmDisposable {
 		}
 		this.process = undefined;
 
-		this.disposables.forEach(async (d) => {
-			try {
-				await d.dispose();
-			} catch (e: any) {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-				this.logger.error({ message: e.toString() });
-			}
-		});
-		this.disposables.length = 0;
+		await disposeAllAsync(this.disposables, this.logger);
 
 		// Clear log file so if any more log events come through later, we don't
 		// create a new log file and overwrite what we had.

--- a/src/shared/services/stdio_service.ts
+++ b/src/shared/services/stdio_service.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import { IAmDisposable, Logger, SpawnedProcess } from "../interfaces";
+import { IAmDisposable, IAmDisposableAsync, Logger, SpawnedProcess } from "../interfaces";
 import { safeSpawn } from "../processes";
 import { Request, UnknownResponse } from "../services/interfaces";
 import { PromiseCompleter } from "../utils";
@@ -7,7 +7,7 @@ import { PromiseCompleter } from "../utils";
 // Reminder: This class is used in the debug adapter as well as the main Code process!
 
 export abstract class StdIOService<T> implements IAmDisposable {
-	private readonly disposables: IAmDisposable[] = [];
+	private readonly disposables: IAmDisposableAsync[] = [];
 	public process?: SpawnedProcess;
 	protected readonly additionalPidsToTerminate: number[] = [];
 	private nextRequestID = 1;
@@ -336,7 +336,7 @@ export abstract class StdIOService<T> implements IAmDisposable {
 
 		this.disposables.forEach(async (d) => {
 			try {
-				return await d.dispose();
+				await d.dispose();
 			} catch (e: any) {
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 				this.logger.error({ message: e.toString() });

--- a/src/shared/services/tooling_daemon.ts
+++ b/src/shared/services/tooling_daemon.ts
@@ -314,7 +314,7 @@ export class DartToolingDaemon implements IAmDisposable {
 		});
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		this.isShuttingDown = true;
 		try {
 			this.connection?.socket?.close();

--- a/src/shared/test/coordinator.ts
+++ b/src/shared/test/coordinator.ts
@@ -330,7 +330,7 @@ The test description was: .*
 		};
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/shared/test/test_model.ts
+++ b/src/shared/test/test_model.ts
@@ -85,7 +85,7 @@ export abstract class TreeNode {
 	}
 
 	public dispose(): void {
-		void this.rangeTracker?.dispose();
+		this.rangeTracker?.dispose();
 	}
 }
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -232,7 +232,7 @@ export function disposeAll(disposables: IAmDisposable[]): void {
 	disposables.length = 0;
 	for (const d of toDispose) {
 		try {
-			void d.dispose();
+			d.dispose();
 		} catch (e) {
 			console.warn(e);
 		}
@@ -248,17 +248,21 @@ export function disposeAll(disposables: IAmDisposable[]): void {
 export async function disposeAllAsync(disposables: IAmDisposableAsync[]): Promise<void> {
 	const toDispose = disposables.slice();
 	disposables.length = 0;
-	await withTimeout(
-		Promise.allSettled(toDispose.map(async (d) => {
-			try {
-				await d.dispose();
-			} catch (e) {
-				console.warn(e);
-			}
-		})),
-		"disposeAllAsync did not complete",
-		3,
-	);
+	try {
+		await withTimeout(
+			Promise.allSettled(toDispose.map(async (d) => {
+				try {
+					await d.dispose();
+				} catch (e) {
+					console.warn(e);
+				}
+			})),
+			"disposeAllAsync did not complete",
+			3,
+		);
+	} catch (e) {
+		console.warn(e);
+	}
 }
 
 export async function withTimeout<T>(promise: Thenable<T>, message: string | (() => string), seconds = 360): Promise<T> {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -227,13 +227,15 @@ export function isWebDevice(deviceId: string | undefined): boolean {
 /**
  * Calls dispose() on all of `disposables` which must all be synchronous disposables.
  */
-export function disposeAll(disposables: IAmDisposable[]): void {
+export function disposeAll(disposables: IAmDisposable[], logger?: Logger): void {
 	const toDispose = disposables.slice();
 	disposables.length = 0;
 	for (const d of toDispose) {
 		try {
 			d.dispose();
-		} catch (e) {
+		} catch (e: any) {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			logger?.error({ message: e.toString() });
 			console.warn(e);
 		}
 	}
@@ -245,7 +247,7 @@ export function disposeAll(disposables: IAmDisposable[]): void {
  * Will `await` all calls to `dispose()` but time out with printing a warning if they do not complete
  * within 3s.
  */
-export async function disposeAllAsync(disposables: IAmDisposableAsync[]): Promise<void> {
+export async function disposeAllAsync(disposables: IAmDisposableAsync[], logger?: Logger): Promise<void> {
 	const toDispose = disposables.slice();
 	disposables.length = 0;
 	try {
@@ -253,7 +255,9 @@ export async function disposeAllAsync(disposables: IAmDisposableAsync[]): Promis
 			Promise.allSettled(toDispose.map(async (d) => {
 				try {
 					await d.dispose();
-				} catch (e) {
+				} catch (e: any) {
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+					logger?.error({ message: e.toString() });
 					console.warn(e);
 				}
 			})),

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import * as semver from "semver";
 import { executableNames, isWin } from "./constants";
 import { LogCategory } from "./enums";
-import { CustomScript, IAmDisposable, Logger } from "./interfaces";
+import { CustomScript, IAmDisposable, IAmDisposableAsync, Logger } from "./interfaces";
 import { ExecutionInfo } from "./processes";
 
 export type PromiseOr<T> = Promise<T> | T;
@@ -224,6 +224,9 @@ export function isWebDevice(deviceId: string | undefined): boolean {
 	return !!(deviceId?.startsWith("web") || deviceId === "chrome" || deviceId === "edge");
 }
 
+/**
+ * Calls dispose() on all of `disposables` which must all be synchronous disposables.
+ */
 export function disposeAll(disposables: IAmDisposable[]): void {
 	const toDispose = disposables.slice();
 	disposables.length = 0;
@@ -234,6 +237,28 @@ export function disposeAll(disposables: IAmDisposable[]): void {
 			console.warn(e);
 		}
 	}
+}
+
+/**
+ * Calls dispose() on all of `disposables`, which can include async disposables.
+ *
+ * Will `await` all calls to `dispose()` but time out with printing a warning if they do not complete
+ * within 3s.
+ */
+export async function disposeAllAsync(disposables: IAmDisposableAsync[]): Promise<void> {
+	const toDispose = disposables.slice();
+	disposables.length = 0;
+	await withTimeout(
+		Promise.allSettled(toDispose.map(async (d) => {
+			try {
+				await d.dispose();
+			} catch (e) {
+				console.warn(e);
+			}
+		})),
+		"disposeAllAsync did not complete",
+		3,
+	);
 }
 
 export async function withTimeout<T>(promise: Thenable<T>, message: string | (() => string), seconds = 360): Promise<T> {

--- a/src/shared/vscode/analyzer_update_diagnostic_information.ts
+++ b/src/shared/vscode/analyzer_update_diagnostic_information.ts
@@ -116,7 +116,7 @@ export class AnalyzerUpdateDiagnosticInformationFeature implements IAmDisposable
 		return results;
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/shared/vscode/device_manager.ts
+++ b/src/shared/vscode/device_manager.ts
@@ -196,8 +196,8 @@ export class FlutterDeviceManager implements IAmDisposable {
 		});
 		quickPickIsValid = false;
 		quickPick.dispose();
-		await deviceAddedSubscription.dispose();
-		await deviceRemovedSubscription.dispose();
+		deviceAddedSubscription.dispose();
+		deviceRemovedSubscription.dispose();
 
 		if (selection && await this.selectDevice(selection))
 			return this.currentDevice;

--- a/src/shared/vscode/device_manager.ts
+++ b/src/shared/vscode/device_manager.ts
@@ -2,7 +2,7 @@ import * as vs from "vscode";
 import { ExtensionRestartReason, skipAction } from "../constants";
 import { LogCategory } from "../enums";
 import * as f from "../flutter/daemon_interfaces";
-import { CustomEmulator, CustomEmulatorDefinition, Emulator, EmulatorCreator, FlutterCreateCommandArgs, IFlutterDaemon, Logger, PlatformEnabler } from "../interfaces";
+import { CustomEmulator, CustomEmulatorDefinition, Emulator, EmulatorCreator, FlutterCreateCommandArgs, IAmDisposable, IFlutterDaemon, Logger, PlatformEnabler } from "../interfaces";
 import { logProcess } from "../logging";
 import { safeSpawn } from "../processes";
 import { disposeAll, flatMap, notNullOrUndefined, uniq, withTimeout } from "../utils";
@@ -13,9 +13,9 @@ import { WorkspaceContext } from "../workspace";
 import { isRunningLocally } from "./utils";
 import { Context } from "./workspace";
 
-export class FlutterDeviceManager implements vs.Disposable {
+export class FlutterDeviceManager implements IAmDisposable {
 	private readonly unresponsiveTimeoutPeriodSeconds = 5;
-	private subscriptions: vs.Disposable[] = [];
+	private subscriptions: IAmDisposable[] = [];
 	private statusBarItem: vs.StatusBarItem;
 	public currentDevice?: f.Device;
 	private devices: f.Device[] = [];

--- a/src/shared/vscode/device_manager.ts
+++ b/src/shared/vscode/device_manager.ts
@@ -642,7 +642,7 @@ export class FlutterDeviceManager implements IAmDisposable {
 		const cancellationTokenSource = new vs.CancellationTokenSource();
 		const waitingForRealDeviceSubscription = this.daemon.registerForDeviceAdded(() => {
 			cancellationTokenSource.cancel();
-			void waitingForRealDeviceSubscription.dispose();
+			waitingForRealDeviceSubscription.dispose();
 		});
 		const selectedEmulator =
 			await vs.window.showQuickPick(
@@ -652,7 +652,7 @@ export class FlutterDeviceManager implements IAmDisposable {
 					placeHolder: "Connect a device or select an emulator to launch",
 				},
 				cancellationTokenSource.token);
-		void waitingForRealDeviceSubscription.dispose();
+		waitingForRealDeviceSubscription.dispose();
 		cancellationTokenSource.dispose();
 
 		if (selectedEmulator?.device?.type === "emulator-creator") {

--- a/src/shared/vscode/interactive_refactors.ts
+++ b/src/shared/vscode/interactive_refactors.ts
@@ -151,7 +151,7 @@ export class InteractiveRefactors implements IAmDisposable {
 		return uri;
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/shared/vscode/mcp.ts
+++ b/src/shared/vscode/mcp.ts
@@ -6,7 +6,7 @@ import { DartToolingDaemon } from "../services/tooling_daemon";
 import { disposeAll } from "../utils";
 
 export class McpTools implements IAmDisposable {
-	private readonly disposables: vs.Disposable[] = [];
+	private readonly disposables: IAmDisposable[] = [];
 
 	constructor(
 		private readonly dartCapabilities: DartCapabilities,
@@ -93,7 +93,7 @@ export class McpTools implements IAmDisposable {
 		}));
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		disposeAll(this.disposables);
 	}
 }

--- a/src/shared/vscode/trackers.ts
+++ b/src/shared/vscode/trackers.ts
@@ -1,11 +1,11 @@
 import * as vs from "vscode";
 import { URI } from "vscode-uri";
-import { Position, Range } from "../interfaces";
+import { IAmDisposable, Position, Range } from "../interfaces";
 import { disposeAll } from "../utils";
 
-export class SingleDocumentPositionTracker implements vs.Disposable {
+export class SingleDocumentPositionTracker implements IAmDisposable {
 	// TODO(dantup): Deprecate and remove this in favour of DocumentPositionTracker
-	private readonly disposables: vs.Disposable[] = [];
+	private readonly disposables: IAmDisposable[] = [];
 	private readonly tracker: SingleDocumentOffsetTracker = new SingleDocumentOffsetTracker();
 	private readonly positionMap: Map<vs.Position, number> = new Map<vs.Position, number>();
 
@@ -52,9 +52,9 @@ export class SingleDocumentPositionTracker implements vs.Disposable {
 	}
 }
 
-export class SingleDocumentOffsetTracker implements vs.Disposable {
+export class SingleDocumentOffsetTracker implements IAmDisposable {
 	// TODO(dantup): Deprecate and remove this in favour of DocumentPositionTracker
-	private readonly disposables: vs.Disposable[] = [];
+	private readonly disposables: IAmDisposable[] = [];
 	private document: vs.TextDocument | undefined;
 	private readonly offsetMap: Map<number, number> = new Map<number, number>();
 
@@ -127,8 +127,8 @@ interface PositionTrackerEntry {
 	dispose(): void;
 }
 
-export class DocumentPositionTracker implements vs.Disposable {
-	private readonly disposables: vs.Disposable[] = [];
+export class DocumentPositionTracker implements IAmDisposable {
+	private readonly disposables: IAmDisposable[] = [];
 	private readonly trackers: Map<string, PositionTrackerEntry[]> = new Map<string, PositionTrackerEntry[]>();
 
 	constructor() {
@@ -136,7 +136,7 @@ export class DocumentPositionTracker implements vs.Disposable {
 		this.disposables.push(vs.workspace.onDidOpenTextDocument((doc) => this.handleDocumentOpen(doc)));
 	}
 
-	public trackPosition(document: vs.TextDocument, position: Position, callback: (newPosition: vs.Position | undefined) => void): vs.Disposable {
+	public trackPosition(document: vs.TextDocument, position: Position, callback: (newPosition: vs.Position | undefined) => void): IAmDisposable {
 		const vsPosition = new vs.Position(position.line, position.character);
 		const offset = document.offsetAt(vsPosition);
 		const key = document.uri.toString();
@@ -248,11 +248,11 @@ interface RangeTrackerEntry {
 	dispose: () => void;
 }
 
-export class DocumentRangeTracker implements vs.Disposable {
+export class DocumentRangeTracker implements IAmDisposable {
 	private readonly positionTracker = new DocumentPositionTracker();
 	private readonly rangeTrackers: RangeTrackerEntry[] = [];
 
-	public async trackRangeForUri(documentUri: URI, range: Range, callback: (newRange: Range | undefined) => void): Promise<vs.Disposable> {
+	public async trackRangeForUri(documentUri: URI, range: Range, callback: (newRange: Range | undefined) => void): Promise<IAmDisposable> {
 		// TODO(dantup): This being async doesn't feel good.
 		const document = vs.workspace.textDocuments.find((d) => d.uri.toString() === documentUri.toString())
 			?? await vs.workspace.openTextDocument(documentUri);
@@ -260,7 +260,7 @@ export class DocumentRangeTracker implements vs.Disposable {
 		return this.trackRange(document, range, callback);
 	}
 
-	public trackRange(document: vs.TextDocument, range: Range, callback: (newRange: Range | undefined) => void): vs.Disposable {
+	public trackRange(document: vs.TextDocument, range: Range, callback: (newRange: Range | undefined) => void): IAmDisposable {
 		let start: Position | undefined = range.start;
 		let end: Position | undefined = range.end;
 
@@ -286,15 +286,15 @@ export class DocumentRangeTracker implements vs.Disposable {
 
 			// If we don't have a range because one position went away, be sure to dispose the other tracker.
 			if (!newRange) {
-				startDisposable.dispose();
-				endDisposable.dispose();
+				void startDisposable.dispose();
+				void endDisposable.dispose();
 			}
 		};
 
 		const entry: RangeTrackerEntry = {
 			dispose: () => {
-				startDisposable.dispose();
-				endDisposable.dispose();
+				void startDisposable.dispose();
+				void endDisposable.dispose();
 				const index = this.rangeTrackers.indexOf(entry);
 				if (index !== -1) {
 					this.rangeTrackers.splice(index, 1);

--- a/src/shared/vscode/trackers.ts
+++ b/src/shared/vscode/trackers.ts
@@ -286,15 +286,15 @@ export class DocumentRangeTracker implements IAmDisposable {
 
 			// If we don't have a range because one position went away, be sure to dispose the other tracker.
 			if (!newRange) {
-				void startDisposable.dispose();
-				void endDisposable.dispose();
+				startDisposable.dispose();
+				endDisposable.dispose();
 			}
 		};
 
 		const entry: RangeTrackerEntry = {
 			dispose: () => {
-				void startDisposable.dispose();
-				void endDisposable.dispose();
+				startDisposable.dispose();
+				endDisposable.dispose();
 				const index = this.rangeTrackers.indexOf(entry);
 				if (index !== -1) {
 					this.rangeTrackers.splice(index, 1);

--- a/src/shared/workspace.ts
+++ b/src/shared/workspace.ts
@@ -45,7 +45,7 @@ export class WorkspaceContext implements IAmDisposable {
 		return types.join(", ");
 	}
 
-	public dispose(): any {
+	public dispose(): void {
 		this.events.dispose();
 	}
 
@@ -56,7 +56,7 @@ export class WorkspaceContext implements IAmDisposable {
 class WorkspaceEvents implements IAmDisposable {
 	public readonly onPackageMapChange = new EventEmitter<void>();
 
-	public dispose(): any {
+	public dispose(): void {
 		this.onPackageMapChange.dispose();
 	}
 }

--- a/src/test/dart/editing/position_trackers.test.ts
+++ b/src/test/dart/editing/position_trackers.test.ts
@@ -315,7 +315,7 @@ describe("multi-document position tracker", () => {
 		await editor.edit((eb) => eb.insert(positionOf("^1", doc), "inserted at start"));
 		assert.ok(positionsEqual(position, positionOf("^333", doc)));
 
-		await posTrack.dispose();
+		posTrack.dispose();
 		await editor.edit((eb) => eb.insert(positionOf("^1", doc), "000"));
 		assert.ok(positionsEqual(position, positionOf("^22 3", doc))); // Was not tracked, so is out of sync.
 	});
@@ -540,7 +540,7 @@ describe("multi-document range tracker", () => {
 		await editor.edit((eb) => eb.insert(positionOf("^1", doc), "inserted at start"));
 		assert.ok(rangesEqual(range, rangeOf("|333|", doc)));
 
-		await rangeTrack.dispose();
+		rangeTrack.dispose();
 		await editor.edit((eb) => eb.insert(positionOf("^1", doc), "000"));
 		assert.ok(rangesEqual(range, rangeOf("|22 |", doc))); // Was not tracked, so is out of sync.
 	});

--- a/src/test/dart/refactors/interactive_refactors.test.ts
+++ b/src/test/dart/refactors/interactive_refactors.test.ts
@@ -43,7 +43,7 @@ describe("interactive refactors", () => {
 		const commandSub = vs.commands.registerCommand(testRefactorCommandName, (args: any) => { capturedArgs = args; });
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 		await vs.commands.executeCommand(codeAction.command!.command, ...codeAction.command!.arguments!);
-		await commandSub.dispose();
+		commandSub.dispose();
 		return capturedArgs;
 	}
 

--- a/src/test/dart/tooling_daemon/tooling_daemon.test.ts
+++ b/src/test/dart/tooling_daemon/tooling_daemon.test.ts
@@ -187,7 +187,7 @@ describe("dart tooling daemon", () => {
 				],
 			);
 		} finally {
-			await listener.dispose();
+			listener.dispose();
 			await daemon.streamCancel(Stream.Editor);
 		}
 	});

--- a/src/test/flutter/device_manager.test.ts
+++ b/src/test/flutter/device_manager.test.ts
@@ -32,9 +32,9 @@ describe("device_manager", () => {
 		);
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		dm.dispose();
-		daemon.dispose();
+		await daemon.dispose();
 	});
 
 	it("auto-selects valid devices", async () => {

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -1233,8 +1233,8 @@ export async function captureDebugSessionCustomEvents(startDebug: () => void, ex
 
 	startDebug();
 	await Promise.all([startPromise, endPromise]);
-	await startSub?.dispose();
-	await endSub?.dispose();
+	startSub?.dispose();
+	endSub?.dispose();
 	eventSub.dispose();
 
 	return events;


### PR DESCRIPTION
Instead of terminating after 100ms, allow 3s for server shutdown. Also change `disposeAll()` from fire-and-forgetting everything, to instead wait up to 3s for them to complete.

This will ensure that during extension shutdown, we block the deactivate method for at least 3s to allow things to shut down.

Doing this required splitting sync/async disposables so we can await disposing things like the analyzer. This also meant avoiding the VS Code Disposable interface because it returns `any` so we can have some safety where we have async disposables.

Fixes [#6085](https://github.com/Dart-Code/Dart-Code/issues/6085)