### PR TITLE
Combine hot reload + hot restart tests to speed up test runs- #6168

### DIFF
--- a/src/test/flutter_debug/flutter_run.test_device.test.ts
+++ b/src/test/flutter_debug/flutter_run.test_device.test.ts
@@ -155,7 +155,7 @@ describe(`flutter run debugger (only test device)`, () => {
 		assert.equal(config!.program, fsPath(flutterHelloWorldMainFile));
 	});
 
-	it("can hot reload with customRequest, using command, on-save, on-save with custom glob, external modification", async () => {
+	it("can hot reload and restart with customRequest, command, on-save, on-save with custom glob, external modification", async () => {
 		const config = await startDebugger(dc, flutterHelloWorldMainFile);
 		await waitAllThrowIfTerminates(dc,
 			dc.flutterAppStarted(),
@@ -206,19 +206,6 @@ describe(`flutter run debugger (only test device)`, () => {
 			);
 		}
 
-		await waitAllThrowIfTerminates(dc,
-			dc.waitForEvent("terminated"),
-			dc.terminateRequest(),
-		);
-	});
-
-	it("can hot restart using customRequest, command", async () => {
-		const config = await startDebugger(dc, flutterHelloWorldMainFile);
-		await waitAllThrowIfTerminates(dc,
-			dc.flutterAppStarted(),
-			dc.configurationSequence(),
-			dc.launch(config),
-		);
 		await delayBeforeRestart();
 
 		// can hot restart using customRequest


### PR DESCRIPTION
Spawning a real Flutter app is very slow, so combe these to have a single launch.

See https://github.com/Dart-Code/Dart-Code/issues/6165