### PR TITLE
Add a command to toggle TODO visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,11 @@
 		],
 		"commands": [
 			{
+				"command": "dart.toggleShowTodos",
+				"title": "Toggle Show TODOs",
+				"category": "Dart"
+			},
+			{
 				"command": "flutter.createProject",
 				"title": "Create New Project",
 				"category": "Flutter"

--- a/src/extension/commands/analyzer.ts
+++ b/src/extension/commands/analyzer.ts
@@ -7,6 +7,7 @@ import { Logger } from "../../shared/interfaces";
 import { getRandomInt } from "../../shared/utils/fs";
 import { envUtils } from "../../shared/vscode/utils";
 import { Analytics, AnalyticsEvent } from "../analytics";
+import { config } from "../config";
 import { ringLog } from "../extension";
 import { openLogContents } from "../utils";
 import { getLogHeader } from "../utils/log";
@@ -50,6 +51,20 @@ export class AnalyzerCommands {
 				this.showServerRestartPrompt().catch((e) => logger.error(e));
 			analytics.log(AnalyticsEvent.Command_ForceReanalyze);
 			await analyzer.forceReanalyze();
+		}));
+		context.subscriptions.push(vs.commands.registerCommand("dart.toggleShowTodos", async () => {
+			const settingName = "showTodos";
+			const currentValue = config.showTodos;
+			const newValue = !currentValue;
+
+			let target = vs.ConfigurationTarget.Global;
+			const configValue = vs.workspace.getConfiguration("dart").inspect(settingName);
+			if (configValue?.workspaceFolderValue !== undefined)
+				target = vs.ConfigurationTarget.WorkspaceFolder;
+			else if (configValue?.workspaceValue !== undefined)
+				target = vs.ConfigurationTarget.Workspace;
+
+			await config.setShowTodos(newValue, target);
 		}));
 	}
 

--- a/src/test/dart/commands/analyzer.test.ts
+++ b/src/test/dart/commands/analyzer.test.ts
@@ -1,0 +1,99 @@
+import { strict as assert } from "assert";
+import * as vs from "vscode";
+import { activate, helloWorldMainFile } from "../../helpers";
+
+describe("toggle show TODOs", () => {
+	const settingName = "showTodos";
+	let config: vs.WorkspaceConfiguration;
+
+	function refresh(): void {
+		config = vs.workspace.getConfiguration("dart");
+	}
+
+	beforeEach(async () => {
+		await activate(helloWorldMainFile);
+		refresh();
+		// Clear overrides to start from a clean state.
+		await config.update(settingName, undefined, vs.ConfigurationTarget.Global);
+		await config.update(settingName, undefined, vs.ConfigurationTarget.Workspace);
+		refresh();
+	});
+
+	// (multi-root) Workspaces are tested in the 'multi_root' tests. This test project is a single folder.
+
+	it("toggles in User settings when not defined anywhere", async () => {
+		// Default is true.
+		refresh();
+		assert.strictEqual(config.get(settingName), true);
+
+		await vs.commands.executeCommand("dart.toggleShowTodos");
+		refresh();
+		assert.strictEqual(config.get(settingName), false);
+		assert.strictEqual(config.inspect(settingName)?.globalValue, false);
+		assert.strictEqual(config.inspect(settingName)?.workspaceValue, undefined);
+
+		await vs.commands.executeCommand("dart.toggleShowTodos");
+		refresh();
+		assert.strictEqual(config.get(settingName), true);
+		assert.strictEqual(config.inspect(settingName)?.globalValue, true);
+		assert.strictEqual(config.inspect(settingName)?.workspaceValue, undefined);
+	});
+
+	it("toggles in User settings when defined in User settings", async () => {
+		await config.update(settingName, false, vs.ConfigurationTarget.Global);
+		refresh();
+		assert.strictEqual(config.get(settingName), false);
+
+		await vs.commands.executeCommand("dart.toggleShowTodos");
+		refresh();
+		assert.strictEqual(config.get(settingName), true);
+		assert.strictEqual(config.inspect(settingName)?.globalValue, true);
+		assert.strictEqual(config.inspect(settingName)?.workspaceValue, undefined);
+		assert.strictEqual(config.inspect(settingName)?.workspaceFolderValue, undefined);
+
+		await vs.commands.executeCommand("dart.toggleShowTodos");
+		refresh();
+		assert.strictEqual(config.get(settingName), false);
+		assert.strictEqual(config.inspect(settingName)?.globalValue, false);
+		assert.strictEqual(config.inspect(settingName)?.workspaceValue, undefined);
+		assert.strictEqual(config.inspect(settingName)?.workspaceFolderValue, undefined);
+	});
+
+	it("toggles in User settings when defined in User settings as an array", async () => {
+		await config.update(settingName, ["TODO", "HACK"], vs.ConfigurationTarget.Global);
+		refresh();
+		assert.deepStrictEqual(config.get(settingName), ["TODO", "HACK"]);
+
+		await vs.commands.executeCommand("dart.toggleShowTodos");
+		refresh();
+		assert.strictEqual(config.get(settingName), false);
+		assert.strictEqual(config.inspect(settingName)?.globalValue, false);
+		assert.strictEqual(config.inspect(settingName)?.workspaceValue, undefined);
+		assert.strictEqual(config.inspect(settingName)?.workspaceFolderValue, undefined);
+
+		await vs.commands.executeCommand("dart.toggleShowTodos");
+		refresh();
+		assert.strictEqual(config.get(settingName), true);
+		assert.strictEqual(config.inspect(settingName)?.globalValue, true);
+		assert.strictEqual(config.inspect(settingName)?.workspaceValue, undefined);
+		assert.strictEqual(config.inspect(settingName)?.workspaceFolderValue, undefined);
+	});
+
+	it("toggles in Workspace (Folder) settings when defined in Workspace (Folder) settings (single-root workspace)", async () => {
+		await config.update(settingName, false, vs.ConfigurationTarget.Workspace);
+		refresh();
+		assert.strictEqual(config.get(settingName), false);
+
+		await vs.commands.executeCommand("dart.toggleShowTodos");
+		refresh();
+		assert.strictEqual(config.get(settingName), true);
+		assert.strictEqual(config.inspect(settingName)?.globalValue, undefined);
+		assert.strictEqual(config.inspect(settingName)?.workspaceValue, true);
+
+		await vs.commands.executeCommand("dart.toggleShowTodos");
+		refresh();
+		assert.strictEqual(config.get(settingName), false);
+		assert.strictEqual(config.inspect(settingName)?.globalValue, undefined);
+		assert.strictEqual(config.inspect(settingName)?.workspaceValue, false);
+	});
+});

