### PR TITLE
Update grammar to fix unclosed code blocks in comments

### DIFF
--- a/src/test/test_projects/grammar_testing/lib/unclosed_code_in_comments.dart
+++ b/src/test/test_projects/grammar_testing/lib/unclosed_code_in_comments.dart
@@ -1,0 +1,19 @@
+/// Text
+/// ```
+/// code
+///
+int? x1;
+
+/// ```
+/// code
+///
+int? x2;
+
+/// Text
+/// ```
+/// code
+int? x3;
+
+/// ```
+/// code
+int? x4;

--- a/src/test/test_projects/grammar_testing/lib/unclosed_code_in_comments.dart.snap
+++ b/src/test/test_projects/grammar_testing/lib/unclosed_code_in_comments.dart.snap
@@ -1,0 +1,54 @@
+>/// Text
+#^^^ source.dart comment.block.documentation.dart
+#   ^^^^^^ source.dart comment.block.documentation.dart
+>/// ```
+#^^^^^^^ source.dart comment.block.documentation.dart
+>/// code
+#^^^^ source.dart comment.block.documentation.dart
+#    ^^^^ source.dart comment.block.documentation.dart variable.other.source.dart
+>///
+#^^^^ source.dart comment.block.documentation.dart
+>int? x1;
+#^^^ source.dart support.class.dart
+#   ^ source.dart keyword.operator.ternary.dart
+#    ^^^ source.dart
+#       ^ source.dart punctuation.terminator.dart
+>
+>/// ```
+#^^^ source.dart comment.block.documentation.dart
+#   ^^^^^ source.dart comment.block.documentation.dart
+>/// code
+#^^^^^^^^^ source.dart comment.block.documentation.dart
+>///
+#^^^^ source.dart comment.block.documentation.dart
+>int? x2;
+#^^^ source.dart support.class.dart
+#   ^ source.dart keyword.operator.ternary.dart
+#    ^^^ source.dart
+#       ^ source.dart punctuation.terminator.dart
+>
+>/// Text
+#^^^ source.dart comment.block.documentation.dart
+#   ^^^^^^ source.dart comment.block.documentation.dart
+>/// ```
+#^^^^^^^ source.dart comment.block.documentation.dart
+>/// code
+#^^^^ source.dart comment.block.documentation.dart
+#    ^^^^ source.dart comment.block.documentation.dart variable.other.source.dart
+>int? x3;
+#^^^ source.dart support.class.dart
+#   ^ source.dart keyword.operator.ternary.dart
+#    ^^^ source.dart
+#       ^ source.dart punctuation.terminator.dart
+>
+>/// ```
+#^^^ source.dart comment.block.documentation.dart
+#   ^^^^^ source.dart comment.block.documentation.dart
+>/// code
+#^^^^^^^^^ source.dart comment.block.documentation.dart
+>int? x4;
+#^^^ source.dart support.class.dart
+#   ^ source.dart keyword.operator.ternary.dart
+#    ^^^ source.dart
+#       ^ source.dart punctuation.terminator.dart
+>

--- a/syntaxes/dart.json
+++ b/syntaxes/dart.json
@@ -1,6 +1,6 @@
 {
 	"name": "Dart",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"fileTypes": [
 		"dart"
 	],
@@ -77,12 +77,12 @@
 	"repository": {
 		"dartdoc-codeblock-triple": {
 			"begin": "^\\s*///\\s*(?!\\s*```)",
-			"end": "\n",
+			"end": "$",
 			"contentName": "variable.other.source.dart"
 		},
 		"dartdoc-codeblock-block": {
 			"begin": "^\\s*\\*\\s*(?!(\\s*```|\/))",
-			"end": "\n",
+			"end": "$",
 			"contentName": "variable.other.source.dart"
 		},
 		"dartdoc": {


### PR DESCRIPTION
Fixes https://github.com/Dart-Code/Dart-Code/issues/6130

We should wait for the other related PRs to be approved before landing here, in case there are changes.

- DevTools PR to update to existing latest grammar before changes: https://github.com/flutter/devtools/pull/9920
- DevTools PR to update to new fixed grammar: https://github.com/flutter/devtools/pull/9921
- dart-syntax-highlight PR: https://github.com/dart-lang/dart-syntax-highlight/pull/91

Before this change:

<img width="627" height="527" alt="Screenshot 2026-07-28 153022" src="https://github.com/user-attachments/assets/0b160299-dee3-46e8-987e-e9f5b2cf9907" />

After this change:

<img width="538" height="467" alt="Screenshot 2026-07-28 153033" src="https://github.com/user-attachments/assets/fe0a85cf-dc21-4ff3-9cd0-44eaf73a186f" />

