### PR TITLE
Enable interactive forms by default, inverting and renaming the previous experiment flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -3283,10 +3283,10 @@
 						"markdownDescription": "Whether to enable experimental (possibly unfinished or unstable) refactors on the lightbulb menu. This setting is intended for use by Dart Analysis Server developers or users that want to try out and provide feedback on in-progress refactors.",
 						"scope": "window"
 					},
-					"dart.experimentalInteractiveForms": {
+					"dart.interactiveForms": {
 						"type": "boolean",
-						"default": false,
-						"markdownDescription": "Whether to enable the experimental (possibly unfinished or unstable) Interactive Forms feature used for accepting user input during refactors. This setting is intended for use by Dart Analysis Server developers or users that want to try out and provide feedback on in-progress refactors.",
+						"default": true,
+						"markdownDescription": "Whether to enable the Interactive Forms feature used for accepting user input during refactors.",
 						"scope": "window"
 					},
 					"dart.dynamicTestTracking": {

--- a/src/extension/analysis/analyzer.ts
+++ b/src/extension/analysis/analyzer.ts
@@ -67,7 +67,7 @@ export class LspAnalyzer extends Analyzer {
 
 		// Register all language client features.
 		this.client.registerFeature(new CommonCapabilitiesFeature().feature);
-		if (config.experimentalInteractiveForms)
+		if (config.interactiveForms)
 			this.client.registerFeature(new InteractiveFormsFeature(this.client));
 		this.client.registerFeature(new AddDependencyCodeActionProvider(this.client).feature);
 		this.client.registerFeature(new LegacyRefactors(this.logger, this.client).feature);

--- a/src/extension/config.ts
+++ b/src/extension/config.ts
@@ -115,7 +115,7 @@ class Config {
 	get mcpServerTools(): Record<string, boolean> { return this.getConfig<Record<string, boolean>>("mcpServerTools", {/* defaults from package.json */ }); }
 
 	get experimentalRefactors(): boolean { return this.getConfig<boolean>("experimentalRefactors", false); }
-	get experimentalInteractiveForms(): boolean { return this.getConfig<boolean>("experimentalInteractiveForms", false); }
+	get interactiveForms(): boolean { return this.getConfig<boolean>("interactiveForms", true); }
 	get extensionLogFile(): undefined | string { return createFolderForFile(insertWorkspaceName(resolvePaths(this.getConfig<null | string>("extensionLogFile", null)))); }
 	get flutterAdbConnectOnChromeOs(): boolean { return this.getConfig<boolean>("flutterAdbConnectOnChromeOs", false); }
 	get flutterCreateAndroidLanguage(): "java" | "kotlin" { return this.getConfig<"java" | "kotlin">("flutterCreateAndroidLanguage", "kotlin"); }

--- a/src/test/dart/refactors/move_top_level_to_file.test.ts
+++ b/src/test/dart/refactors/move_top_level_to_file.test.ts
@@ -9,7 +9,7 @@ describe("move top level to file refactor", () => {
 
 	describe("without interactive forms", () => {
 		it("can move a simple class", async () => {
-			await setConfigForTest("dart", "experimentalInteractiveForms", false);
+			await setConfigForTest("dart", "interactiveForms", false);
 
 			const newFile = vs.Uri.file(path.join(fsPath(helloWorldFolder), "lib/my_new_class.dart"));
 			const showSaveDialog = sb.stub(vs.window, "showSaveDialog");
@@ -42,7 +42,7 @@ class B {}
 			if (!privateApi.dartCapabilities.supportsInteractiveForms)
 				this.skip();
 
-			await setConfigForTest("dart", "experimentalInteractiveForms", true);
+			await setConfigForTest("dart", "interactiveForms", true);
 
 			// Stub the quick-pick to select the "Create New File" option.
 			sb.stub(vs.window, "showQuickPick").callsFake(async (items: vs.QuickPickItem[]) => {


### PR DESCRIPTION
Rather than just deleting the flag, keep it around inverted for a little while so if any issues crop up, users can easily disable it (either to avoid them, or to confirm whether it's related to interactive forms).