### PR TITLE
Don't enqueue() entire test suite unless we know the whole suite is being run

### DIFF
--- a/src/extension/test/vs_test_controller.ts
+++ b/src/extension/test/vs_test_controller.ts
@@ -490,8 +490,8 @@ export class VsCodeTestController implements TestEventListener, IAmDisposable {
 		const run = this.testRuns[sessionID]!;
 
 		// If the tests were not started by the test runner, they won't have been marked
-		// as queued, so we do this for each suite as it starts.
-		if (!run.wasStartedByTestRunner) {
+		// as queued. If we know the entire suite is being run, enqueue them.
+		if (!run.wasStartedByTestRunner && node.suiteData.isRunningWholeSuite) {
 			const item = this.itemForNode.get(node);
 			if (item)
 				this.markEnqueued(run.run, new Set([item]));

--- a/src/shared/test/test_model.ts
+++ b/src/shared/test/test_model.ts
@@ -223,6 +223,9 @@ export class TestModel {
 	}
 
 	public flagSuiteStart(suite: SuiteData, isRunningWholeSuite: boolean): void {
+		// Used for enqueue().
+		suite.isRunningWholeSuite = isRunningWholeSuite;
+
 		// Mark all test for this suite as "stale" which will make them faded, so that results from
 		// the "new" run are more obvious in the tree.
 		suite.getAllGroups().forEach((g) => g.isStale = true);
@@ -707,6 +710,19 @@ export class SuiteData {
 	private readonly groupsByName = new Map<string, GroupNode>();
 	private readonly testsById = new Map<string, TestNode>();
 	private readonly testsByName = new Map<string, TestNode>();
+
+	/**
+	 * A flag set when a suite starts running that indicates whether the entire suite was being run or not.
+	 *
+	 * Only in the case that we know the entire suite is being run should we enqueue the entire suite
+	 * if we were not run from the VS Code test explorer.
+	 *
+	 * Eg., when a user hits F5 to run a whole file, we want to show all tests as queued. But if they are
+	 * only running a subset, without knowing which subset, we cannot.
+	 * https://github.com/Dart-Code/Dart-Code/issues/6091
+	 * https://github.com/Dart-Code/Dart-Code/issues/5928
+	 */
+	public isRunningWholeSuite = false;
 
 	constructor(public readonly path: string, public readonly projectPath: string | undefined, parent: ProjectNode | WorkspaceFolderNode | undefined) {
 		this.node = new SuiteNode(this, parent);


### PR DESCRIPTION
The fix for https://github.com/Dart-Code/Dart-Code/issues/5928 was to enqueue() an entire test suite when it started running. However, this meant that running even a single test would enqueue the entire test suite, and then when only one test ran, the others would all get marked as skipped.

To fix this, we only enqueue() the whole suite in cases where we know we are running the entire suite (eg. you press `F5`). If you run a subset of tests, we do not. This does mean that if you run a _group_ then nothing gets enqueued (so you won't see the "waiting" status icons), but this seems to be the best trade-off we can make given that we don't have a concrete link between the debug session we start and what tests run (because of dynamic test names, etc.).

Fixes https://github.com/Dart-Code/Dart-Code/issues/6091