### PR TITLE
fix: bump @types/vscode dependency to restore clean build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"@types/node": "^24.0.0",
 				"@types/semver": "^7.7.1",
 				"@types/sinon": "5.0.5",
-				"@types/vscode": "~1.101.0",
+				"@types/vscode": "^1.89.0",
 				"@types/ws": "^8.18.1",
 				"@vscode/debugadapter-testsupport": "^1.68.0",
 				"@vscode/test-electron": "^3.0.0",
@@ -43,7 +43,7 @@
 				"xvfb-maybe": "^0.2.1"
 			},
 			"engines": {
-				"vscode": "^1.101.0"
+				"vscode": "^1.89.0"
 			},
 			"optionalDependencies": {
 				"bufferutil": "^4.0.9",
@@ -81,6 +81,7 @@
 			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.7",
 				"@babel/generator": "^7.29.7",
@@ -905,6 +906,7 @@
 			"integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.61.0",
 				"@typescript-eslint/types": "8.61.0",
@@ -1366,6 +1368,7 @@
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1616,6 +1619,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.12",
 				"caniuse-lite": "^1.0.30001782",
@@ -1636,20 +1640,6 @@
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/bufferutil": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
-			"integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=6.14.2"
-			}
 		},
 		"node_modules/caching-transform": {
 			"version": "4.0.0",
@@ -2093,6 +2083,7 @@
 			"integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.2",
@@ -4372,6 +4363,7 @@
 			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -4906,6 +4898,7 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -5025,6 +5018,7 @@
 			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -5103,20 +5097,6 @@
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
-			}
-		},
-		"node_modules/utf-8-validate": {
-			"version": "6.0.6",
-			"resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
-			"integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"node-gyp-build": "^4.3.0"
-			},
-			"engines": {
-				"node": ">=6.14.2"
 			}
 		},
 		"node_modules/util-deprecate": {
@@ -5355,6 +5335,7 @@
 			"integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "^1.0.8",
 				"@types/json-schema": "^7.0.15",
@@ -5402,6 +5383,7 @@
 			"integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@discoveryjs/json-ext": "^0.6.1",
 				"@webpack-cli/configtest": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"version": "3.142.0-dev",
 	"publisher": "Dart-Code",
 	"engines": {
-		"vscode": "^1.101.0"
+		"vscode": "^1.89.0"
 	},
 	"extensionKind": [
 		"workspace"
@@ -793,7 +793,9 @@
 							"description": "Absolute path to the Dart file to format."
 						}
 					},
-					"required": ["filePath"]
+					"required": [
+						"filePath"
+					]
 				}
 			},
 			{
@@ -810,7 +812,6 @@
 						"filePath": {
 							"type": "string",
 							"description": "Absolute path to a single Dart file if fixes should only be run for one file. If not provided, the whole workspace will be fixed."
-
 						}
 					}
 				}
@@ -3735,7 +3736,7 @@
 		"@types/node": "^24.0.0",
 		"@types/semver": "^7.7.1",
 		"@types/sinon": "5.0.5",
-		"@types/vscode": "~1.101.0",
+		"@types/vscode": "^1.89.0",
 		"@types/ws": "^8.18.1",
 		"@vscode/debugadapter-testsupport": "^1.68.0",
 		"@vscode/test-electron": "^3.0.0",


### PR DESCRIPTION
SnippetTextEdit requires @types/vscode >= 1.89.0 and fresh clones currently fail yarn run build on latest version of VS Code / Codium.

```text
yarn run build        
yarn run v1.22.22
warning dart-code@3.142.0-dev: The engine "vscode" appears to be invalid.
$ webpack --mode development --stats errors-only
ERROR in /Users/arfeenyousuf/.vscode-oss/extensions/Dart-Code/src/extension/analysis/analyzer.ts
./src/extension/analysis/analyzer.ts 433:3-22
[tsl] ERROR in /Users/arfeenyousuf/.vscode-oss/extensions/Dart-Code/src/extension/analysis/analyzer.ts(433,4)
      TS2353: Object literal may only specify known properties, and 'textSynchronization' does not exist in type 'LanguageClientOptions'.
 @ ./src/extension/extension.ts 68:19-49

ERROR in /Users/arfeenyousuf/.vscode-oss/extensions/Dart-Code/src/extension/analysis/analyzer.ts
./src/extension/analysis/analyzer.ts 557:21-36
[tsl] ERROR in /Users/arfeenyousuf/.vscode-oss/extensions/Dart-Code/src/extension/analysis/analyzer.ts(557,22)
      TS2339: Property 'SnippetTextEdit' does not exist on type 'typeof import("/Users/arfeenyousuf/.vscode-oss/extensions/Dart-Code/node_modules/vscode-languageclient/lib/common/api")'.
 @ ./src/extension/extension.ts 68:19-49

ERROR in /Users/arfeenyousuf/.vscode-oss/extensions/Dart-Code/src/extension/analysis/analyzer.ts
./src/extension/analysis/analyzer.ts 558:102-109
[tsl] ERROR in /Users/arfeenyousuf/.vscode-oss/extensions/Dart-Code/src/extension/analysis/analyzer.ts(558,103)
      TS2339: Property 'snippet' does not exist on type 'TextEdit'.
 @ ./src/extension/extension.ts 68:19-49

ERROR in /Users/arfeenyousuf/.vscode-oss/extensions/Dart-Code/src/extension/analysis/analyzer.ts
./src/extension/analysis/analyzer.ts 563:49-61
[tsl] ERROR in /Users/arfeenyousuf/.vscode-oss/extensions/Dart-Code/src/extension/analysis/analyzer.ts(563,50)
      TS2339: Property 'annotationId' does not exist on type 'TextEdit'.
 @ ./src/extension/extension.ts 68:19-49

ERROR in /Users/arfeenyousuf/.vscode-oss/extensions/Dart-Code/src/test/test_all.ts
113:3-9
[tsl] ERROR in /Users/arfeenyousuf/.vscode-oss/extensions/Dart-Code/src/test/test_all.ts(113,4)
      TS2353: Object literal may only specify known properties, and 'stdout' does not exist in type 'TestOptions'.

webpack compiled with 5 errors
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```