### PR TITLE
Handle deep link notifications from new Flutter DAP

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -113,7 +113,7 @@ jobs:
         if: matrix.bot != 'flutter_snap' && !startsWith(matrix.bot, 'dart')
         uses: DanTup/gh-actions/setup-flutter@27c44eb7d43bced080fc5c9b6c3e4cfdd4cdcc41
         with:
-          channel: ${{ matrix.build-version }}
+          channel: master
 
       - name: Set up Dart ${{ matrix.build-version }}
         if: startsWith(matrix.bot, 'dart') || matrix.bot == 'misc'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -113,7 +113,7 @@ jobs:
         if: matrix.bot != 'flutter_snap' && !startsWith(matrix.bot, 'dart')
         uses: DanTup/gh-actions/setup-flutter@27c44eb7d43bced080fc5c9b6c3e4cfdd4cdcc41
         with:
-          channel: master
+          channel: ${{ matrix.build-version }}
 
       - name: Set up Dart ${{ matrix.build-version }}
         if: startsWith(matrix.bot, 'dart') || matrix.bot == 'misc'

--- a/src/extension/commands/debug.ts
+++ b/src/extension/commands/debug.ts
@@ -1013,12 +1013,12 @@ export class DebugCommands implements IAmDisposable {
 			const choice = await vs.window.showWarningMessage(data.summary, inspectAction, doNotAskAgainAction);
 			if (choice === inspectAction && session.vmServiceUri) {
 				const link = this.parseDeepLinkUri(data.deepLinkUrl);
-				if (link !== null) {
+				if (link) {
 					void this.devTools.spawn(
 						session as DartDebugSessionInformation & { vmServiceUri: string },
 						{
-							inspectorRef: link?.inspectorRef,
-							pageId: link?.pageId,
+							inspectorRef: link.inspectorRef,
+							pageId: link.pageId,
 						},
 						true,
 					);
@@ -1051,7 +1051,7 @@ export class DebugCommands implements IAmDisposable {
 			const url = new URL(deepLinkUrl.replace("#/", ""));
 			const pageId = url.pathname.split("/")[1];
 			const inspectorRef = url.searchParams.get("inspectorRef") ?? undefined;
-			if (pageId !== "") {
+			if (pageId) {
 				return { pageId, inspectorRef };
 			}
 			return undefined;

--- a/src/extension/commands/debug.ts
+++ b/src/extension/commands/debug.ts
@@ -5,7 +5,7 @@ import { FlutterCapabilities } from "../../shared/capabilities/flutter";
 import { CommandSource, debugLaunchProgressId, debugTerminatingProgressId, devToolsPages, doNotAskAgainAction, doNotShowAgainAction, moreInfoAction, widgetInspectorPage } from "../../shared/constants";
 import { isInDartDebugSessionContext, isInFlutterDebugModeDebugSessionContext, isInFlutterProfileModeDebugSessionContext, isInFlutterReleaseModeDebugSessionContext } from "../../shared/constants.contexts";
 import { DebugOption, DebuggerType, LogCategory, LogSeverity, VmService, VmServiceExtension, debugOptionNames } from "../../shared/enums";
-import { DartWorkspaceContext, IAmDisposable, LogMessage, Logger, WidgetErrorInspectData } from "../../shared/interfaces";
+import { DartWorkspaceContext, DevToolsDeepLinkData, IAmDisposable, LegacyWidgetErrorInspectData, LogMessage, Logger } from "../../shared/interfaces";
 import { PromiseCompleter, disposeAll } from "../../shared/utils";
 import { fsPath, isFlutterProjectFolder, isWithinPath } from "../../shared/utils/fs";
 import { ANALYSIS_FILTERS } from "../../shared/vscode/constants";
@@ -964,11 +964,11 @@ export class DebugCommands implements IAmDisposable {
 				}
 				progress.complete();
 			}
-		} else if (event === "dart.flutter.widgetErrorInspectData") {
+		} else if (event === "dart.flutter.widgetErrorInspectData") { // Legacy DAP deep links
 			if (this.suppressFlutterWidgetErrors || !config.showInspectorNotificationsForWidgetErrors)
 				return;
 
-			const data = e.body as WidgetErrorInspectData;
+			const data = e.body as LegacyWidgetErrorInspectData;
 			if (data.devToolsUrl !== (await this.devTools.devtoolsUrl))
 				return;
 
@@ -993,6 +993,41 @@ export class DebugCommands implements IAmDisposable {
 			}
 			clearTimeout(timer);
 			this.suppressFlutterWidgetErrors = false;
+		} else if (event === "dart.flutter.devToolsDeepLink") { // New DAP deep links
+			if (this.suppressFlutterWidgetErrors || !config.showInspectorNotificationsForWidgetErrors)
+				return;
+
+			// "event":"dart.flutter.devToolsDeepLink",
+			// "body":{
+			//   "summary":"A RenderFlex overflowed by 266 pixels on the right.",
+			//   "deepLinkUrl":"http://example.org/#/inspector?uri&inspectorRef=inspector-0"
+			// }
+			const data = e.body as DevToolsDeepLinkData;
+
+			// To avoid spam, when we show this dialog we will set a flag that prevents any more
+			// of these types of dialogs until it is dismissed or 5 seconds have passed.
+			this.suppressFlutterWidgetErrors = true;
+			const timer = setTimeout(() => this.suppressFlutterWidgetErrors = false, 5000);
+
+			const inspectAction = `Inspect Widget`;
+			const choice = await vs.window.showWarningMessage(data.summary, inspectAction, doNotAskAgainAction);
+			if (choice === inspectAction && session.vmServiceUri) {
+				const link = this.parseDeepLinkUri(data.deepLinkUrl);
+				if (link !== null) {
+					void this.devTools.spawn(
+						session as DartDebugSessionInformation & { vmServiceUri: string },
+						{
+							inspectorRef: link?.inspectorRef,
+							pageId: link?.pageId,
+						},
+						true,
+					);
+				}
+			} else if (choice === doNotAskAgainAction) {
+				void config.setShowInspectorNotificationsForWidgetErrors(false);
+			}
+			clearTimeout(timer);
+			this.suppressFlutterWidgetErrors = false;
 		} else if (event === "flutter.appStarted") {
 			session.hasStarted = true;
 			debugSessionChangedEmitter.fire(session);
@@ -1007,6 +1042,22 @@ export class DebugCommands implements IAmDisposable {
 			session.supportsHotReload = body?.supportsRestart;
 			debugSessionChangedEmitter.fire(session);
 			debugSessionsChangedEmitter.fire();
+		}
+	}
+
+	private parseDeepLinkUri(deepLinkUrl: string): { pageId: string, inspectorRef: string | undefined } | undefined {
+		try {
+			// http://example.org/#/inspector?uri&inspectorRef=inspector-0
+			const url = new URL(deepLinkUrl.replace("#/", ""));
+			const pageId = url.pathname.split("/")[1];
+			const inspectorRef = url.searchParams.get("inspectorRef") ?? undefined;
+			if (pageId !== "") {
+				return { pageId, inspectorRef };
+			}
+			return undefined;
+		} catch {
+			this.logger.error(`Failed to parse DevTools deep link URL: ${deepLinkUrl}`);
+			return undefined;
 		}
 	}
 

--- a/src/shared/capabilities/flutter.ts
+++ b/src/shared/capabilities/flutter.ts
@@ -15,6 +15,7 @@ export class FlutterCapabilities {
 	get supportsSkeleton() { return !versionIsAtLeast(this.version, "3.29.0"); }
 	get supportsWidgetPreview() { return versionIsAtLeast(this.version, "3.36.0-1"); }
 	get supportsWidgetPreviewByDefault() { return versionIsAtLeast(this.version, "3.38.0-0"); }
+	get hasInspectorDeepLinkNotificationForwarding() { return versionIsAtLeast(this.version, "3.47.0-1"); }
 }
 
 export class DaemonCapabilities {

--- a/src/shared/interfaces.ts
+++ b/src/shared/interfaces.ts
@@ -251,10 +251,15 @@ export interface DevToolsPage {
 	isStaticTool?: boolean;
 }
 
-export interface WidgetErrorInspectData {
+export interface LegacyWidgetErrorInspectData {
 	errorDescription: string;
 	devToolsUrl: string;
 	inspectorReference: string;
+}
+
+export interface DevToolsDeepLinkData {
+	summary: string;
+	deepLinkUrl: string;
 }
 
 export interface Range {

--- a/src/test/dart_debug_client.ts
+++ b/src/test/dart_debug_client.ts
@@ -15,7 +15,7 @@ import { DebugCommandHandler } from "../shared/vscode/interfaces";
 import { DebugClient, ILocation, IPartialLocation } from "./debug_client_ms";
 import { delay, logger, privateApi, watchPromise } from "./helpers";
 
-const customEventsToForward = ["dart.log", "dart.serviceExtensionAdded", "dart.serviceRegistered", "dart.debuggerUris", "dart.startTerminalProcess", "dart.exposeUrl", "flutter.appStart", "flutter.appStarted", "dart.toolEvent"];
+const customEventsToForward = ["dart.log", "dart.serviceExtensionAdded", "dart.serviceRegistered", "dart.debuggerUris", "dart.startTerminalProcess", "dart.exposeUrl", "flutter.appStart", "flutter.appStarted", "dart.toolEvent", "dart.flutter.devToolsDeepLink"];
 
 type DebugClientArgs = { runtime: string, executable: string, args: string[] } | { runtime?: undefined, executable?: undefined, args?: undefined };
 

--- a/src/test/flutter/refactors/extract_widget.test.ts
+++ b/src/test/flutter/refactors/extract_widget.test.ts
@@ -34,8 +34,8 @@ class MyWidget extends StatelessWidget {
 
 class MyNewWidget extends StatelessWidget {
   const MyNewWidget({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/src/test/flutter_debug/flutter_run.test_device.test.ts
+++ b/src/test/flutter_debug/flutter_run.test_device.test.ts
@@ -6,7 +6,7 @@ import { versionIsAtLeast } from "../../shared/utils";
 import { fsPath } from "../../shared/utils/fs";
 import { DartDebugClient } from "../dart_debug_client";
 import { createDebugClient, ensureServiceExtensionValue, flutterTestDeviceId, flutterTestDeviceIsWeb, killFlutterTester, startDebugger, waitAllThrowIfTerminates } from "../debug_helpers";
-import { activateWithoutAnalysis, closeAllOpenFiles, customScriptExt, defer, deferUntilLast, delay, ensureHasRunWithArgsStarting, flutterHelloWorldFolder, flutterHelloWorldMainFile, flutterHelloWorldNavigateFromFile, flutterHelloWorldNavigateToFile, flutterHelloWorldReadmeFile, flutterHelloWorldStack60File, getLaunchConfiguration, getPackages, makeTrivialChangeToFileDirectly, openFile, positionOf, prepareHasRunFile, privateApi, saveTrivialChangeToFile, sb, setConfigForTest, waitForResult, watchPromise } from "../helpers";
+import { activateWithoutAnalysis, closeAllOpenFiles, customScriptExt, defer, deferUntilLast, delay, ensureHasRunWithArgsStarting, flutterHelloWorldFolder, flutterHelloWorldMainFile, flutterHelloWorldNavigateFromFile, flutterHelloWorldNavigateToFile, flutterHelloWorldOverflowFile, flutterHelloWorldReadmeFile, flutterHelloWorldStack60File, getLaunchConfiguration, getPackages, makeTrivialChangeToFileDirectly, openFile, positionOf, prepareHasRunFile, privateApi, saveTrivialChangeToFile, sb, setConfigForTest, waitForResult, watchPromise } from "../helpers";
 
 describe(`flutter run debugger (only test device)`, () => {
 	beforeEach("Skip test-device tests on web", function () {
@@ -600,5 +600,43 @@ describe(`flutter run debugger (only test device)`, () => {
 				dc.terminateRequest(),
 			);
 		});
+	});
+
+	it("shows deep link prompt for overflow errors", async function () {
+		// Currently this test fails on Chrome because we always lose the race
+		// with enabling structured errors versus the error occurring
+		if (flutterTestDeviceIsWeb)
+			return this.skip();
+
+		await openFile(flutterHelloWorldOverflowFile);
+		const config = await startDebugger(dc, flutterHelloWorldOverflowFile);
+
+		const showInformationMessage = sb.stub(vs.window, "showWarningMessage");
+
+		await waitAllThrowIfTerminates(dc,
+			dc.flutterAppStarted(),
+			// Disable breaking on exceptions so we don't have to resume.
+			dc.waitForEvent("initialized")
+				.then(() => dc.setExceptionBreakpointsRequest({ filters: ["None"] }))
+				.then(() => dc.configurationDoneRequest()),
+			dc.launch(config),
+		);
+
+		await waitAllThrowIfTerminates(dc,
+			dc.waitForHotReload(),
+			Promise.resolve(vs.commands.executeCommand("flutter.hotReload")),
+		);
+
+		await waitAllThrowIfTerminates(dc,
+			dc.waitForEvent("terminated"),
+			dc.terminateRequest(),
+		);
+
+		assert.ok(showInformationMessage.called);
+		const args = showInformationMessage.getCalls()[0].args;
+		const message = args[0] as string;
+		const buttons = args[1] as string[];
+		assert.ok(message.includes("A RenderFlex overflowed by"));
+		assert.ok(buttons[0], "Inspect Widget");
 	});
 });

--- a/src/test/flutter_debug/flutter_run.test_device.test.ts
+++ b/src/test/flutter_debug/flutter_run.test_device.test.ts
@@ -603,9 +603,8 @@ describe(`flutter run debugger (only test device)`, () => {
 	});
 
 	it("shows deep link prompt for overflow errors", async function () {
-		// Currently this test fails on Chrome because we always lose the race
-		// with enabling structured errors versus the error occurring
-		if (flutterTestDeviceIsWeb)
+		// Does the Flutter SDK support forwarding the new events?
+		if (!privateApi.flutterCapabilities.hasInspectorDeepLinkNotificationForwarding)
 			return this.skip();
 
 		await openFile(flutterHelloWorldOverflowFile);

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -126,6 +126,7 @@ export const flutterHelloWorldPubspec = vs.Uri.file(path.join(fsPath(flutterHell
 export const flutterHelloWorldCounterAppFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "lib/counter.dart"));
 export const flutterHelloWorldOutlineFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "lib/outline.dart"));
 export const flutterHelloWorldBrokenFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "lib/broken.dart"));
+export const flutterHelloWorldOverflowFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "lib/overflow.dart"));
 export const flutterHelloWorldHttpFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "lib/http.dart"));
 export const flutterHelloWorldGettersFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "lib/getters.dart"));
 export const flutterHelloWorldLocalPackageFile = vs.Uri.file(path.join(fsPath(flutterHelloWorldFolder), "lib/local_package.dart"));

--- a/src/test/test_projects/bazel_workspace/flutter_hello_world_bazel/pubspec.yaml
+++ b/src/test/test_projects/bazel_workspace/flutter_hello_world_bazel/pubspec.yaml
@@ -4,7 +4,7 @@ description: A test Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.14.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/src/test/test_projects/flutter_hello_world/example/pubspec.yaml
+++ b/src/test/test_projects/flutter_hello_world/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.14.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter_hello_world:

--- a/src/test/test_projects/flutter_hello_world/lib/overflow.dart
+++ b/src/test/test_projects/flutter_hello_world/lib/overflow.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MainApp());
+}
+
+class MainApp extends StatelessWidget {
+  const MainApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Row(
+          children: [
+            Icon(Icons.message),
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Title',
+                  style: Theme.of(context).textTheme.headlineMedium,
+                ),
+                Text(
+                  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed '
+                  'do eiusmod tempor incididunt ut labore et dolore magna '
+                  'aliqua. Ut enim ad minim veniam, quis nostrud '
+                  'exercitation ullamco laboris nisi ut aliquip ex ea '
+                  'commodo consequat.',
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/src/test/test_projects/flutter_hello_world/pubspec.yaml
+++ b/src/test/test_projects/flutter_hello_world/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.14.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This is work towards https://github.com/Dart-Code/Dart-Code/issues/6134. It also requires a Flutter change (https://github.com/flutter/flutter/pull/190455) and to track down why the DevTools server URL + VM Service URL in the Flutter code are `null` (which prevents the error not being included).

## Failing test

The new test will fail until the Flutter change lands and we can guard the test with a version check.