--- a/src/test/multi_root/commands/analyzer.test.ts
+++ b/src/test/multi_root/commands/analyzer.test.ts
@@ -1,0 +1,39 @@
+import { strict as assert } from "assert";
+import * as vs from "vscode";
+import { activate, helloWorldMainFile } from "../../helpers";
+
+describe("toggle show TODOs", () => {
+	const settingName = "showTodos";
+	let config: vs.WorkspaceConfiguration;
+
+	function refresh(): void {
+		config = vs.workspace.getConfiguration("dart");
+	}
+
+	beforeEach(async () => {
+		await activate(helloWorldMainFile);
+		refresh();
+		// Clear overrides to start from a clean state.
+		await config.update(settingName, undefined, vs.ConfigurationTarget.Global);
+		await config.update(settingName, undefined, vs.ConfigurationTarget.Workspace);
+		refresh();
+	});
+
+	it("toggles in Workspace settings when defined in Folder settings (multi-root workspace)", async () => {
+		await config.update(settingName, false, vs.ConfigurationTarget.Workspace);
+		refresh();
+		assert.strictEqual(config.get(settingName), false);
+
+		await vs.commands.executeCommand("dart.toggleShowTodos");
+		refresh();
+		assert.strictEqual(config.get(settingName), true);
+		assert.strictEqual(config.inspect(settingName)?.globalValue, undefined);
+		assert.strictEqual(config.inspect(settingName)?.workspaceValue, true);
+
+		await vs.commands.executeCommand("dart.toggleShowTodos");
+		refresh();
+		assert.strictEqual(config.get(settingName), false);
+		assert.strictEqual(config.inspect(settingName)?.globalValue, undefined);
+		assert.strictEqual(config.inspect(settingName)?.workspaceValue, false);
+	});
+});


### PR DESCRIPTION
This only toggles as a bool though, so you can't set it to show TODO without HACK etc.

Fixes https://github.com/Dart-Code/Dart-Code/issues/6118