### PR TITLE
Add tests for Interactive Forms + minor validation tweaks

### DIFF
--- a/src/extension/analysis/form.ts
+++ b/src/extension/analysis/form.ts
@@ -782,7 +782,28 @@ export class InteractiveFormsFeature implements StaticFeature {
 	}
 
 	/**
+	 * Validates a string, returning a user-facing error message if it's not valid.
+	 */
+	private validateString(text: string, required: boolean): string | null {
+		if (required && text.trim() === "")
+			return "Please enter a value";
+		return null;
+	}
+
+	/**
+	 * Validates a number, returning a user-facing error message if it's not valid.
+	 */
+	private validateNumber(text: string, required: boolean): string | null {
+		if (text.trim() === "")
+			return required ? "Please enter a number" : null;
+		return !Number.isFinite(Number(text)) ? "Please enter a valid number" : null;
+	}
+
+	/**
 	 * Helper to prompt for a single field based on its type.
+	 *
+	 * Returns `undefined` if an input is cancelled.
+	 * Returns `null` if an answer was skipped/no answer (for example an empty input).
 	 */
 	private async promptForField(field: FormField, prevAnswer: any | undefined): Promise<any | undefined> {
 		const fieldType = field.type;
@@ -910,16 +931,28 @@ export class InteractiveFormsFeature implements StaticFeature {
 					return uri ? uri.toString() : undefined;
 				}
 			}
