### PR TITLE
Open Xcode by bundle ID rather than app name

### DIFF
--- a/src/extension/commands/open_in_other_editors.ts
+++ b/src/extension/commands/open_in_other_editors.ts
@@ -60,7 +60,7 @@ export class OpenInOtherEditorCommands implements IAmDisposable {
 		}
 
 		const file = path.join(folder, files[0].name);
-		safeToolSpawn(folder, "open", ["-a", "XCode", file]);
+		safeToolSpawn(folder, "open", ["-b", "com.apple.dt.Xcode", file]);
 	}
 
 	private async getAndroidStudioDir(folder: string): Promise<string> {


### PR DESCRIPTION
Fixes #6159

`openInXcode` currently launches Xcode by application name:

```ts
safeToolSpawn(folder, "open", ["-a", "XCode", file]);
```

`open -a` resolves via LaunchServices by app name, so this fails when the only installed Xcode is `Xcode-beta.app`:

```console
$ open -a "XCode" ios/Runner.xcworkspace
Unable to find application named 'XCode'
$ echo $?
1
```

Because the `safeToolSpawn` result isn't checked, nothing surfaces in the UI and the context-menu item appears to do nothing at all. This affects anyone working against an iOS/macOS beta, who generally can't install a stable Xcode for the current SDK alongside the beta.

This switches to launching by bundle ID, which both `Xcode.app` and `Xcode-beta.app` declare:

```console
$ defaults read /Applications/Xcode-beta.app/Contents/Info.plist CFBundleIdentifier
com.apple.dt.Xcode
```

`-b` uses the same LaunchServices database as `-a`, just keyed on bundle ID rather than name, so it should continue to work for Xcode installed outside `/Applications` (#5420). It also removes the reliance on `open -a` being case-insensitive for `"XCode"`.

The `.xcworkspace`/`.xcodeproj` discovery above this line is unchanged — only the launch call differs.

**Testing:** verified by patching the compiled `extension.js` in an installed 3.140.0 extension and restarting the editor; **Open in Xcode** then correctly opens `Runner.xcworkspace` in Xcode 27 beta. I haven't run the full extension test suite locally — happy to if you'd like, though there's no existing coverage for `openInXcode`.