-			case 'string':
-				return await vscode.window.showInputBox({
+			case 'string': {
+				const value = await vscode.window.showInputBox({
 					prompt: field.description,
-					value: prevAnswer !== undefined ? prevAnswer : field.default,
+					value: prevAnswer !== undefined && prevAnswer !== null
+						? prevAnswer
+						: field.default,
 					placeHolder: field.description,
 					// Keep the input box open when focus is lost. This allows the
 					// user to  browse the workspace or inspect code (e.g., checking
 					// destination files or existing struct tags) before answering.
-					ignoreFocusOut: true
+					ignoreFocusOut: true,
+					validateInput: (text) => this.validateString(text, field.required)
 				} as vscode.InputBoxOptions);
+
+				if (value === undefined) {
+					return undefined; // Cancelled.
+				}
+				if (value.trim() === '') {
+					return null; // Treat empty as no answer.
+				}
+				return value;
+			}
 
 			case 'enum': {
 				const pickItems = fieldType.entries.map((entry, _) => {
@@ -970,19 +1003,14 @@ export class InteractiveFormsFeature implements StaticFeature {
 					value: value,
 					placeHolder: '0',
 					ignoreFocusOut: true,
-					validateInput: (text) => {
-						if (text.trim() === '') {
-							return field.required ? 'Please enter a number' : null;
-						}
-						return isNaN(Number(text)) ? 'Please enter a valid number' : null;
-					}
+					validateInput: (text) => this.validateNumber(text, field.required)
 				});
 
 				if (numResult === undefined) {
-					return undefined; // undefined = canceled
+					return undefined; // Cancelled.
 				}
 				if (numResult.trim() === '') {
-					return null; // null = empty (eg. not answering optional question)
+					return null; // Treat empty as no answer.
 				}
 				return Number(numResult);
 			}
@@ -992,22 +1020,43 @@ export class InteractiveFormsFeature implements StaticFeature {
 				if (fieldType.elementType.kind === 'string' || fieldType.elementType.kind === 'number') {
 					const rawList = await vscode.window.showInputBox({
 						prompt: `${field.description} (comma separated)`,
-						ignoreFocusOut: true
+						ignoreFocusOut: true,
+						validateInput: (text) => {
+							if (text.trim() === '') {
+								return field.required ? 'Please enter at least one item' : null;
+							}
+							const parts = text.split(',').map((s) => s.trim());
+							if (fieldType.elementType.kind === 'string') {
+								for (const part of parts) {
+									if (this.validateString(part, true)) {
+										return 'Please enter valid values';
+									}
+								}
+							} else if (fieldType.elementType.kind === 'number') {
+								for (const part of parts) {
+									if (this.validateNumber(part, true)) {
+										return 'Please enter valid numbers';
+									}
+								}
+							}
+							return null;
+						}
 					});
 
 					if (rawList === undefined) {
-						return undefined;
+						return undefined; // Cancelled.
 					}
 
-					// If empty input, return empty list
 					if (rawList.trim() === '') {
-						return [];
+						// Treat empty as no answer. We shouldn't get here if required because
+						// of validation.
+						return null;
 					}
 
 					const parts = rawList.split(',').map((s) => s.trim());
-
 					if (fieldType.elementType.kind === 'number') {
-						return parts.map(Number).filter((n) => !isNaN(n));
+						// Validation should prevent us having NaNs here.
+						return parts.map(Number);
 					}
 					return parts;
 				}

--- a/src/test/dart/refactors/interactive_forms.test.ts
+++ b/src/test/dart/refactors/interactive_forms.test.ts
@@ -1,0 +1,721 @@
+import { strict as assert } from "assert";
+import { mock } from "node:test";
+import * as vscode from "vscode";
+import { ClientCapabilities, LanguageClient } from "vscode-languageclient/node";
+import { FileExistence, FileType, InteractiveFormsFeature } from "../../../extension/analysis/form";
+
+describe("interactive forms", () => {
+	afterEach("reset mocks", () => mock.reset());
+
+	it("fills client capabilities with supported inputs", () => {
+		const mockClient = {
+			clientOptions: {},
+			initializeResult: {}
+		} as unknown as LanguageClient;
+
+		const feature = new InteractiveFormsFeature(mockClient);
+		const capabilities = {} as ClientCapabilities;
+		feature.fillClientCapabilities(capabilities);
+
+		assert.deepEqual(capabilities.experimental?.interactiveResolve, {
+			inputTypes: ["bool", "file", "enum", "lazyEnum", "number", "string"]
+		});
+	});
+
+	it("forwards through middleware when not supported", async () => {
+		const flow = await runInteractiveFormTest({
+			serverCapabilities: {},
+			command: "fooCommand",
+			commandArguments: ["barArg", "bazArg"],
+		});
+
+		// We expect the middleware to forward the request on to nextMock.
+		assert.equal(flow.nextMock.mock.callCount(), 1);
+		assert.deepEqual(flow.nextMock.mock.calls[0].arguments, ["fooCommand", ["barArg", "bazArg"]]);
+	});
+
+	describe("field types", () => {
+		describe("string", () => {
+			it("handles and validates required", async () => {
+				const showInputBoxMock = mock.method(vscode.window, "showInputBox", async (options: any) => {
+					assert.equal(options.prompt, "What is your name?");
+					assert.equal(options.value, "Alice");
+
+					// Check validation.
+					assert.ok(options.validateInput);
+					assert.equal(options.validateInput(""), "Please enter a value");
+					assert.equal(options.validateInput(" "), "Please enter a value");
+					assert.equal(options.validateInput("Bob"), null);
+
+					return "Bob";
+				});
+
+				const flow = await runInteractiveFormTest({
+					formFields: [
+						{
+							id: "name",
+							description: "What is your name?",
+							type: { kind: "string" },
+							required: true,
+							default: "Alice"
+						}
+					],
+				});
+
+				assert.equal(showInputBoxMock.mock.callCount(), 1);
+				assert.equal(flow.nextMock.mock.callCount(), 0);
+				assert.deepEqual(flow.executeCallRequestParams.formAnswers, [
+					{ id: "name", value: "Bob" }
+				]);
+			});
+
+			it("handles and validates optional", async () => {
+				const showInputBoxMock = mock.method(vscode.window, "showInputBox", async (options: any) => {
+					assert.equal(options.prompt, "What is your nickname?");
+
+					// All inputs are allowed for optional fields.
+					assert.ok(options.validateInput);
+					assert.equal(options.validateInput(""), null);
+					assert.equal(options.validateInput(" "), null);
+					assert.equal(options.validateInput("Bob"), null);
+
+					return "   ";
+				});
+
+				const flow = await runInteractiveFormTest({
+					formFields: [
+						{
+							id: "nickname",
+							description: "What is your nickname?",
+							type: { kind: "string" },
+							required: false
+						}
+					],
+				});
+
+				assert.equal(showInputBoxMock.mock.callCount(), 1);
+				assert.deepEqual(flow.executeCallRequestParams.formAnswers, [
+					{ id: "nickname", value: null }
+				]);
+			});
+		});
+
+		describe("number", () => {
+			it("handles and validates required", async () => {
+				const showInputBoxMock = mock.method(vscode.window, "showInputBox", async (options: any) => {
+					assert.equal(options.prompt, "How old are you?");
+					assert.equal(options.value, "25");
+
+					// Check validation.
+					assert.ok(options.validateInput);
+					assert.equal(options.validateInput("not-a-number"), "Please enter a valid number");
+					assert.equal(options.validateInput(""), "Please enter a number");
+					assert.equal(options.validateInput("  "), "Please enter a number");
+					assert.equal(options.validateInput("42"), null);
+
+					return "30";
+				});
+
+				const flow = await runInteractiveFormTest({
+					formFields: [
+						{
+							id: "age",
+							description: "How old are you?",
+							type: { kind: "number" },
+							required: true,
+							default: 25
+						}
+					],
+				});
+
+				assert.equal(showInputBoxMock.mock.callCount(), 1);
+				assert.deepEqual(flow.executeCallRequestParams.formAnswers, [
+					{ id: "age", value: 30 }
+				]);
+			});
+
+			it("handles and validates optional", async () => {
+				const showInputBoxMock = mock.method(vscode.window, "showInputBox", async (options: any) => {
+					assert.equal(options.prompt, "What is your favorite number?");
+
+					// All inputs are allowed for optional fields, but they
+					// must still be numbers.
+					assert.ok(options.validateInput);
+					assert.equal(options.validateInput(""), null);
+					assert.equal(options.validateInput(" "), null);
+					assert.equal(options.validateInput("not-a-number"), "Please enter a valid number");
+					assert.equal(options.validateInput("7"), null);
+
+					return "";
+				});
+
+				const flow = await runInteractiveFormTest({
+					formFields: [
+						{
+							id: "favNumber",
+							description: "What is your favorite number?",
+							type: { kind: "number" },
+							required: false
+						}
+					],
+				});
+
+				assert.equal(showInputBoxMock.mock.callCount(), 1);
+				assert.deepEqual(flow.executeCallRequestParams.formAnswers, [
+					{ id: "favNumber", value: null }
+				]);
+			});
+		});
+
+		describe("boolean", () => {
+			it("handles using QuickPick", async () => {
+				const showQuickPickMock = mock.method(vscode.window, "showQuickPick", async (items: any, options: any) => {
+					assert.equal(options.placeHolder, "Enable feature?");
+					assert.deepEqual(items, [
+						{ label: "Yes", value: true },
+						{ label: "No", value: false }
+					]);
+					return { label: "Yes", value: true };
+				});
+
+				const flow = await runInteractiveFormTest({
+					formFields: [
+						{
+							id: "enable",
+							description: "Enable feature?",
+							type: { kind: "bool" },
+							required: true
+						}
+					],
+				});
+
+				assert.equal(showQuickPickMock.mock.callCount(), 1);
+				assert.deepEqual(flow.executeCallRequestParams.formAnswers, [
+					{ id: "enable", value: true }
+				]);
+			});
+		});
+
+		describe("enum", () => {
+			it("handles using QuickPick", async () => {
+				const showQuickPickMock = mock.method(vscode.window, "showQuickPick", async (items: any, options: any) => {
+					assert.equal(options.placeHolder, "Select environment");
+					assert.deepEqual(items, [
+						{ label: "Production environment", description: "prod", value: "prod" },
+						{ label: "Staging environment", description: "staging", value: "staging" }
+					]);
+					return { label: "Production environment", value: "prod" };
+				});
+
+				const flow = await runInteractiveFormTest({
+					formFields: [
+						{
+							id: "env",
+							description: "Select environment",
+							type: {
+								kind: "enum",
+								entries: [
+									{ value: "prod", description: "Production environment" },
+									{ value: "staging", description: "Staging environment" }
+								]
+							},
+							required: true
+						}
+					],
+				});
+
+				assert.equal(showQuickPickMock.mock.callCount(), 1);
+				assert.deepEqual(flow.executeCallRequestParams.formAnswers, [
+					{ id: "env", value: "prod" }
+				]);
+			});
+		});
+
+		describe("lazy enum", () => {
+			it("handles using createQuickPick", async () => {
+				const onDidChangeValueCallbacks: Array<(v: string) => void> = [];
+				const onDidAcceptCallbacks: Array<() => void> = [];
+				const onDidHideCallbacks: Array<() => void> = [];
+
+				const quickPickMock = {
+					title: "",
+					placeholder: "",
+					matchOnDescription: false,
+					busy: false,
+					items: [] as any[],
+					onDidChangeValue: (cb: (v: string) => void) => {
+						onDidChangeValueCallbacks.push(cb);
+						return { dispose: () => { } };
+					},
+					onDidAccept: (cb: () => void) => {
+						onDidAcceptCallbacks.push(cb);
+						return { dispose: () => { } };
+					},
+					onDidHide: (cb: () => void) => {
+						onDidHideCallbacks.push(cb);
+						return { dispose: () => { } };
+					},
+					show: () => { },
+					hide: () => {
+						onDidHideCallbacks.forEach((cb) => cb());
+					},
+					dispose: () => { },
+					selectedItems: [] as any[]
+				};
+
+				const createQuickPickMock = mock.method(vscode.window, "createQuickPick", () => quickPickMock);
+
+				const flow = await runInteractiveFormTest({
+					formFields: [
+						{
+							id: "lazy",
+							description: "Search things",
+							type: {
+								kind: "lazyEnum",
+								source: "workspace/symbols"
+							},
+							required: true
+						}
+					],
+					lazyEnumEntries: [
+						{ value: "custom-lazy-val", description: "Custom Lazy Value" }
+					],
+					async mockUserInteraction() {
+						// Wait until the form implementation has registered the callbacks.
+						let attempts = 100;
+						while (!onDidAcceptCallbacks.length && attempts-- > 0) {
+							await new Promise((resolve) => setTimeout(resolve, 10));
+						}
+
+						quickPickMock.selectedItems = [{ label: "Custom Lazy Value", value: "custom-lazy-val" }];
+						onDidAcceptCallbacks.forEach((cb) => cb());
+					}
+				});
+
+				assert.equal(createQuickPickMock.mock.callCount(), 1);
+				assert.deepEqual(flow.executeCallRequestParams.formAnswers, [
+					{ id: "lazy", value: "custom-lazy-val" }
+				]);
+			});
+		});
+
+		describe("file input", () => {
+			it("handles for existing resource using showOpenDialog", async () => {
+				const showOpenDialogMock = mock.method(vscode.window, "showOpenDialog", async (options: any) => {
+					assert.equal(options.canSelectFiles, true);
+					assert.equal(options.canSelectFolders, false);
+					assert.equal(options.title, "Select existing workspace file");
+					assert.deepEqual(options.filters, { "Supported Files": ["dart"] });
+					return [vscode.Uri.parse("file:///workspace/app.dart")];
+				});
+
+				const flow = await runInteractiveFormTest({
+					formFields: [
+						{
+							id: "existingFile",
+							description: "Select existing workspace file",
+							type: {
+								kind: "file",
+								existence: FileExistence.Existing,
+								type: FileType.Regular,
+								filters: ["dart"]
+							},
+							required: true
+						}
+					],
+				});
+
+				assert.equal(showOpenDialogMock.mock.callCount(), 1);
+				assert.deepEqual(flow.executeCallRequestParams.formAnswers, [
+					{ id: "existingFile", value: "file:///workspace/app.dart" }
+				]);
+			});
+
+			it("handles for new resource using showSaveDialog", async () => {
+				const showSaveDialogMock = mock.method(vscode.window, "showSaveDialog", async (options: any) => {
+					assert.equal(options.title, "Create new output file");
+					return vscode.Uri.parse("file:///workspace/output.dart");
+				});
+
+				const flow = await runInteractiveFormTest({
+					formFields: [
+						{
+							id: "newFile",
+							description: "Create new output file",
+							type: {
+								kind: "file",
+								existence: FileExistence.New,
+								type: FileType.Regular
+							},
+							required: true
+						}
+					],
+				});
+
+				assert.equal(showSaveDialogMock.mock.callCount(), 1);
+				assert.deepEqual(flow.executeCallRequestParams.formAnswers, [
+					{ id: "newFile", value: "file:///workspace/output.dart" }
+				]);
+			});
+
+			it("handles for existing or new resource via additional QuickPick", async () => {
+				const showQuickPickMock = mock.method(vscode.window, "showQuickPick", async <T>(items: T[]) => items[0]);
+
+				const showOpenDialogMock = mock.method(vscode.window, "showOpenDialog", async () => [vscode.Uri.parse("file:///workspace/selected.dart")]);
+
+				// eslint-disable-next-line no-bitwise
+				const combinationExistence = FileExistence.New | FileExistence.Existing;
+
+				const flow = await runInteractiveFormTest({
+					formFields: [
+						{
+							id: "anyFile",
+							description: "Pick any file",
+							type: {
+								kind: "file",
+								existence: combinationExistence,
+								type: FileType.Regular
+							},
+							required: true
+						}
+					],
+				});
+
+				assert.equal(showQuickPickMock.mock.callCount(), 1);
+				assert.equal(showOpenDialogMock.mock.callCount(), 1);
+				assert.deepEqual(flow.executeCallRequestParams.formAnswers, [
+					{ id: "anyFile", value: "file:///workspace/selected.dart" }
+				]);
+			});
+		});
+
+		describe("list", () => {
+			it("handles and validates required strings", async () => {
+				const showInputBoxMock = mock.method(vscode.window, "showInputBox", async (options: any) => {
+					assert.equal(options.prompt, "Tags (comma separated)");
+
+					// Check validation.
+					assert.ok(options.validateInput);
+					assert.equal(options.validateInput(""), "Please enter at least one item");
+					assert.equal(options.validateInput(" "), "Please enter at least one item");
+					assert.equal(options.validateInput("apple, banana"), null);
+
+					return "apple, banana, cherry";
+				});
+
+				const flow = await runInteractiveFormTest({
+					formFields: [
+						{
+							id: "tags",
+							description: "Tags",
+							type: {
+								kind: "list",
+								elementType: { kind: "string" }
+							},
+							required: true
+						}
+					],
+				});
+
+				assert.equal(showInputBoxMock.mock.callCount(), 1);
+				assert.deepEqual(flow.executeCallRequestParams.formAnswers, [
+					{ id: "tags", value: ["apple", "banana", "cherry"] }
+				]);
+			});
+
+			it("handles and validates optional strings", async () => {
+				const showInputBoxMock = mock.method(vscode.window, "showInputBox", async (options: any) => {
+					assert.equal(options.prompt, "Tags (comma separated)");
+
+					// All inputs are allowed for optional fields.
+					assert.ok(options.validateInput);
+					assert.equal(options.validateInput(""), null);
+					assert.equal(options.validateInput("   "), null);
+
+					return "   ";
+				});
+
+				const flow = await runInteractiveFormTest({
+					formFields: [
+						{
+							id: "tags",
+							description: "Tags",
+							type: {
+								kind: "list",
+								elementType: { kind: "string" }
+							},
+							required: false
+						}
+					],
+				});
+
+				assert.equal(showInputBoxMock.mock.callCount(), 1);
+				assert.deepEqual(flow.executeCallRequestParams.formAnswers, [
+					{ id: "tags", value: null }
+				]);
+			});
+
+			it("handles and validates required numbers", async () => {
+				const showInputBoxMock = mock.method(vscode.window, "showInputBox", async (options: any) => {
+					assert.equal(options.prompt, "Ages (comma separated)");
+
+					// Check validation.
+					assert.ok(options.validateInput);
+					assert.equal(options.validateInput(""), "Please enter at least one item");
+					assert.equal(options.validateInput(" "), "Please enter at least one item");
+					assert.equal(options.validateInput("10, not a number, 20"), "Please enter valid numbers");
+					assert.equal(options.validateInput("10, 20"), null);
+
+					return "10, 20";
+				});
+
+				const flow = await runInteractiveFormTest({
+					formFields: [
+						{
+							id: "ages",
+							description: "Ages",
+							type: {
+								kind: "list",
+								elementType: { kind: "number" }
+							},
+							required: true
+						}
+					],
+				});
+
+				assert.equal(showInputBoxMock.mock.callCount(), 1);
+				assert.deepEqual(flow.executeCallRequestParams.formAnswers, [
+					{ id: "ages", value: [10, 20] }
+				]);
+			});
+
+			it("handles and validates optional numbers", async () => {
+				const showInputBoxMock = mock.method(vscode.window, "showInputBox", async (options: any) => {
+					assert.equal(options.prompt, "Ages (comma separated)");
+
+					// All inputs are allowed for optional fields, but they
+					// must still be numbers.
+					assert.ok(options.validateInput);
+					assert.equal(options.validateInput(""), null);
+					assert.equal(options.validateInput("   "), null);
+					assert.equal(options.validateInput("10, not a number, 20"), "Please enter valid numbers");
+
+					return "";
+				});
+
+				const flow = await runInteractiveFormTest({
+					formFields: [
+						{
+							id: "ages",
+							description: "Ages",
+							type: {
+								kind: "list",
+								elementType: { kind: "number" }
+							},
+							required: false
+						}
+					],
+				});
+
+				assert.equal(showInputBoxMock.mock.callCount(), 1);
+				assert.deepEqual(flow.executeCallRequestParams.formAnswers, [
+					{ id: "ages", value: null }
+				]);
+			});
+
+			it("warns and fails when list elements are unsupported", async () => {
+				const showErrorMessageMock = mock.method(vscode.window, "showErrorMessage", async (msg: string) => {
+					assert.ok(msg.includes("List input for bool is not supported"));
+					return undefined;
+				});
+
+				const flow = await runInteractiveFormTest({
+					formFields: [
+						{
+							id: "boolList",
+							description: "Bools",
+							type: {
+								kind: "list",
+								elementType: { kind: "bool" }
+							},
+							required: true
+						}
+					],
+				});
+
+				assert.equal(showErrorMessageMock.mock.callCount(), 1);
+				assert.equal(flow.executeCallRequestParams, null);
+			});
+		});
+	});
+
+	describe("validation and errors", () => {
+		it("shows warning messages for validation errors from the server", async () => {
+			const showWarningMessageMock = mock.method(vscode.window, "showWarningMessage", async () => undefined);
+
+			const showInputBoxMock = mock.method(vscode.window, "showInputBox", async () => "user-attempt");
+
+			const flow = await runInteractiveFormTest({
+				formFields: [
+					{
+						id: "username",
+						description: "Username",
+						type: { kind: "string" },
+						required: true,
+						error: "Username is already taken"
+					}
+				],
+				mockUserInteraction() { }
+			});
+
+			assert.ok(flow);
+			assert.equal(showInputBoxMock.mock.callCount(), 1);
+			const warnings = showWarningMessageMock.mock.calls.map((c: any) => c.arguments[0] as string);
+			assert.ok(warnings.includes("Question 1: Username is already taken"));
+		});
+
+		it("aborts when the server exceeds maximum retry attempts", async () => {
+			const showWarningMessageMock = mock.method(vscode.window, "showWarningMessage", async () => undefined);
+
+			mock.method(vscode.window, "showInputBox", async () => "some-input");
+
+			const flow = await runInteractiveFormTest({
+				formFields: [
+					{
+						id: "forever",
+						description: "Try again",
+						type: { kind: "string" },
+						required: true
+					}
+				],
+				returnFormFieldsIndefinitely: true,
+			});
+
+			assert.equal(flow.result, undefined);
+			assert.equal(flow.resolveCallCount, 5);
+
+			const warnings = showWarningMessageMock.mock.calls.map((c: any) => c.arguments[0] as string);
+			assert.ok(warnings.some((w: string) => w.includes("exceeds the maximum allowed attempts")));
+		});
+
+		it("cancels execution if the user cancels an input prompt", async () => {
+			const showInputBoxMock = mock.method(vscode.window, "showInputBox", async () => undefined);
+
+			const flow = await runInteractiveFormTest({
+				formFields: [
+					{
+						id: "cancelled",
+						description: "Enter string",
+						type: { kind: "string" },
+						required: true
+					}
+				],
+				mockUserInteraction() { }
+			});
+
+			assert.equal(showInputBoxMock.mock.callCount(), 1);
+			assert.equal(flow.executeCallRequestParams, null);
+			assert.equal(flow.result, undefined);
+		});
+	});
+});
+
+
+/**
+ * Helper to run form tests and verify command execution/resolution flow.
+ */
+async function runInteractiveFormTest(params: {
+	// Fields to return from `/resolve`.
+	formFields?: any[];
+	// Function to call to allow the test to simulate user interaction.
+	mockUserInteraction?: () => void;
+	// If testing lazy enum, the mock response to return from `interactive/listEnum`.
+	lazyEnumEntries?: Array<{ value: string; description: string }>;
+	// Server capabilities. If not supplied, we assume interactive forms are supported.
+	serverCapabilities?: any;
+	// Whether `/resolve` should keep returning formFields indefinitely. If not set, will
+	// only return formFields on the first request.
+	returnFormFieldsIndefinitely?: boolean;
+	// The command to execute.
+	command?: string;
+	// The arguments to pass to the command.
+	commandArguments?: string[];
+}) {
+	// Options passed to the client. Our middleware gets installed here.
+	const clientOptions: any = {};
+
+	// How many times `/resolve` was called.
+	let resolveCallCount = 0;
+
+	// Capture the params send to the underlying execute command for test
+	// validation.
+	let executeCallRequestParams: any = null;
+
+	const serverCapabilities = params.serverCapabilities ?? {
+		experimental: {
+			interactiveResolveProvider: {
+				kinds: ["command"]
+			}
+		}
+	};
+
+	const mockClient = {
+		clientOptions,
+		initializeResult: {
+			capabilities: serverCapabilities
+		},
+		sendRequest: async (method: string, requestParams: any) => {
+			if (method === "command/resolve") {
+				resolveCallCount++;
+				if (resolveCallCount === 1 || params.returnFormFieldsIndefinitely) {
+					return {
+						command: requestParams.command,
+						arguments: requestParams.arguments,
+						formFields: params.formFields,
+						formAnswers: requestParams.formAnswers
+					};
+				} else {
+					return {
+						command: requestParams.command,
+						arguments: requestParams.arguments,
+						formAnswers: requestParams.formAnswers
+					};
+				}
+			}
+			if (method === "interactive/listEnum") {
+				assert.ok(requestParams.source);
+				assert.notEqual(requestParams.query, undefined); // Will be empty string for initial request.
+				return params.lazyEnumEntries;
+			}
+			if (method === "workspace/executeCommand") {
+				assert.ok(requestParams.command);
+				assert.ok(requestParams.arguments);
+				executeCallRequestParams = requestParams;
+				return { success: true };
+			}
+			throw new Error(`Unknown request to mock client: ${method}`);
+		},
+		handleFailedRequest: (_type: any, _value: any, error: any, _token: any) => {
+			throw error;
+		}
+	} as unknown as LanguageClient;
+
+	new InteractiveFormsFeature(mockClient);
+
+	// Trigger any mock user interaction function provided by the test.
+	if (params.mockUserInteraction)
+		params.mockUserInteraction();
+
+	// Execute the middleware with a stub next function.
+	const executeCommand = clientOptions.middleware.executeCommand;
+	const nextMock = mock.fn();
+	const result = await executeCommand(params.command ?? "testCommand", params.commandArguments ?? ["testArg1"], nextMock);
+
+	// Return anything that the test may require to verify against.
+	return {
+		result, // executeCommand response.
+		executeCallRequestParams, // params passed to the final executeCommand() after form completion.
+		nextMock, // Mock used as the next() implementation (called in middleware when not completing forms).
+		resolveCallCount, // The number of times `/resolve` was called.
+	};
+}


### PR DESCRIPTION
This adds some tests for `form.ts`, plus some minor changes to the validation for consistency, including:

- consider empty strings as "no answer" (eg. fail validation if required)
- treat empty inputs as "null" answer for optional fields
- validate individual parts of a list input